### PR TITLE
[FEAT] manager login 기능 구현

### DIFF
--- a/apps/manager/api/auth.ts
+++ b/apps/manager/api/auth.ts
@@ -1,22 +1,10 @@
-import { AxiosError } from 'axios';
-
 import instance from '@/api';
 import { AuthPayload, AuthType } from '@/types/auth';
 
 export const postLogin = async (body: AuthPayload) => {
-  try {
-    const response = await instance.post<AuthType>('/accounts/login/', body);
+  const { data } = await instance.post<AuthType>('/accounts/login/', body);
 
-    return response.data;
-  } catch (error) {
-    const axiosError = error as AxiosError;
-
-    if (axiosError.response) {
-      throw new Error(axiosError.response.statusText);
-    } else {
-      throw new Error('팀 목록을 불러오는 데에 실패했습니다!');
-    }
-  }
+  return data;
 };
 
 export const postGameStatus = async (id: number, gameStatus: string) => {

--- a/apps/manager/app/layout.tsx
+++ b/apps/manager/app/layout.tsx
@@ -7,6 +7,9 @@ import { ReactNode } from 'react';
 
 import { mantineTheme } from '@/styles/theme';
 
+import * as styles from './page.css';
+import ReactQueryProvider from './ReactQueryProvider';
+
 interface RootLayoutProps {
   children: ReactNode;
 }
@@ -23,8 +26,10 @@ export default function RootLayout({ children }: RootLayoutProps): JSX.Element {
         />
         <ColorSchemeScript />
       </head>
-      <body>
-        <MantineProvider theme={mantineTheme}>{children}</MantineProvider>
+      <body className={styles.layout}>
+        <ReactQueryProvider>
+          <MantineProvider theme={mantineTheme}>{children}</MantineProvider>
+        </ReactQueryProvider>
       </body>
     </html>
   );

--- a/apps/manager/app/login/page.css.ts
+++ b/apps/manager/app/login/page.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css';
+
+export const page = style({
+  minHeight: '100vh',
+});

--- a/apps/manager/app/login/page.tsx
+++ b/apps/manager/app/login/page.tsx
@@ -2,12 +2,16 @@
 
 import { Box, Button, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import useLoginMutation from '@/hooks/mutations/useLoginMutation';
 
 import * as styles from './page.css';
 
 export default function Login() {
+  const router = useRouter();
+  const params = useSearchParams();
+
   const form = useForm({
     initialValues: {
       email: '',
@@ -19,9 +23,17 @@ export default function Login() {
     },
     validateInputOnChange: true,
   });
+
   const { mutate: mutateLogin } = useLoginMutation();
   const handleSubmit = (values: typeof form.values) => {
-    mutateLogin(values);
+    mutateLogin(values, {
+      onSuccess: () => {
+        const redirect = params.get('redirect');
+
+        if (redirect) router.replace(redirect);
+        else router.replace('/');
+      },
+    });
   };
 
   return (

--- a/apps/manager/app/login/page.tsx
+++ b/apps/manager/app/login/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Toast } from '@hcc/ui';
 import { Box, Button, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 
@@ -22,10 +21,7 @@ export default function Login() {
   });
   const { mutate: mutateLogin } = useLoginMutation();
   const handleSubmit = (values: typeof form.values) => {
-    mutateLogin(values, {
-      onSuccess: () => Toast.show('로그인에 성공했습니다!'),
-      onError: () => Toast.show('이메일 혹은 비밀번호를 확인해주세요.'),
-    });
+    mutateLogin(values);
   };
 
   return (

--- a/apps/manager/app/login/page.tsx
+++ b/apps/manager/app/login/page.tsx
@@ -1,3 +1,55 @@
+'use client';
+
+import { Toast } from '@hcc/ui';
+import { Box, Button, TextInput } from '@mantine/core';
+import { useForm } from '@mantine/form';
+
+import useLoginMutation from '@/hooks/mutations/useLoginMutation';
+
+import * as styles from './page.css';
+
 export default function Login() {
-  return <>로그인</>;
+  const form = useForm({
+    initialValues: {
+      email: '',
+      password: '',
+    },
+    validate: {
+      email: value => (value.includes('@') ? null : 'Invalid email'),
+      password: value => (value.length >= 4 ? null : 'Password is too short'),
+    },
+    validateInputOnChange: true,
+  });
+  const { mutate: mutateLogin } = useLoginMutation();
+  const handleSubmit = (values: typeof form.values) => {
+    mutateLogin(values, {
+      onSuccess: () => Toast.show('로그인에 성공했습니다!'),
+      onError: () => Toast.show('이메일 혹은 비밀번호를 확인해주세요.'),
+    });
+  };
+
+  return (
+    <Box>
+      <form onSubmit={form.onSubmit(handleSubmit)} className={styles.page}>
+        <TextInput
+          withAsterisk
+          label="Email"
+          placeholder="이메일을 입력해주세요."
+          {...form.getInputProps('email')}
+        />
+
+        <TextInput
+          type="password"
+          withAsterisk
+          label="Password"
+          placeholder="비밀번호을 입력해주세요."
+          {...form.getInputProps('password')}
+        />
+
+        <Button mt="md" fullWidth type="submit">
+          로그인
+        </Button>
+      </form>
+    </Box>
+  );
 }

--- a/apps/manager/app/page.css.ts
+++ b/apps/manager/app/page.css.ts
@@ -1,7 +1,8 @@
 import { theme } from '@hcc/styles';
 import { style } from '@vanilla-extract/css';
 
-export const customButtonStyle = style({
-  backgroundColor: theme.colors.gray[2],
-  color: theme.colors.gray[6],
+export const layout = style({
+  maxWidth: theme.sizes.appWidth,
+  margin: 'auto',
+  paddingInline: theme.spaces.default,
 });

--- a/apps/manager/app/page.tsx
+++ b/apps/manager/app/page.tsx
@@ -3,7 +3,9 @@ import Link from 'next/link';
 export default function Page(): JSX.Element {
   return (
     <main style={{ display: 'flex', flexDirection: 'column' }}>
-      <Link href={{ href: '/login', query: { redirectPath: 'redirectUrl' } }}>
+      <Link
+        href={{ pathname: '/login', query: { redirectPath: 'redirectUrl' } }}
+      >
         로그인 페이지로
       </Link>
     </main>

--- a/apps/manager/app/page.tsx
+++ b/apps/manager/app/page.tsx
@@ -1,24 +1,11 @@
-import { Button, Select } from '@mantine/core';
-
-import * as styles from './page.css';
+import Link from 'next/link';
 
 export default function Page(): JSX.Element {
   return (
     <main style={{ display: 'flex', flexDirection: 'column' }}>
-      훕치치 매니저
-      <Select
-        label="라운드"
-        placeholder="골라봐"
-        data={['16강', '8강', '4강', '결승']}
-      />
-      <Button>버튼</Button>
-      <Button variant="light">버튼</Button>
-      <Button variant="subtle">버튼</Button>
-      <Button variant="gradient">버튼</Button>
-      <Button variant="outline">버튼</Button>
-      <Button variant="transparent">버튼</Button>
-      <Button variant="white">버튼</Button>
-      <Button className={styles.customButtonStyle}>버튼</Button>
+      <Link href={{ href: '/login', query: { redirectPath: 'redirectUrl' } }}>
+        로그인 페이지로
+      </Link>
     </main>
   );
 }

--- a/apps/manager/hooks/mutations/useLoginMutation.ts
+++ b/apps/manager/hooks/mutations/useLoginMutation.ts
@@ -1,25 +1,16 @@
 import { useMutation } from '@tanstack/react-query';
-import { useRouter, useSearchParams } from 'next/navigation';
 
 import { postLogin } from '@/api/auth';
 import { ADMIN_MUTATION_KEY } from '@/constants/mutationKey';
 
 export default function useLoginMutation() {
-  const router = useRouter();
-  const params = useSearchParams();
-
   return useMutation({
     mutationKey: [ADMIN_MUTATION_KEY.POST_LOGIN],
     mutationFn: postLogin,
     onSuccess: ({ access }) => {
       if (typeof window !== 'undefined') {
-        localStorage.setItem('aceessToken', access);
+        localStorage.setItem('accessToken', access);
       }
-
-      const redirectPath = params.get('redirectPath');
-
-      if (redirectPath) router.replace(redirectPath);
-      else router.replace('/');
     },
   });
 }

--- a/apps/manager/hooks/mutations/useLoginMutation.ts
+++ b/apps/manager/hooks/mutations/useLoginMutation.ts
@@ -1,21 +1,25 @@
 import { useMutation } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { postLogin } from '@/api/auth';
 import { ADMIN_MUTATION_KEY } from '@/constants/mutationKey';
 
 export default function useLoginMutation() {
   const router = useRouter();
+  const params = useSearchParams();
 
   return useMutation({
     mutationKey: [ADMIN_MUTATION_KEY.POST_LOGIN],
     mutationFn: postLogin,
     onSuccess: ({ access }) => {
       if (typeof window !== 'undefined') {
-        localStorage.setItem('token', access);
+        localStorage.setItem('aceessToken', access);
       }
 
-      router.push('/admin/league');
+      const redirectPath = params.get('redirectPath');
+
+      if (redirectPath) router.replace(redirectPath);
+      else router.replace('/');
     },
   });
 }

--- a/apps/manager/package.json
+++ b/apps/manager/package.json
@@ -17,6 +17,7 @@
     "@hcc/styles": "workspace:*",
     "@hcc/ui": "workspace:*",
     "@mantine/core": "^7.6.1",
+    "@mantine/form": "^7.6.1",
     "@mantine/hooks": "^7.6.1",
     "@mantine/vanilla-extract": "^7.6.1",
     "@tanstack/react-query": "^5.17.19",

--- a/apps/manager/types/auth.ts
+++ b/apps/manager/types/auth.ts
@@ -2,6 +2,7 @@ export type AuthPayload = {
   email: string;
   password: string;
 };
+
 export type AuthType = {
   access: string;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@mantine/core':
         specifier: ^7.6.1
         version: 7.6.1(@mantine/hooks@7.6.1)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)
+      '@mantine/form':
+        specifier: ^7.6.1
+        version: 7.6.1(react@18.2.0)
       '@mantine/hooks':
         specifier: ^7.6.1
         version: 7.6.1(react@18.2.0)
@@ -2740,6 +2743,16 @@ packages:
       type-fest: 3.13.1
     transitivePeerDependencies:
       - '@types/react'
+    dev: false
+
+  /@mantine/form@7.6.1(react@18.2.0):
+    resolution: {integrity: sha512-S0pdvFohRX3ahzhrCGM+d2sBaSHH88UkQhbzyOAGJ7xqNjPJ11Bh/xb4Mc+NXXxaq9MjPrRVe6fgpKJtXszBpQ==}
+    peerDependencies:
+      react: ^18.2.0
+    dependencies:
+      fast-deep-equal: 3.1.3
+      klona: 2.0.6
+      react: 18.2.0
     dev: false
 
   /@mantine/hooks@7.6.1(react@18.2.0):
@@ -8126,7 +8139,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
 
   /fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
@@ -9566,6 +9578,11 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
     dev: true
+
+  /klona@2.0.6:
+    resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
+    engines: {node: '>= 8'}
+    dev: false
 
   /language-subtag-registry@0.3.22:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #72

## ✅ 작업 내용

- 로그인 기능 구현
  - 로그인 시 form 컴포넌트를 사용합니다.
  - 이외에도 매니저 어플리케이션에서는 다양한 정보를 제출하는 형태의 유저 시나리오가 많습니다.
  - 이에 따라 `@mantine/form`을 설치하여 form 데이터를 보다 쉽고 간편하게 다룰 수 있도록 합니다.

## 📝 참고 자료

- [@mantine/form](https://v5.mantine.dev/form/use-form/)

## ♾️ 기타

- 현재 `@hcc/ui`의 toast 컴포넌트가 내부에서 `document`를 사용하고 있기 때문에 빌드 시 에러가 발생합니다.
  - 때문에 현재는 토스트 메시지 관련 코드를 제거한 채 올려두었습니다.
  - 추후 toast 컴포넌트를 변경한다면 사용할 수 있을 것으로 보이고, 시간 여유가 없다고 판단하면 `@mantine/notification`와 같은 라이브러리를 사용하는 것도 좋아 보입니다.
  - 이 부분은 필수 기능을 먼저 구현한 뒤 남은 시간에 따라 정해보면 좋을 것 같습니다!
- 쿼리 훅 함수 파일의 위치 변경을 제안합니다.
  - 현재에는 쿼리 훅 함수를 `root/queries` 디렉토리에 두고 있습니다. 
  - 하지만 내부에 query 함수와 mutation 함수가 혼재되어 있어 적절하지 못한 폴더명이라는 생각이 계속 들었습니다.
  - 더욱이 queries 폴더 내에 정의해둔 hook 함수들 역시 query, mutation 함수를 일종의 hook 형태로 재정의한 것이고, 이를 통해 관련된 작업을 한 군데에 모아 처리할 수 있도록 한 것입니다. 이런 의도에서 `hooks/` 디렉토리 하위에 각각 `queries`, `mutations`를 두고 이 안에 카테고리별로 모아두는 것은 어떨지 제안드립니다!
  - 사실 관객 앱에서도 동일한 방법을 사용하고 싶었지만, 이미 작업이 진행되던 터라 괜히 혼선을 일으키거나 작업이 지체될 수 있을 것이라 판단해서 후순위로 미뤄뒀습니다. 하지만 매니저 앱은 이제 시작하는 단계라 미리 정하면 좋을 것 같아서 이야기 해봅니다ㅎㅎ
  - 추가로 늦은 감이 있지만, query hook 네이밍은 `use + {기능} + Query`, mutation hook 네이밍은 `use + {기능} + Mutation` 어떤가요? 기존에는 query hook에 대한 네이밍 컨벤션이 없어서 이 참에 정하면 좋을 것 같네요!
- 현재 `api/index.ts`에서 인터셉터 기능을 이용하여 에러 처리를 담당하고 있습니다. 세부적으로 잘 작성해준 것 같아서 좋은 것 같습니다. 여기에 더해 에러 바운더리를 사용한다면 네트워크 통신의 실패하는 경우에 대해 관심을 갖지 않고, 관심사 분리도 더 확실하게 할 수 있을 것 같네요! 이를 통해 더 이해하기 쉬운 코드를 작성할 수 있을 것 같습니다! 차차 개선해나가보면 좋을 것 같아요ㅎㅎ