### PR TITLE
[FEAT] manager card 컴포넌트 추가

### DIFF
--- a/apps/manager/components/Card/Card.css.ts
+++ b/apps/manager/components/Card/Card.css.ts
@@ -1,0 +1,71 @@
+import { rem, theme } from '@hcc/styles';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const root = recipe({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: theme.spaces.xs,
+
+    paddingInline: theme.spaces.default,
+    borderRadius: rem(12),
+
+    backgroundColor: theme.colors.background.normal,
+
+    boxShadow: theme.shadows.base,
+  },
+  variants: {
+    paddingVertical: {
+      sm: {
+        paddingBlock: theme.spaces.sm,
+      },
+      md: {
+        paddingBlock: theme.spaces.default,
+      },
+    },
+  },
+});
+
+export const content = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spaces.default,
+
+  width: '100%',
+});
+
+export const inner = style({
+  display: 'flex',
+  alignItems: 'center',
+  flex: 1,
+});
+
+export const title = recipe({
+  base: { ...theme.textVariants.default },
+  variants: {
+    text: {
+      bold: {
+        fontWeight: theme.textVariants.lg.fontWeight,
+      },
+      normal: {
+        fontWeight: theme.textVariants.sm.fontWeight,
+      },
+    },
+  },
+});
+
+export const subContent = style({
+  color: theme.colors.gray[4],
+  ...theme.textVariants.sm,
+});
+
+export const footer = style({
+  display: 'grid',
+  gridAutoFlow: 'column',
+  gap: theme.spaces.xs,
+
+  width: '100%',
+  paddingTop: theme.spaces.xs,
+});

--- a/apps/manager/components/Card/index.tsx
+++ b/apps/manager/components/Card/index.tsx
@@ -1,0 +1,98 @@
+import { ComponentPropsWithoutRef, forwardRef } from 'react';
+
+import * as styles from './Card.css';
+
+interface CardProps extends ComponentPropsWithoutRef<'div'> {
+  paddingVertical?: 'sm' | 'md';
+  children: React.ReactNode;
+}
+
+const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
+  { paddingVertical = 'md', children, ...props },
+  ref,
+) {
+  return (
+    <div ref={ref} className={styles.root({ paddingVertical })} {...props}>
+      {children}
+    </div>
+  );
+});
+
+interface CardContentProps extends ComponentPropsWithoutRef<'div'> {
+  left?: React.ReactNode;
+  right?: React.ReactNode;
+}
+
+const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
+  function CardContent({ left, right, children, ...props }, ref) {
+    return (
+      <div ref={ref} className={styles.content} {...props}>
+        {left}
+        <div className={styles.inner}>{children}</div>
+        {right}
+      </div>
+    );
+  },
+);
+
+interface CardActionProps extends ComponentPropsWithoutRef<'button'> {}
+
+const CardAction = forwardRef<HTMLButtonElement, CardActionProps>(
+  function CardAction({ children, ...props }, ref) {
+    return (
+      <button ref={ref} {...props}>
+        {children}
+      </button>
+    );
+  },
+);
+
+interface CardTitleProps extends ComponentPropsWithoutRef<'h3'> {
+  text?: 'bold' | 'normal';
+}
+
+const CardTitle = forwardRef<HTMLHeadingElement, CardTitleProps>(
+  function CardTitle({ children, text = 'normal', ...props }, ref) {
+    return (
+      <h3 ref={ref} {...props} className={styles.title({ text })}>
+        {children}
+      </h3>
+    );
+  },
+);
+
+interface CardSubContentProps extends ComponentPropsWithoutRef<'span'> {}
+
+const CardSubContent = forwardRef<HTMLSpanElement, CardSubContentProps>(
+  function CardSubContent({ children, ...props }, ref) {
+    return (
+      <span ref={ref} {...props} className={styles.subContent}>
+        {children}
+      </span>
+    );
+  },
+);
+
+interface CardFooterProps extends ComponentPropsWithoutRef<'div'> {}
+
+const CardFooter = forwardRef<HTMLDivElement, CardFooterProps>(
+  function CardFooter({ children, ...props }, ref) {
+    return (
+      <div ref={ref} {...props} className={styles.footer}>
+        {children}
+      </div>
+    );
+  },
+);
+
+export default Object.assign(
+  {},
+  {
+    Root: Card,
+    Content: CardContent,
+    Action: CardAction,
+    Title: CardTitle,
+    SubContent: CardSubContent,
+    Footer: CardFooter,
+  },
+);

--- a/apps/manager/package.json
+++ b/apps/manager/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-query": "^5.17.19",
     "@tanstack/react-query-devtools": "^5.17.21",
     "@vanilla-extract/css": "^1.14.0",
+    "@vanilla-extract/recipes": "^0.5.1",
     "axios": "^1.6.5",
     "next": "^14.0.4",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^18.4.4
-        version: 18.4.4(@types/node@20.11.16)(typescript@5.3.3)
+        version: 18.4.4(@types/node@20.11.16)(typescript@5.4.2)
       '@commitlint/config-conventional':
         specifier: ^18.4.4
         version: 18.4.4
@@ -50,6 +50,9 @@ importers:
       '@vanilla-extract/css':
         specifier: ^1.14.0
         version: 1.14.0
+      '@vanilla-extract/recipes':
+        specifier: ^0.5.1
+        version: 0.5.1(@vanilla-extract/css@1.14.0)
       axios:
         specifier: ^1.6.5
         version: 1.6.5
@@ -1853,14 +1856,14 @@ packages:
     dev: true
     optional: true
 
