### PR TITLE
[FEAT] Toast 컴포넌트 생성

### DIFF
--- a/docs/storybook/stories/Toast.stories.tsx
+++ b/docs/storybook/stories/Toast.stories.tsx
@@ -1,0 +1,50 @@
+import { Toast } from '@hcc/ui';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: '@hcc/Toast',
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => {
+    return (
+      <button
+        onClick={() => {
+          Toast.show('API 호출에 실패했습니다.');
+        }}
+      >
+        Toast
+      </button>
+    );
+  },
+};
+
+export const Children: Story = {
+  render: () => {
+    const ToastItem = () => {
+      return (
+        <div>
+          <span>API 호출에 실패했습니다.</span>
+          <button>다시 시도하기</button>
+        </div>
+      );
+    };
+
+    return (
+      <button
+        onClick={() => {
+          Toast.show(<ToastItem />);
+        }}
+      >
+        Toast
+      </button>
+    );
+  },
+};

--- a/docs/storybook/turbo.json
+++ b/docs/storybook/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "pipeline": {
+    "dev": {
+      "dependsOn": ["dev"]
+    },
     "build": {
       "outputs": ["storybook-static/**"]
     },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,20 +6,26 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
+    "dev": "tsc -w",
     "lint": "eslint . --max-warnings 0",
     "build": "tsc"
   },
   "devDependencies": {
     "@hcc/eslint-config": "workspace:*",
+    "@hcc/styles": "workspace:^",
     "@hcc/typescript-config": "workspace:*",
     "@turbo/gen": "^1.11.3",
     "@types/eslint": "^8.56.1",
     "@types/node": "^20.10.6",
     "@types/react": "^18.2.46",
     "@types/react-dom": "^18.2.18",
+    "@types/uuid": "^9.0.8",
+    "@vanilla-extract/recipes": "^0.5.1",
     "eslint": "^8.56.0",
     "react": "^18.2.0",
-    "typescript": "^5.3.3"
+    "react-dom": "^18.2.0",
+    "typescript": "^5.3.3",
+    "uuid": "^9.0.1"
   },
   "dependencies": {
     "@vanilla-extract/css": "^1.14.0"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,2 +1,3 @@
 export { default as Uploader } from './image-uploader';
 export { default as Input } from './input';
+export { default as Toast } from './toast';

--- a/packages/ui/src/toast/ToastItem.tsx
+++ b/packages/ui/src/toast/ToastItem.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+import { TOAST } from './constants';
+import useTimeout from './hooks/useTimeout';
+import * as styles from './toast.css';
+import { Toast } from './type';
+
+interface ToastItemProps extends Toast {
+  onDone: () => void;
+}
+
+const ToastItem = ({ message, duration, onDone }: ToastItemProps) => {
+  const [show, setShow] = useState(true);
+
+  const onClickRemove = () => {
+    setShow(false);
+    setTimeout(() => onDone(), TOAST.OPACITY_DURATION);
+  };
+
+  useTimeout(() => {
+    setShow(false);
+    setTimeout(() => onDone(), TOAST.OPACITY_DURATION);
+  }, duration);
+
+  return (
+    <div className={styles.toastItem({ show })}>
+      {message}
+      <button onClick={onClickRemove} className={styles.toastRemove({ show })}>
+        <svg
+          width="15"
+          height="15"
+          viewBox="0 0 15 15"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.7816 4.03157C12.0062 3.80702 12.0062 3.44295 11.7816 3.2184C11.5571 2.99385 11.193 2.99385 10.9685 3.2184L7.50005 6.68682L4.03164 3.2184C3.80708 2.99385 3.44301 2.99385 3.21846 3.2184C2.99391 3.44295 2.99391 3.80702 3.21846 4.03157L6.68688 7.49999L3.21846 10.9684C2.99391 11.193 2.99391 11.557 3.21846 11.7816C3.44301 12.0061 3.80708 12.0061 4.03164 11.7816L7.50005 8.31316L10.9685 11.7816C11.193 12.0061 11.5571 12.0061 11.7816 11.7816C12.0062 11.557 12.0062 11.193 11.7816 10.9684L8.31322 7.49999L11.7816 4.03157Z"
+            fill="currentColor"
+            fillRule="evenodd"
+            clipRule="evenodd"
+          ></path>
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export default ToastItem;

--- a/packages/ui/src/toast/ToastManager.tsx
+++ b/packages/ui/src/toast/ToastManager.tsx
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from 'react';
+import { v4 } from 'uuid';
+
+import * as styles from './toast.css';
+import ToastItem from './ToastItem';
+import { CreateToastParams, TCreateToast, Toast } from './type';
+
+interface ToastManagerProps {
+  bind: (createToast: TCreateToast) => void;
+}
+
+const ToastManager = ({ bind }: ToastManagerProps) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const createToast = useCallback(
+    ({ message, duration }: CreateToastParams) => {
+      const newToast = { id: v4(), message, duration };
+
+      setToasts([newToast]);
+    },
+    [],
+  );
+
+  const removeToast = useCallback((id: string) => {
+    setToasts(prev => prev.filter(toast => toast.id !== id));
+  }, []);
+
+  useEffect(() => {
+    bind(createToast);
+  }, [bind, createToast]);
+
+  return (
+    <div className={styles.root}>
+      {toasts.map(({ id, message, duration }) => (
+        <ToastItem
+          key={id}
+          id={id}
+          message={message}
+          duration={duration}
+          onDone={() => removeToast(id)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default ToastManager;

--- a/packages/ui/src/toast/constants.ts
+++ b/packages/ui/src/toast/constants.ts
@@ -1,0 +1,4 @@
+export const TOAST = {
+  DURATION: 2000,
+  OPACITY_DURATION: 400,
+};

--- a/packages/ui/src/toast/hooks/useHover.ts
+++ b/packages/ui/src/toast/hooks/useHover.ts
@@ -1,0 +1,26 @@
+import { RefObject, useEffect, useState } from 'react';
+
+export default function useHover<T extends Element>(
+  ref: RefObject<T>,
+): boolean {
+  const [state, setState] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+
+    if (!element) return;
+
+    const onMouseEnter = () => setState(true);
+    const onMouseLeave = () => setState(false);
+
+    element.addEventListener('mouseenter', onMouseEnter);
+    element.addEventListener('mouseleave', onMouseLeave);
+
+    return () => {
+      element.removeEventListener('mouseenter', onMouseEnter);
+      element.removeEventListener('mouseleave', onMouseLeave);
+    };
+  });
+
+  return state;
+}

--- a/packages/ui/src/toast/hooks/useTimeout.ts
+++ b/packages/ui/src/toast/hooks/useTimeout.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const useTimeout = (fn: () => void, delay: number) => {
+  const timeoutId = useRef<NodeJS.Timeout | null>(null);
+  const callback = useRef(fn);
+
+  useEffect(() => {
+    callback.current = fn;
+  }, [fn]);
+
+  const run = useCallback(() => {
+    timeoutId.current && clearTimeout(timeoutId.current);
+
+    timeoutId.current = setTimeout(() => {
+      callback.current();
+    }, delay);
+  }, [delay]);
+
+  const clear = useCallback(() => {
+    timeoutId.current && clearTimeout(timeoutId.current);
+  }, []);
+
+  useEffect(() => clear, [clear]);
+
+  useEffect(() => {
+    run();
+
+    return clear;
+  }, [clear, run]);
+
+  return clear;
+};
+
+export default useTimeout;

--- a/packages/ui/src/toast/index.tsx
+++ b/packages/ui/src/toast/index.tsx
@@ -1,0 +1,43 @@
+import { ReactNode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { TOAST } from './constants';
+import ToastManager from './ToastManager';
+import { TCreateToast } from './type';
+
+class Toast {
+  portal: HTMLElement | null = null;
+  createToast: TCreateToast | undefined;
+
+  constructor() {
+    const portalId = 'toast-portal';
+    const portalElement = document.getElementById(portalId);
+
+    if (portalElement) {
+      this.portal = portalElement;
+
+      return;
+    } else {
+      this.portal = document.createElement('div');
+      this.portal.id = portalId;
+
+      document.body.appendChild(this.portal);
+    }
+
+    createRoot(this.portal).render(
+      <ToastManager
+        bind={createToast => {
+          this.createToast = createToast;
+        }}
+      />,
+    );
+  }
+
+  show(message: ReactNode, duration = TOAST.DURATION) {
+    if (!this.createToast) throw new Error('ToastManager is not initialized');
+
+    this.createToast({ message, duration });
+  }
+}
+
+export default new Toast();

--- a/packages/ui/src/toast/toast.css.ts
+++ b/packages/ui/src/toast/toast.css.ts
@@ -1,0 +1,87 @@
+import { breakpoint } from '@hcc/styles/dist/responsive.css';
+import { theme } from '@hcc/styles/dist/theme.css';
+import { keyframes, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { TOAST } from './constants';
+
+const fadeIn = keyframes({
+  '0%': { marginTop: '-80px', opacity: 0 },
+  '100%': { marginTop: 0, opacity: 1 },
+});
+
+const fadeOut = keyframes({
+  '0%': { opacity: 1 },
+  '100%': { transform: 'translateX(100%)', opacity: 0 },
+});
+
+export const root = style({
+  position: 'fixed',
+  top: '16px',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  zIndex: '10',
+  flexDirection: 'column',
+  width: '100%',
+  maxWidth: '420px',
+  padding: '0 16px',
+
+  ...breakpoint('mobile', {
+    left: 'auto',
+    right: '16px',
+    transform: 'translateX(0)',
+  }),
+});
+
+export const toastItem = recipe({
+  base: {
+    position: 'relative',
+    display: 'flex',
+    width: '100%',
+    alignItems: 'center',
+    overflow: 'hidden',
+    borderRadius: '0.25rem',
+    backgroundColor: '#ffffff',
+    padding: '16px 24px 16px 16px',
+    opacity: '1',
+    boxShadow: theme.shadows.sm,
+    animation: `${TOAST.OPACITY_DURATION}ms ease-in-out`,
+    animationFillMode: 'forwards',
+    transition: `opacity ${TOAST.OPACITY_DURATION}ms ease-out`,
+    boxSizing: 'border-box',
+  },
+
+  variants: {
+    show: {
+      true: {
+        animationName: fadeIn,
+      },
+      false: {
+        animationName: fadeOut,
+      },
+    },
+  },
+});
+
+export const toastRemove = recipe({
+  base: {
+    position: 'absolute',
+    top: '8px',
+    right: '8px',
+    transition: 'opacity 100ms ease-out',
+    backgroundColor: 'transparent',
+    outline: 'none',
+    border: 'none',
+  },
+
+  variants: {
+    show: {
+      true: {
+        opacity: 1,
+      },
+      false: {
+        opacity: 0,
+      },
+    },
+  },
+});

--- a/packages/ui/src/toast/toast.css.ts
+++ b/packages/ui/src/toast/toast.css.ts
@@ -6,8 +6,8 @@ import { recipe } from '@vanilla-extract/recipes';
 import { TOAST } from './constants';
 
 const fadeIn = keyframes({
-  '0%': { marginTop: '-80px', opacity: 0 },
-  '100%': { marginTop: 0, opacity: 1 },
+  '0%': { transform: 'translateY(-80px)', opacity: 0 },
+  '100%': { transform: 'translateY(0)', opacity: 1 },
 });
 
 const fadeOut = keyframes({

--- a/packages/ui/src/toast/type.ts
+++ b/packages/ui/src/toast/type.ts
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+export type Toast = {
+  id: string;
+  message: ReactNode;
+  duration: number;
+};
+
+export type CreateToastParams = Omit<Toast, 'id'>;
+
+export type TCreateToast = ({ message, duration }: CreateToastParams) => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       '@hcc/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@hcc/styles':
+        specifier: workspace:^
+        version: link:../styles
       '@hcc/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
@@ -324,15 +327,27 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.18
         version: 18.2.18
+      '@types/uuid':
+        specifier: ^9.0.8
+        version: 9.0.8
+      '@vanilla-extract/recipes':
+        specifier: ^0.5.1
+        version: 0.5.1(@vanilla-extract/css@1.14.0)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
 
 packages:
 
@@ -5113,6 +5128,14 @@ packages:
 
   /@vanilla-extract/private@1.0.3:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
+
+  /@vanilla-extract/recipes@0.5.1(@vanilla-extract/css@1.14.0):
+    resolution: {integrity: sha512-7dCuBgPQQ/89siQ0w2lkfjgkmToPUUDzFlHf5DRmt9ykiiycfA52tmPJ2RI/mr7jXi7U/vEN2aGP9QJSXEpGlA==}
+    peerDependencies:
+      '@vanilla-extract/css': ^1.0.0
+    dependencies:
+      '@vanilla-extract/css': 1.14.0
+    dev: true
 
   /@vanilla-extract/vite-plugin@3.9.5(@types/node@20.10.6)(vite@5.0.12):
     resolution: {integrity: sha512-CWI/CtrVW6i3HKccI6T7uGQkTJ8bd8Xl2UMBg3Pkr7dwWMmavXTeucV0I9KSbmXaYXSbEj+Q8c9y0xAZwtmTig==}


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #18

## ✅ 작업 내용

- Toast 컴포넌트 생성
  - Toast instance를 import 한 뒤, show 메서드를 호출하여 토스트를 생성할 수 있습니다.
  - 현재 디자인이 결정되지 않은 관계로 토스트를 여러 개 띄울 수 있도록 확장 가능하게 구현해두었습니다.
  - 다만 UI는 하나만 띄울 수 있도록 구현해두었는데, 추후 디자인이 결정됨에 따라 수정이 필요하다면 개선하도록 하겠습니다. 
  - toast item이 일정 시간 뒤 삭제될 수 있도록 id를 부여할 필요가 있는데, 이에 따라 고유한 식별자를 생성하는 `uuid` 라이브러리를 설치했습니다.
  - 리액트에서 새로운 진입점(?)을 만들어주는 `createRoot` 메서드를 사용하기 위해 `react-dom` 라이브러리를 설치했습니다.

- Storybook package의 task 의존성 수정
  - 현재 @hcc/ui의 코드가 수정되어도 즉각적인 re-build가 되지 않아 스토리북에서 이를 확인하려면 매번 `pnpm run build`를 실행해야 합니다.
  - 이를 개선하기 위해 `@hcc/ui`에 `"dev": "tsc --watch"` 커맨드를 추가하고 task 의존성을 추가합니다.

## 📝 참고 자료

## ♾️ 기타

- 추후 디자인 결정에 따라 변경사항이 생길 시 스타일 수정

