### PR TITLE
[REFACTOR] Header 컴포넌트 스타일 변경

### DIFF
--- a/apps/spectator/components/Sidebar/Sidebar.css.ts
+++ b/apps/spectator/components/Sidebar/Sidebar.css.ts
@@ -38,10 +38,14 @@ export const sidebarHeader = style({
   borderBottom: `1px solid ${theme.colors.gray[2]}`,
 });
 
+export const openIconButton = style({
+  display: 'flex',
+  alignItems: 'center',
+});
+
 export const close = style({
   position: 'absolute',
   top: '50%',
   right: 0,
   transform: 'translate(0, -50%)',
-  // transform: 'translateY(-75%)',
 });

--- a/apps/spectator/components/Sidebar/index.tsx
+++ b/apps/spectator/components/Sidebar/index.tsx
@@ -12,7 +12,7 @@ export default function Sidebar() {
   return (
     <Modal>
       <Modal.Trigger>
-        <Icon source={HamburgerIcon} />
+        <Icon source={HamburgerIcon} color="primary" />
       </Modal.Trigger>
       <Modal.Content
         key="sidebar"

--- a/apps/spectator/components/Sidebar/index.tsx
+++ b/apps/spectator/components/Sidebar/index.tsx
@@ -11,8 +11,8 @@ import LeagueList from '../LeagueList';
 export default function Sidebar() {
   return (
     <Modal>
-      <Modal.Trigger>
-        <Icon source={HamburgerIcon} color="primary" />
+      <Modal.Trigger className={styles.openIconButton}>
+        <Icon source={HamburgerIcon} size={20} color="primary" />
       </Modal.Trigger>
       <Modal.Content
         key="sidebar"

--- a/apps/spectator/components/layout/Header.css.ts
+++ b/apps/spectator/components/layout/Header.css.ts
@@ -5,20 +5,13 @@ export const header = styleVariants({
   wrapper: {
     display: 'flex',
     position: 'relative',
-    padding: '1rem',
+    paddingInline: theme.spaces.default,
+    paddingBlock: theme.spaces.xs,
     justifyContent: 'space-between',
     alignItems: 'center',
   },
-  logoWrapper: {
-    display: 'flex',
-    gap: '0.25rem',
-    alignItems: 'baseline',
-    textAlign: 'center',
-  },
   logoContent: {
-    fontSize: '1.875rem',
-    lineHeight: '2.25rem',
-    fontWeight: 700,
+    display: 'flex',
+    alignItems: 'center',
   },
-  hamburgerMenu: { aspectRatio: '1 / 1', color: theme.colors.gray[3] },
 });

--- a/apps/spectator/components/layout/Header.tsx
+++ b/apps/spectator/components/layout/Header.tsx
@@ -10,13 +10,11 @@ import Sidebar from '../Sidebar';
 export default function Header() {
   return (
     <header className={styles.header.wrapper}>
-      <div>
-        <Link href="/" className={styles.header.logoWrapper}>
-          <span className={styles.header.logoContent}>
-            <Icon source={HccIcon} size={75} />
-          </span>
-        </Link>
-      </div>
+      <Link href="/">
+        <span className={styles.header.logoContent}>
+          <Icon source={HccIcon} size={58} height={41} color="primary" />
+        </span>
+      </Link>
       <Sidebar />
     </header>
   );

--- a/packages/ui/src/modal/Trigger.tsx
+++ b/packages/ui/src/modal/Trigger.tsx
@@ -14,12 +14,17 @@ type TriggerType = <C extends ElementType = 'button'>(
 
 const ModalTrigger: TriggerType = forwardRef(function ModalTrigger<
   C extends ElementType = 'button',
->({ as, children }: Props<C>, ref: PolymorphicRef<C>) {
+>({ as, className, children, ...props }: Props<C>, ref: PolymorphicRef<C>) {
   const Component = as || 'button';
   const { onOpenToggle } = useModal();
 
   return (
-    <Component ref={ref} onClick={onOpenToggle}>
+    <Component
+      ref={ref}
+      className={className}
+      {...props}
+      onClick={onOpenToggle}
+    >
       {children}
     </Component>
   );


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #61 

## ✅ 작업 내용

- Header 영역의 스타일과 아이콘 색상을 변경했습니다.
> <img width="334" alt="image" src="https://github.com/hufscheer/client_v2/assets/97780352/10316a45-62fe-4ff1-84db-0478bb028b5f">

## ♾️ 기타
- Sidebar Trigger 버튼에 수직 가운데 정렬을 추가하기 위해 모달 컴포넌트의 Trigger 영역을 수정했습니다.