### PR TITLE
[BUILD] 관객 및 매니저 앱 프록시 연결

### DIFF
--- a/apps/manager/.eslintrc.js
+++ b/apps/manager/.eslintrc.js
@@ -1,4 +1,4 @@
-/** @type {import('eslint').Linter.Config} */
+/** @type {import("eslint").Linter.Config} */
 module.exports = {
   root: true,
   extends: ['@hcc/eslint-config/next.js'],

--- a/apps/manager/.eslintrc.js
+++ b/apps/manager/.eslintrc.js
@@ -1,9 +1,9 @@
-/** @type {import("eslint").Linter.Config} */
+/** @type {import('eslint').Linter.Config} */
 module.exports = {
   root: true,
   extends: ['@hcc/eslint-config/next.js'],
   parser: '@typescript-eslint/parser',
-  ignorePatterns: ['next.config.js', 'postcss.config.js', '_redirects'],
+  ignorePatterns: ['next.config.js', 'postcss.config.js'],
   parserOptions: {
     project: true,
   },

--- a/apps/manager/.eslintrc.js
+++ b/apps/manager/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
   root: true,
   extends: ['@hcc/eslint-config/next.js'],
   parser: '@typescript-eslint/parser',
-  ignorePatterns: ['next.config.js', 'postcss.config.js'],
+  ignorePatterns: ['next.config.js', 'postcss.config.js', '_redirects'],
   parserOptions: {
     project: true,
   },

--- a/apps/manager/_redirects
+++ b/apps/manager/_redirects
@@ -1,1 +1,1 @@
-/api/*  https://backoffice.hufstreaming.site/:splat  200!a
+/api/*  https://backoffice.hufstreaming.site/:splat  200!

--- a/apps/manager/_redirects
+++ b/apps/manager/_redirects
@@ -1,1 +1,1 @@
-/api/*  https://backoffice.hufstreaming.site/:splat 200
+/api/*  https://backoffice.hufstreaming.site/:splat  200!a

--- a/apps/manager/_redirects
+++ b/apps/manager/_redirects
@@ -1,0 +1,1 @@
+/api/*  https://backoffice.hufstreaming.site/:splat 200

--- a/apps/manager/api/index.ts
+++ b/apps/manager/api/index.ts
@@ -6,7 +6,7 @@ import axios, {
 } from 'axios';
 
 const instance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_BACK_OFFICE_BASE_URL,
+  baseURL: '/api',
   headers: {
     Authorization: `Bearer `,
     'Content-Type': 'application/json',

--- a/apps/manager/next.config.js
+++ b/apps/manager/next.config.js
@@ -3,8 +3,19 @@ const withVanillaExtract = createVanillaExtractPlugin();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  trailingSlash: true,
+
   experimental: {
     optimizePackageImports: ['@mantine/core', '@mantine/hooks'],
+  },
+
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*/',
+        destination: 'https://backoffice.hufstreaming.site/:path*/',
+      },
+    ];
   },
 };
 

--- a/apps/manager/next.config.js
+++ b/apps/manager/next.config.js
@@ -13,7 +13,7 @@ const nextConfig = {
     return [
       {
         source: '/api/:path*/',
-        destination: 'https://backoffice.hufstreaming.site/:path*/',
+        destination: `https://backoffice.hufstreaming.site/:path*/`,
       },
     ];
   },

--- a/apps/manager/package.json
+++ b/apps/manager/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --max-warnings 0"
   },
   "lint-staged": {
-    "**/*": "prettier --write",
+    "**/*.{js,jsx,ts,tsx,json,css,md}": "prettier --write",
     "**/*.{ts,tsx}": "eslint --fix --max-warnings 0"
   },
   "dependencies": {

--- a/apps/spectator/_redirects
+++ b/apps/spectator/_redirects
@@ -1,1 +1,1 @@
-/api/*  https://api.hufstreaming.site/:splat  200!a
+/api/*  https://api.hufstreaming.site/:splat  200!

--- a/apps/spectator/_redirects
+++ b/apps/spectator/_redirects
@@ -1,0 +1,1 @@
+/api/*  https://api.hufstreaming.site/:splat  200!a

--- a/apps/spectator/api/game.ts
+++ b/apps/spectator/api/game.ts
@@ -22,7 +22,7 @@ export type GameListParams = {
 export const getGameList = async ({ ...params }: GameListParams) => {
   const queryString = convertObjectToQueryString(params);
 
-  const { data } = await instance.get<GameListType[]>(`games?${queryString}`);
+  const { data } = await instance.get<GameListType[]>(`/games?${queryString}`);
 
   return data;
 };

--- a/apps/spectator/api/index.ts
+++ b/apps/spectator/api/index.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const instance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  baseURL: '/api',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/apps/spectator/next.config.js
+++ b/apps/spectator/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
     return [
       {
         source: '/api/:path*',
-        destination: 'https://api.hufstreaming.site/:path*',
+        destination: `${process.env.NEXT_PUBLIC_API_BASE_URL}/:path*`,
       },
     ];
   },

--- a/apps/spectator/next.config.js
+++ b/apps/spectator/next.config.js
@@ -3,6 +3,15 @@ const withVanillaExtract = createVanillaExtractPlugin();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'https://api.hufstreaming.site/:path*',
+      },
+    ];
+  },
+
   images: {
     formats: ['image/avif', 'image/webp'],
     minimumCacheTTL: 60 * 60 * 24 * 14,

--- a/apps/spectator/package.json
+++ b/apps/spectator/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --max-warnings 0"
   },
   "lint-staged": {
-    "**/*": "prettier --write",
+    "**/*.{js,jsx,ts,tsx,json,css,md}": "prettier --write",
     "**/*.{ts,tsx}": "eslint --fix --max-warnings 0"
   },
   "dependencies": {


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #77 

## ✅ 작업 내용

- 관객 및 매니저 앱에 NextJS의 `rewrites` 기능을 이용하여 프록시를 적용했습니다. 
  - `/api/:path*` 경로에 요청을 보내면 서버 통신이 이루어집니다.

## 📝 참고 자료

- `process.env`를 사용하는 경우 매니저 앱에서 프록시 연결이 정상적으로 되지 않아(POST 요청이 아니라 GET 요청만 보내는 경우 존재) `next.config.js` 파일 내에 명시적으로 작성했습니다.
- 이에 따라 `.env` 파일이 사라져도 될 거 같습니다.

## ♾️ 기타

- 현재 관객 앱에서 `ECONNREFUSED` 로 인한 오류가 발생하고 있는데, 찾아보니 정상적이지 않은 URL로 연결을 할 때 발생한다고 하더라구요.
- 정상적이지 않은 URL로 연결 요청을 하는 경우 자동으로 'localhost:80' 으로 요청을 보내는데, 현재 관객 앱은 3000 포트에서 돌아가기 때문에, 80에 요청을 보내면 오류가 납니다.
- 서버에 올리면 포트가 같아지니 문제는 없지만, 어디서 오류가 발생하는 것인지 정확하게 찾으면 좋을 거 같습니다. 간단하게 API 사용하는 부분 훑어봤는데 아직 못 찾았습니다.
