### PR TITLE
[STYLE]: spaces 토큰 추가

### DIFF
--- a/packages/styles/src/theme.css.ts
+++ b/packages/styles/src/theme.css.ts
@@ -53,7 +53,7 @@ export const theme = createGlobalTheme(':root', {
       '6': '#28323C',
     },
     background: {
-      normal: 'white',
+      normal: '#FFFFFF',
       secondary: '#F7F8F9',
       light: '#D5D5DC',
     },
@@ -69,6 +69,15 @@ export const theme = createGlobalTheme(':root', {
 
   fonts: {
     body: `"Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif`,
+  },
+
+  spaces: {
+    xxs: rem(4),
+    xs: rem(8),
+    sm: rem(12),
+    default: rem(16),
+    lg: rem(24),
+    xl: rem(32),
   },
 
   textVariants: {
@@ -107,7 +116,7 @@ export const theme = createGlobalTheme(':root', {
       fontWeight: '400',
       lineHeight: 'normal',
     },
-    '2xs': {
+    xxs: {
       fontSize: rem(10),
       fontWeight: '400',
       lineHeight: 'normal',


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #35

## ✅ 작업 내용

- 와이어프레임에 의거하여 spaces token 추가
  ```ts
  spaces: {
    xxs: rem(4),
    xs: rem(8),
    sm: rem(12),
    default: rem(16),
    lg: rem(24),
    xl: rem(32),
  },
  ``

## 📝 참고 자료

## ♾️ 기타

- 사이즈와 관련한 토큰 key에서 `xs`, `xl` 이상의 값은 숫자 대신 `x`를 하나씩 붙여 표현합니다.
  - `2xs` -> `xxs`
  - `2xl` -> `xxl`