-  /@commitlint/cli@18.4.4(@types/node@20.11.16)(typescript@5.3.3):
+  /@commitlint/cli@18.4.4(@types/node@20.11.16)(typescript@5.4.2):
     resolution: {integrity: sha512-Ro3wIo//fV3XiV1EkdpHog6huaEyNcUAVrSmtgKqYM5g982wOWmP4FXvEDFwRMVgz878CNBvvCc33dMZ5AQJ/g==}
     engines: {node: '>=v18'}
     hasBin: true
     dependencies:
       '@commitlint/format': 18.4.4
       '@commitlint/lint': 18.4.4
-      '@commitlint/load': 18.4.4(@types/node@20.11.16)(typescript@5.3.3)
+      '@commitlint/load': 18.4.4(@types/node@20.11.16)(typescript@5.4.2)
       '@commitlint/read': 18.4.4
       '@commitlint/types': 18.4.4
       execa: 5.1.1
@@ -1931,7 +1934,7 @@ packages:
       '@commitlint/types': 18.4.4
     dev: true
 
-  /@commitlint/load@18.4.4(@types/node@20.11.16)(typescript@5.3.3):
+  /@commitlint/load@18.4.4(@types/node@20.11.16)(typescript@5.4.2):
     resolution: {integrity: sha512-RaDIa9qwOw2xRJ3Jr2DBXd14rmnHJIX2XdZF4kmoF1rgsg/+7cvrExLSUNAkQUNimyjCn1b/bKX2Omm+GdY0XQ==}
     engines: {node: '>=v18'}
     dependencies:
@@ -1940,8 +1943,8 @@ packages:
       '@commitlint/resolve-extends': 18.4.4
       '@commitlint/types': 18.4.4
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.3.3)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.11.16)(cosmiconfig@8.3.6)(typescript@5.3.3)
+      cosmiconfig: 8.3.6(typescript@5.4.2)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.11.16)(cosmiconfig@8.3.6)(typescript@5.4.2)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -5371,7 +5374,6 @@ packages:
       '@vanilla-extract/css': ^1.0.0
     dependencies:
       '@vanilla-extract/css': 1.14.0
-    dev: true
 
   /@vanilla-extract/vite-plugin@3.9.5(@types/node@20.11.16)(vite@5.0.12):
     resolution: {integrity: sha512-CWI/CtrVW6i3HKccI6T7uGQkTJ8bd8Xl2UMBg3Pkr7dwWMmavXTeucV0I9KSbmXaYXSbEj+Q8c9y0xAZwtmTig==}
@@ -6690,7 +6692,7 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
 
-  /cosmiconfig-typescript-loader@5.0.0(@types/node@20.11.16)(cosmiconfig@8.3.6)(typescript@5.3.3):
+  /cosmiconfig-typescript-loader@5.0.0(@types/node@20.11.16)(cosmiconfig@8.3.6)(typescript@5.4.2):
     resolution: {integrity: sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==}
     engines: {node: '>=v16'}
     peerDependencies:
@@ -6699,9 +6701,9 @@ packages:
       typescript: '>=4'
     dependencies:
       '@types/node': 20.11.16
-      cosmiconfig: 8.3.6(typescript@5.3.3)
+      cosmiconfig: 8.3.6(typescript@5.4.2)
       jiti: 1.21.0
-      typescript: 5.3.3
+      typescript: 5.4.2
     dev: true
 
   /cosmiconfig@8.3.6(typescript@5.3.3):
@@ -6718,6 +6720,22 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       typescript: 5.3.3
+    dev: true
+
+  /cosmiconfig@8.3.6(typescript@5.4.2):
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      typescript: 5.4.2
     dev: true
 
   /create-require@1.1.1:
@@ -12408,6 +12426,12 @@ packages:
 
   /typescript@5.3.3:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
+  /typescript@5.4.2:
+    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #63 

## ✅ 작업 내용

- 매니저 앱에서 사용할 카드 컴포넌트를 추가합니다.
  - Card: 가장 상위의 컴포넌트. 기본 카드 컴포넌트의 스타일이 정의되어 있습니다.
  - Content: 내용물을 렌더링하는 컴포넌트. 컨텐츠 왼쪽에 들어갈 컴포넌트를 `left` props로, 오른쪽에 들어갈 컴포넌트를 `right` props로 전달 받습니다. 양쪽의 아이콘을 제외한 내부 요소의 레이아웃은 직접 스타일을 작성해주어야 합니다.
  - Title: 카드 컴포넌트의 제목을 표시합니다. `fontWeight` props로 폰트 굵기를 결정합니다.
  - SubContent: 제목 아래의 시간 정보와 같이 추가적으로 덧붙여야 하는 내용을 표시합니다.
  - Action: 우측 아이콘과 같이 클릭 시 이벤트를 발생시킬 수 있는 요소를 담당합니다.
  - Footer: 요소 하단의 영역을 담당합니다.

![image](https://github.com/hufscheer/client_v2/assets/88662637/d6f1e7f1-e2e1-4bf5-a949-8cdde799433f)

## 📝 참고 자료

Card/index.tsx 파일에 모든 조각 컴포넌트를 포함시켰습니다. 이렇게 한 이유는 매니저 앱에서는 조각 컴포넌트를 어디서든 import 해올 수 있는데, 이렇게만 사용하면 컴포넌트를 조합 가능하도록 만든 이유가 없다고 판단해서입니다. 그래서 하나의 파일에서 작성하고, Root 컴포넌트에 포함시킨 뒤 해당 컴포넌트만 export 하여 조각 컴포넌트를 다른 곳에서 불러오지 못하도록 했습니다.

## ♾️ 기타
