### PR TITLE
[CHORE]: 린트 오류 교정

### DIFF
--- a/apps/manager/package.json
+++ b/apps/manager/package.json
@@ -11,7 +11,7 @@
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
       "prettier --write",
-      "eslint --fix"
+      "eslint --fix --max-warnings 0"
     ]
   },
   "dependencies": {

--- a/apps/manager/package.json
+++ b/apps/manager/package.json
@@ -8,6 +8,12 @@
     "start": "next start",
     "lint": "eslint . --max-warnings 0"
   },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
+  },
   "dependencies": {
     "@hcc/styles": "workspace:*",
     "@hcc/ui": "workspace:*",

--- a/apps/spectator/api/league.ts
+++ b/apps/spectator/api/league.ts
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios';
+
 import instance from '@/api';
 import { LeagueType, SportsType } from '@/types/league';
 

--- a/apps/spectator/api/match.ts
+++ b/apps/spectator/api/match.ts
@@ -10,7 +10,6 @@ import {
   MatchType,
   MatchVideoType,
 } from '@/types/match';
-
 import { convertObjectToQueryString } from '@/utils/queryString';
 
 export type MatchListParams = {

--- a/apps/spectator/app/match/[id]/page.tsx
+++ b/apps/spectator/app/match/[id]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { MatchCommentType } from '@/types/match';
 
 import AsyncBoundary from '@/components/common/AsyncBoundary';
 import Loader from '@/components/common/Loader';
@@ -22,6 +21,7 @@ import MatchCommentFetcher from '@/queries/useMatchCommentById/Fetcher';
 import MatchTimelineFetcher from '@/queries/useMatchTimelineById/Fetcher';
 import MatchVideoFetcher from '@/queries/useMatchVideoById/Fetcher';
 import useSaveCommentMutation from '@/queries/useSaveCommentMutation/query';
+import { MatchCommentType } from '@/types/match';
 
 import * as styles from './page.css';
 

--- a/apps/spectator/app/page.css.ts
+++ b/apps/spectator/app/page.css.ts
@@ -1,5 +1,5 @@
-import { style, styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 export const section = style({
   display: 'flex',

--- a/apps/spectator/app/page.tsx
+++ b/apps/spectator/app/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { MatchStatus } from '@/types/match';
-
 import AsyncBoundary from '@/components/common/AsyncBoundary';
 import SportsList from '@/components/league/SportsList';
 import MatchList from '@/components/match/MatchList';
@@ -9,6 +7,7 @@ import { QUERY_PARAMS } from '@/constants/queryParams';
 import useQueryParams from '@/hooks/useQueryParams';
 import MatchListFetcher from '@/queries/useMatchList/Fetcher';
 import SportsListFetcher from '@/queries/useSportsListByLeagueId/Fetcher';
+import { MatchStatus } from '@/types/match';
 
 import {
   matchListWrapper,

--- a/apps/spectator/app/rummikube/[id]/page.tsx
+++ b/apps/spectator/app/rummikube/[id]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { MatchCommentType } from '@/types/match';
 
 import AsyncBoundary from '@/components/common/AsyncBoundary';
 import Loader from '@/components/common/Loader';
@@ -21,6 +20,7 @@ import MatchLineupFetcher from '@/queries/useMatchLineupById/Fetcher';
 import MatchTimelineFetcher from '@/queries/useMatchTimelineById/Fetcher';
 import MatchVideoFetcher from '@/queries/useMatchVideoById/Fetcher';
 import useSaveCommentMutation from '@/queries/useSaveCommentMutation/query';
+import { MatchCommentType } from '@/types/match';
 
 import * as styles from './page.css';
 

--- a/apps/spectator/components/common/Loader/Loader.css.ts
+++ b/apps/spectator/components/common/Loader/Loader.css.ts
@@ -1,5 +1,5 @@
-import { keyframes, styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { keyframes, styleVariants } from '@vanilla-extract/css';
 
 const spin = keyframes({
   from: { transform: 'rotate(0deg)' },

--- a/apps/spectator/components/common/MatchCard/pieces/Background.css.ts
+++ b/apps/spectator/components/common/MatchCard/pieces/Background.css.ts
@@ -1,5 +1,5 @@
-import { style } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { style } from '@vanilla-extract/css';
 
 export const background = style({
   position: 'absolute',

--- a/apps/spectator/components/common/MatchCard/pieces/Team.css.ts
+++ b/apps/spectator/components/common/MatchCard/pieces/Team.css.ts
@@ -1,5 +1,5 @@
-import { style } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { style } from '@vanilla-extract/css';
 
 export const teamLogoDefault = style({
   width: '4rem',

--- a/apps/spectator/components/common/MatchCard/pieces/Team.tsx
+++ b/apps/spectator/components/common/MatchCard/pieces/Team.tsx
@@ -2,8 +2,8 @@ import Image from 'next/image';
 
 import { useMatchCardContext } from '@/hooks/useMatchCardContext';
 
-import { Icon } from '../../Icon';
 import * as styles from './Team.css';
+import { Icon } from '../../Icon';
 
 type TeamProps = {
   teamIndex: number;

--- a/apps/spectator/components/common/MatchCard/pieces/Wrapper.tsx
+++ b/apps/spectator/components/common/MatchCard/pieces/Wrapper.tsx
@@ -1,5 +1,6 @@
-import { createContext, ReactNode } from 'react';
 import { clsx } from 'clsx';
+import { createContext, ReactNode } from 'react';
+
 import { MatchType } from '@/types/match';
 
 import * as styles from './Wrapper.css';

--- a/apps/spectator/components/fcOnline/UserInfo/UserInfo.css.ts
+++ b/apps/spectator/components/fcOnline/UserInfo/UserInfo.css.ts
@@ -1,5 +1,5 @@
-import { styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { styleVariants } from '@vanilla-extract/css';
 
 export const FconlineUserLineup = styleVariants({
   frame: {

--- a/apps/spectator/components/layout/Header.css.ts
+++ b/apps/spectator/components/layout/Header.css.ts
@@ -1,5 +1,5 @@
-import { styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { styleVariants } from '@vanilla-extract/css';
 
 export const header = styleVariants({
   wrapper: {

--- a/apps/spectator/components/league/SportsList/SportsList.css.ts
+++ b/apps/spectator/components/league/SportsList/SportsList.css.ts
@@ -1,5 +1,5 @@
-import { keyframes, style, styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { keyframes, style, styleVariants } from '@vanilla-extract/css';
 
 const sportsItemBase = style({
   borderRadius: '0.75rem',

--- a/apps/spectator/components/league/SportsList/index.tsx
+++ b/apps/spectator/components/league/SportsList/index.tsx
@@ -1,7 +1,6 @@
-import { SportsType } from '@/types/league';
-
 import { Icon } from '@/components/common/Icon';
 import { QUERY_PARAMS } from '@/constants/queryParams';
+import { SportsType } from '@/types/league';
 
 import * as styles from './SportsList.css';
 

--- a/apps/spectator/components/match/Banner/Banner.css.ts
+++ b/apps/spectator/components/match/Banner/Banner.css.ts
@@ -1,5 +1,5 @@
-import { styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { styleVariants } from '@vanilla-extract/css';
 
 export const matchBanner = styleVariants({
   frame: {

--- a/apps/spectator/components/match/Banner/index.tsx
+++ b/apps/spectator/components/match/Banner/index.tsx
@@ -1,7 +1,6 @@
-import { MatchType } from '@/types/match';
-
 import { FallbackProps } from '@/components/common/ErrorBoundary';
 import { MatchCard } from '@/components/common/MatchCard';
+import { MatchType } from '@/types/match';
 
 import * as styles from './Banner.css';
 

--- a/apps/spectator/components/match/Cheer/Cheer.css.ts
+++ b/apps/spectator/components/match/Cheer/Cheer.css.ts
@@ -1,5 +1,5 @@
-import { styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { styleVariants } from '@vanilla-extract/css';
 
 export const cheer = styleVariants({
   wrapper: {

--- a/apps/spectator/components/match/Cheer/index.tsx
+++ b/apps/spectator/components/match/Cheer/index.tsx
@@ -1,9 +1,8 @@
+import { FallbackProps } from '@/components/common/ErrorBoundary';
 import { MatchCheerType, MatchTeamType } from '@/types/match';
 
-import { FallbackProps } from '@/components/common/ErrorBoundary';
-
-import CheerTeam from '../CheerTeam';
 import * as styles from './Cheer.css';
+import CheerTeam from '../CheerTeam';
 
 type CheerProps = {
   matchId: string;

--- a/apps/spectator/components/match/CheerTeam/CheerTeam.css.ts
+++ b/apps/spectator/components/match/CheerTeam/CheerTeam.css.ts
@@ -1,5 +1,5 @@
-import { style } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { style } from '@vanilla-extract/css';
 
 export const button = style({
   display: 'flex',

--- a/apps/spectator/components/match/CommentForm/CommentForm.css.ts
+++ b/apps/spectator/components/match/CommentForm/CommentForm.css.ts
@@ -1,5 +1,5 @@
-import { style, styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 export const form = style({
   position: 'absolute',

--- a/apps/spectator/components/match/CommentForm/index.tsx
+++ b/apps/spectator/components/match/CommentForm/index.tsx
@@ -1,5 +1,6 @@
-import { ChangeEvent, FormEvent, useState } from 'react';
 import { UseMutateFunction } from '@tanstack/react-query';
+import { ChangeEvent, FormEvent, useState } from 'react';
+
 import { MatchCommentPayload, MatchTeamType } from '@/types/match';
 
 import * as styles from './CommentForm.css';

--- a/apps/spectator/components/match/CommentItem/CommentItem.css.ts
+++ b/apps/spectator/components/match/CommentItem/CommentItem.css.ts
@@ -1,5 +1,5 @@
-import { style, styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 const base = style({
   borderRadius: '0.75rem',

--- a/apps/spectator/components/match/CommentList/index.tsx
+++ b/apps/spectator/components/match/CommentList/index.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { useEffect } from 'react';
 import { AxiosError } from 'axios';
-import { MatchCommentType } from '@/types/match';
+import { useEffect } from 'react';
 
 import { FallbackProps } from '@/components/common/ErrorBoundary';
 import { COMMENT_API_ERROR_MESSAGE } from '@/constants/error';
 import useInfiniteObserver from '@/hooks/useInfiniteObserver';
+import { MatchCommentType } from '@/types/match';
 
-import CommentItem from '../CommentItem';
 import { errorFallback } from './CommentLIst.css';
+import CommentItem from '../CommentItem';
 
 type CommentListProps = {
   commentList: MatchCommentType[];

--- a/apps/spectator/components/match/LineupItem/LineupItem.css.ts
+++ b/apps/spectator/components/match/LineupItem/LineupItem.css.ts
@@ -1,5 +1,5 @@
-import { styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { styleVariants } from '@vanilla-extract/css';
 
 export const lineupItem = styleVariants({
   li: {

--- a/apps/spectator/components/match/LineupList/LineupList.css.ts
+++ b/apps/spectator/components/match/LineupList/LineupList.css.ts
@@ -1,5 +1,5 @@
-import { styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { styleVariants } from '@vanilla-extract/css';
 
 import { errorFallback as videoErrorFallback } from '../Video/Video.css';
 

--- a/apps/spectator/components/match/LineupList/index.tsx
+++ b/apps/spectator/components/match/LineupList/index.tsx
@@ -1,11 +1,11 @@
 import { AxiosError } from 'axios';
-import { MatchLineupType } from '@/types/match';
 
 import { FallbackProps } from '@/components/common/ErrorBoundary';
 import { LINEUP_API_ERROR_MESSAGE } from '@/constants/error';
+import { MatchLineupType } from '@/types/match';
 
-import LineupItem from '../LineupItem';
 import * as styles from './LineupList.css';
+import LineupItem from '../LineupItem';
 
 export default function Lineup({ teamName, gameTeamPlayers }: MatchLineupType) {
   return (

--- a/apps/spectator/components/match/MatchList/index.tsx
+++ b/apps/spectator/components/match/MatchList/index.tsx
@@ -1,7 +1,6 @@
+import { AxiosError } from 'axios';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { AxiosError } from 'axios';
-import { MatchListType } from '@/types/match';
 
 import { FallbackProps } from '@/components/common/ErrorBoundary';
 import { MatchCard } from '@/components/common/MatchCard';
@@ -10,6 +9,7 @@ import {
   COMMON_ERROR_MESSAGE,
   MATCH_LIST_API_ERROR_MESSAGE,
 } from '@/constants/error';
+import { MatchListType } from '@/types/match';
 
 import * as styles from './matchList.css';
 

--- a/apps/spectator/components/match/MatchList/matchList.css.ts
+++ b/apps/spectator/components/match/MatchList/matchList.css.ts
@@ -1,5 +1,5 @@
-import { styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { styleVariants } from '@vanilla-extract/css';
 
 export const matchCard = styleVariants({
   frame: { display: 'flex', flexDirection: 'column' },

--- a/apps/spectator/components/match/Panel/Panel.css.ts
+++ b/apps/spectator/components/match/Panel/Panel.css.ts
@@ -1,5 +1,5 @@
-import { styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { styleVariants } from '@vanilla-extract/css';
 
 export const panel = styleVariants({
   wrapper: {

--- a/apps/spectator/components/match/RecordList/index.tsx
+++ b/apps/spectator/components/match/RecordList/index.tsx
@@ -1,11 +1,11 @@
 import { AxiosError } from 'axios';
-import { MatchTimelineType } from '@/types/match';
 
 import { FallbackProps } from '@/components/common/ErrorBoundary';
 import { TIMELINE_API_ERROR_MESSAGE } from '@/constants/error';
+import { MatchTimelineType } from '@/types/match';
 
-import RecordItem from '../RecordItem';
 import * as styles from './RecordList.css';
+import RecordItem from '../RecordItem';
 
 export default function RecordList({
   gameQuarter,

--- a/apps/spectator/components/match/Video/Video.css.ts
+++ b/apps/spectator/components/match/Video/Video.css.ts
@@ -1,5 +1,5 @@
-import { style, styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 export const video = style({ aspectRatio: '16 / 9', width: '100%' });
 

--- a/apps/spectator/components/match/Video/index.tsx
+++ b/apps/spectator/components/match/Video/index.tsx
@@ -1,5 +1,5 @@
-import { ComponentProps } from 'react';
 import { AxiosError } from 'axios';
+import { ComponentProps } from 'react';
 
 import { FallbackProps } from '@/components/common/ErrorBoundary';
 import { VIDEO_API_ERROR_MESSAGE } from '@/constants/error';

--- a/apps/spectator/components/rummikub/Cheer/index.tsx
+++ b/apps/spectator/components/rummikub/Cheer/index.tsx
@@ -1,7 +1,6 @@
-import { MatchCheerType, MatchTeamType } from '@/types/match';
-
 import { FallbackProps } from '@/components/common/ErrorBoundary';
 import CheerTeam from '@/components/match/CheerTeam';
+import { MatchCheerType, MatchTeamType } from '@/types/match';
 
 import * as styles from './Cheer.css';
 

--- a/apps/spectator/components/rummikub/MatchBanner/MatchBanner.css.ts
+++ b/apps/spectator/components/rummikub/MatchBanner/MatchBanner.css.ts
@@ -1,5 +1,5 @@
-import { style, styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 import {
   errorFallback as ogErrorFallback,

--- a/apps/spectator/components/rummikub/MatchBanner/index.tsx
+++ b/apps/spectator/components/rummikub/MatchBanner/index.tsx
@@ -1,7 +1,6 @@
-import { MatchType } from '@/types/match';
-
 import { FallbackProps } from '@/components/common/ErrorBoundary';
 import { MatchCard } from '@/components/common/MatchCard';
+import { MatchType } from '@/types/match';
 
 import * as styles from './MatchBanner.css';
 

--- a/apps/spectator/components/rummikub/MatchItem/MatchItem.css.ts
+++ b/apps/spectator/components/rummikub/MatchItem/MatchItem.css.ts
@@ -1,5 +1,5 @@
-import { styleVariants } from '@vanilla-extract/css';
 import { theme } from '@hcc/styles';
+import { styleVariants } from '@vanilla-extract/css';
 
 import { matchCard } from '@/components/match/MatchList/matchList.css';
 

--- a/apps/spectator/components/rummikub/MatchItem/index.tsx
+++ b/apps/spectator/components/rummikub/MatchItem/index.tsx
@@ -1,6 +1,5 @@
-import { MatchType } from '@/types/match';
-
 import { MatchCard } from '@/components/common/MatchCard';
+import { MatchType } from '@/types/match';
 
 import * as styles from './MatchItem.css';
 

--- a/apps/spectator/hooks/useMatchCardContext.ts
+++ b/apps/spectator/hooks/useMatchCardContext.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
-import { MatchType } from '@/types/match';
 
 import { MatchContext } from '@/components/common/MatchCard/pieces/Wrapper';
+import { MatchType } from '@/types/match';
 
 type MatchCardContextType = () => MatchType;
 

--- a/apps/spectator/hooks/useQueryParams.ts
+++ b/apps/spectator/hooks/useQueryParams.ts
@@ -1,4 +1,5 @@
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
 import { MatchStatus } from '@/types/match';
 
 export default function useQueryParams() {

--- a/apps/spectator/package.json
+++ b/apps/spectator/package.json
@@ -11,7 +11,7 @@
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
       "prettier --write",
-      "eslint --fix"
+      "eslint --fix --max-warnings 0"
     ]
   },
   "dependencies": {

--- a/apps/spectator/package.json
+++ b/apps/spectator/package.json
@@ -8,6 +8,12 @@
     "start": "next start",
     "lint": "eslint . --max-warnings 0"
   },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
+  },
   "dependencies": {
     "@hcc/styles": "workspace:*",
     "@hcc/ui": "workspace:*",

--- a/apps/spectator/queries/useCheerMutation/query.ts
+++ b/apps/spectator/queries/useCheerMutation/query.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import { postCheer } from '@/api/match';
 
 export default function useCheerMutation({

--- a/apps/spectator/queries/useFconlineLineupById/Fetcher.tsx
+++ b/apps/spectator/queries/useFconlineLineupById/Fetcher.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
-import { MatchLineupType } from '@/types/match';
 
 import { FconlineInfoType } from '@/api/player';
+import { MatchLineupType } from '@/types/match';
 
 import { useMatchFconlineLineupById } from './query';
 

--- a/apps/spectator/queries/useFconlineLineupById/query.ts
+++ b/apps/spectator/queries/useFconlineLineupById/query.ts
@@ -1,6 +1,6 @@
 import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
-import { getMatchLineupById } from '@/api/match';
 
+import { getMatchLineupById } from '@/api/match';
 import { FconlineInfoType, getFconlinePlayerInfo } from '@/api/player';
 
 export const useMatchFconlineLineupById = (matchId: string) => {

--- a/apps/spectator/queries/useMatchById/Fetcher.tsx
+++ b/apps/spectator/queries/useMatchById/Fetcher.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+
 import { MatchType } from '@/types/match';
 
 import useMatchById from './query';

--- a/apps/spectator/queries/useMatchById/query.ts
+++ b/apps/spectator/queries/useMatchById/query.ts
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+
 import { getMatchById } from '@/api/match';
 
 export const QUERY_KEY = {

--- a/apps/spectator/queries/useMatchCheerById/Fetcher.tsx
+++ b/apps/spectator/queries/useMatchCheerById/Fetcher.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+
 import { MatchCheerType, MatchTeamType } from '@/types/match';
 
 import { useMatchCheerById } from './query';

--- a/apps/spectator/queries/useMatchCheerById/query.ts
+++ b/apps/spectator/queries/useMatchCheerById/query.ts
@@ -1,4 +1,5 @@
 import { useSuspenseQueries } from '@tanstack/react-query';
+
 import { getMatchById, getMatchCheerById } from '@/api/match';
 import { MatchType } from '@/types/match';
 

--- a/apps/spectator/queries/useMatchCommentById/Fetcher.tsx
+++ b/apps/spectator/queries/useMatchCommentById/Fetcher.tsx
@@ -1,5 +1,6 @@
-import { ReactNode } from 'react';
 import { InfiniteData } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+
 import { MatchCommentType, MatchTeamType } from '@/types/match';
 
 import useMatchCommentById from './query';

--- a/apps/spectator/queries/useMatchCommentById/query.ts
+++ b/apps/spectator/queries/useMatchCommentById/query.ts
@@ -2,6 +2,7 @@ import {
   useSuspenseInfiniteQuery,
   useSuspenseQuery,
 } from '@tanstack/react-query';
+
 import { getMatchById, getMatchCommentById } from '@/api/match';
 
 export default function useMatchCommentById(matchId: string) {

--- a/apps/spectator/queries/useMatchLineupById/Fetcher.tsx
+++ b/apps/spectator/queries/useMatchLineupById/Fetcher.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+
 import { MatchLineupType } from '@/types/match';
 
 import { useMatchLineupById } from './query';

--- a/apps/spectator/queries/useMatchLineupById/query.ts
+++ b/apps/spectator/queries/useMatchLineupById/query.ts
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+
 import { getMatchLineupById } from '@/api/match';
 
 export const useMatchLineupById = (matchId: string) => {

--- a/apps/spectator/queries/useMatchList/Fetcher.tsx
+++ b/apps/spectator/queries/useMatchList/Fetcher.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+
 import { MatchListParams } from '@/api/match';
 import { MatchListType } from '@/types/match';
 

--- a/apps/spectator/queries/useMatchList/query.ts
+++ b/apps/spectator/queries/useMatchList/query.ts
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+
 import { getMatchList, MatchListParams } from '@/api/match';
 
 export const useMatchList = ({

--- a/apps/spectator/queries/useMatchTimelineById/Fetcher.tsx
+++ b/apps/spectator/queries/useMatchTimelineById/Fetcher.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+
 import { MatchTimelineType } from '@/types/match';
 
 import { useMatchTimelineById } from './query';

--- a/apps/spectator/queries/useMatchTimelineById/query.ts
+++ b/apps/spectator/queries/useMatchTimelineById/query.ts
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+
 import { getMatchTimelineById } from '@/api/match';
 
 export const useMatchTimelineById = (matchId: string) => {

--- a/apps/spectator/queries/useMatchVideoById/Fetcher.tsx
+++ b/apps/spectator/queries/useMatchVideoById/Fetcher.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+
 import { MatchVideoType } from '@/types/match';
 
 import { useMatchVideoById } from './query';

--- a/apps/spectator/queries/useMatchVideoById/query.ts
+++ b/apps/spectator/queries/useMatchVideoById/query.ts
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+
 import { getMatchVideoById } from '@/api/match';
 
 export const useMatchVideoById = (matchId: string) => {

--- a/apps/spectator/queries/useReportCommentMutation/query.ts
+++ b/apps/spectator/queries/useReportCommentMutation/query.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+
 import { postReportComment } from '@/api/match';
 
 export default function useReportCommentMutation() {

--- a/apps/spectator/queries/useSaveCommentMutation/query.ts
+++ b/apps/spectator/queries/useSaveCommentMutation/query.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+
 import { postMatchComment } from '@/api/match';
 
 export default function useSaveCommentMutation() {

--- a/apps/spectator/queries/useSportsListByLeagueId/Fetcher.tsx
+++ b/apps/spectator/queries/useSportsListByLeagueId/Fetcher.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+
 import { SportsType } from '@/types/league';
 
 import useSportsListByLeagueId from './query';

--- a/apps/spectator/queries/useSportsListByLeagueId/query.ts
+++ b/apps/spectator/queries/useSportsListByLeagueId/query.ts
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+
 import { getSportsListByLeagueId } from '@/api/league';
 
 export default function useSportsListByLeagueId(leagueId: string) {

--- a/package.json
+++ b/package.json
@@ -11,16 +11,6 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "prepare": "husky install"
   },
-  "lint-staged": {
-    "apps/**/*.{js,jsx,ts,tsx}": [
-      "prettier --write",
-      "eslint --fix"
-    ],
-    "packages/ui/**/*.{js,jsx,ts,tsx}": [
-      "prettier --write",
-      "eslint --fix"
-    ]
-  },
   "devDependencies": {
     "@commitlint/cli": "^18.4.4",
     "@commitlint/config-conventional": "^18.4.4",

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -47,6 +47,10 @@ module.exports = {
             position: 'after',
           },
         ],
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true,
+        },
       },
     ],
     // prettier

--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -27,10 +27,6 @@ module.exports = {
     'react/prop-types': 0,
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
-    '@next/next/no-html-link-for-pages': [
-      'error',
-      path.join(__dirname, '/app'),
-    ],
   },
   ignorePatterns: [
     // Ignore dotfiles

--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -1,4 +1,4 @@
-const { resolve } = require('node:path');
+const path = require('node:path');
 
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
@@ -27,7 +27,10 @@ module.exports = {
     'react/prop-types': 0,
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
-    '@next/next/no-html-link-for-pages': ['error', 'apps/*/app/'],
+    '@next/next/no-html-link-for-pages': [
+      'error',
+      path.join(__dirname, '/app'),
+    ],
   },
   ignorePatterns: [
     // Ignore dotfiles

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -9,6 +9,12 @@
     "lint": "eslint . --max-warnings 0",
     "build": "tsc"
   },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "prettier --write",
+      "eslint --fix --max-warnings 0"
+    ]
+  },
   "devDependencies": {
     "@hcc/eslint-config": "workspace:*",
     "@hcc/typescript-config": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,12 @@
     "lint": "eslint . --max-warnings 0",
     "build": "tsc"
   },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
+  },
   "devDependencies": {
     "@hcc/eslint-config": "workspace:*",
     "@hcc/styles": "workspace:^",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,7 +13,7 @@
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
       "prettier --write",
-      "eslint --fix"
+      "eslint --fix --max-warnings 0"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #22 

## ✅ 작업 내용

- `eslint-config` 내 `base.js`에 import/order를 알파벳 순으로 정렬해주는 `alphabetize` 옵션을 추가했습니다.
- `next.js` 설정에 build시 발생하는 `Pages directory cannot be found at apps/*/app/. If using a custom path, please configure with the `no-html-link-for-pages` rule in your eslint config file.` 에러를 교정하는 옵션을 바로잡았습니다.
- `lint-staged`가 정상적으로 작동하지 않는 버그를 각 프로젝트 `package.json`에 각각 이전해 해결하였습니다.
  - apps/manager
  - apps/spectator
  - packages/ui

## 📝 참고 자료

- 각 프로젝트별 lint-staged 참고문서
  - https://nitpum.com/post/lint-staged-eslint-monorepo/
  - https://yeoulcoding.me/316
