### PR TITLE
[FEAT] 리그 팀 관리 페이지 생성

### DIFF
--- a/apps/manager/api/index.ts
+++ b/apps/manager/api/index.ts
@@ -1,9 +1,4 @@
-import axios, {
-  AxiosError,
-  AxiosResponse,
-  InternalAxiosRequestConfig,
-  isAxiosError,
-} from 'axios';
+import axios, { InternalAxiosRequestConfig } from 'axios';
 
 const instance = axios.create({
   baseURL: '/api',
@@ -13,22 +8,6 @@ const instance = axios.create({
   },
 });
 
-const onRequest = (config: InternalAxiosRequestConfig) => {
-  const existedToken = getAccessToken();
-  config.headers.Authorization = `Bearer ${existedToken}`;
-
-  return config;
-};
-
-instance.interceptors.request.use(onRequest);
-
-const onResponse = (res: AxiosResponse) => {
-  retryCounter = 0;
-  return res;
-};
-
-let retryCounter = 0;
-
 const getAccessToken = () => {
   if (typeof window !== 'undefined') {
     const tokenInLocalStorage = localStorage.getItem('accessToken');
@@ -37,64 +16,13 @@ const getAccessToken = () => {
   } else return null;
 };
 
-const alertError = async (message: string) => {
-  alert(message);
-  return;
+const onRequest = (config: InternalAxiosRequestConfig) => {
+  const existedToken = getAccessToken();
+  config.headers.Authorization = `Bearer ${existedToken}`;
+
+  return config;
 };
 
-const onError = async (error: AxiosError | Error) => {
-  if (isAxiosError(error)) {
-    switch (error.response?.status) {
-      case 400: {
-        alertError('400: 잘못된 요청입니다.');
-        break;
-      }
-      case 401: {
-        if (retryCounter < 3) {
-          retryCounter++;
-          try {
-            const existedToken = getAccessToken();
-            if (!existedToken) throw new Error('no accessible token');
-            return await instance({
-              ...error.config,
-              headers: { Authorization: `Bearer ${existedToken}` },
-            });
-          } catch (e) {
-            const message =
-              e instanceof Error ? e.message : '401: 로그인이 필요합니다.';
-            alertError(message);
-            return (window.location.href = '/login');
-          }
-        } else {
-          alertError(
-            '재시도 횟수를 초과하였습니다. 로그인 페이지로 이동합니다.',
-          );
-          return (window.location.href = '/login');
-        }
-      }
-      case 403: {
-        alertError('403: 권한이 필요합니다.');
-        break;
-      }
-      case 404: {
-        alertError('404: 잘못된 요청입니다.');
-        break;
-      }
-      case 500: {
-        alertError('500: 서버에 문제가 발생했습니다.');
-        break;
-      }
-      default: {
-        alertError('알 수 없는 오류입니다.');
-        break;
-      }
-    }
-  } else {
-    alertError(error.message);
-  }
-  return Promise.reject(error);
-};
-
-instance.interceptors.response.use(onResponse, onError);
+instance.interceptors.request.use(onRequest);
 
 export default instance;

--- a/apps/manager/api/team.ts
+++ b/apps/manager/api/team.ts
@@ -1,22 +1,11 @@
-import { isAxiosError } from 'axios';
-
 import instance from '@/api';
-import { TeamErrorType, TeamType } from '@/types/team';
+import { TeamType } from '@/types/team';
 
 /* 리그 내 팀 관리 API */
-
 export const getTeamListByLeagueId = async (leagueId: string) => {
-  try {
-    const { data } = await instance.get<TeamType[]>(`/team/${leagueId}/`);
+  const { data } = await instance.get<TeamType[]>(`/league-teams/${leagueId}/`);
 
-    return data;
-  } catch (error) {
-    if (isAxiosError<TeamErrorType>(error)) {
-      return error.response?.data.detail;
-    } else {
-      throw new Error('리그 내 팀을 조회하는데 실패했습니다.');
-    }
-  }
+  return data;
 };
 
 export const postTeamByLeagueId = async (payload: {

--- a/apps/manager/app/ReactQueryProvider.tsx
+++ b/apps/manager/app/ReactQueryProvider.tsx
@@ -19,6 +19,7 @@ export default function ReactQueryProvider({
             refetchOnWindowFocus: false,
             refetchInterval: false,
             staleTime: 1000 * 60 * 10,
+            retry: 0,
           },
         },
       }),

--- a/apps/manager/app/league/[leagueId]/_components/LeagueMenuCard.tsx
+++ b/apps/manager/app/league/[leagueId]/_components/LeagueMenuCard.tsx
@@ -1,5 +1,4 @@
 import { CaretDownIcon } from '@hcc/icons';
-import { rem } from '@hcc/styles';
 import { Icon } from '@hcc/ui';
 import Link from 'next/link';
 
@@ -8,29 +7,22 @@ import Card from '@/components/Card';
 type LeagueMenuCardProps = {
   href: string;
   title: string;
-  marginTop?: number;
 };
 
-export default function LeagueMenuCard({
-  href,
-  title,
-  marginTop = 12,
-}: LeagueMenuCardProps) {
+export default function LeagueMenuCard({ href, title }: LeagueMenuCardProps) {
   return (
-    <Link href={href} style={{ marginTop: rem(marginTop) }}>
-      <Card.Root paddingVertical="sm">
-        <Card.Content>
-          <div style={{ flex: 1 }}>
-            <Card.Title text="semibold">{title}</Card.Title>
-          </div>
-          <Card.Action>
-            <Icon
-              source={CaretDownIcon}
-              style={{ transform: 'rotate(-90deg)' }}
-            />
-          </Card.Action>
-        </Card.Content>
-      </Card.Root>
-    </Link>
+    <Card.Root paddingVertical="sm">
+      <Card.Content component={Link} href={href}>
+        <Card.Title text="semibold" style={{ flex: 1 }}>
+          {title}
+        </Card.Title>
+        <Card.Action>
+          <Icon
+            source={CaretDownIcon}
+            style={{ transform: 'rotate(-90deg)' }}
+          />
+        </Card.Action>
+      </Card.Content>
+    </Card.Root>
   );
 }

--- a/apps/manager/app/league/[leagueId]/page.tsx
+++ b/apps/manager/app/league/[leagueId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Flex } from '@mantine/core';
 import { usePathname } from 'next/navigation';
 
 import Layout from '@/components/Layout';
@@ -19,9 +20,11 @@ export default function LeagueInfoMap() {
 
   return (
     <Layout navigationTitle={league.name}>
-      <LeagueMenuCard href={`${pathname}/detail`} title="대회 정보 관리" />
-      <LeagueMenuCard href={`${pathname}/team`} title="대회 팀 관리" />
-      <LeagueMenuCard href={`${pathname}/game`} title="대회 게임 관리" />
+      <Flex direction="column" gap="xs">
+        <LeagueMenuCard href={`${pathname}/detail`} title="대회 정보 관리" />
+        <LeagueMenuCard href={`${pathname}/team`} title="대회 팀 관리" />
+        <LeagueMenuCard href={`${pathname}/game`} title="대회 게임 관리" />
+      </Flex>
     </Layout>
   );
 }

--- a/apps/manager/app/league/[leagueId]/team/_components/ActionIcon/ActionIcon.css.ts
+++ b/apps/manager/app/league/[leagueId]/team/_components/ActionIcon/ActionIcon.css.ts
@@ -1,0 +1,10 @@
+import { style } from '@vanilla-extract/css';
+
+export const caretIcon = style({
+  transform: 'rotate(-90deg)',
+});
+
+export const subtractIcon = style({
+  padding: 4,
+  boxSizing: 'content-box',
+});

--- a/apps/manager/app/league/[leagueId]/team/_components/ActionIcon/index.tsx
+++ b/apps/manager/app/league/[leagueId]/team/_components/ActionIcon/index.tsx
@@ -1,0 +1,26 @@
+import { CaretDownIcon, SubtractIcon } from '@hcc/icons';
+import { Icon } from '@hcc/ui';
+
+import * as styles from './ActionIcon.css';
+
+type LeagueTeamActionIconProps = {
+  edit: boolean;
+};
+
+export default function LeagueTeamActionIcon({
+  edit,
+}: LeagueTeamActionIconProps) {
+  if (edit) {
+    return (
+      <Icon color="error" source={SubtractIcon} aria-label="대회 팀 삭제" />
+    );
+  }
+
+  return (
+    <Icon
+      source={CaretDownIcon}
+      className={styles.caretIcon}
+      aria-label="대회 팀 관리"
+    />
+  );
+}

--- a/apps/manager/app/league/[leagueId]/team/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/page.tsx
@@ -1,15 +1,70 @@
 'use client';
 
+import { rem } from '@hcc/styles';
+import { Button, Flex } from '@mantine/core';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
+import { MouseEvent, useState } from 'react';
+
+import Card from '@/components/Card';
+import Layout from '@/components/Layout';
+import useLeagueTeamQuery from '@/hooks/queries/useLeagueTeamQuery';
+
+import LeagueTeamActionIcon from './_components/ActionIcon';
 
 export default function LeagueTeamList() {
+  const [edit, setEdit] = useState(false);
   const pathname = usePathname();
+  const params = useParams();
+  const leagueId = params.leagueId as string;
+
+  const { data: leagueTeams } = useLeagueTeamQuery(leagueId);
+  // const {} = useDeleteLeagueTeamMutation()
+
+  if (!leagueTeams) return null;
+
+  const handleClickCard = (e: MouseEvent<HTMLButtonElement>) => {
+    if (!edit) return;
+
+    e.preventDefault();
+    alert('팀 삭제 API');
+  };
+
+  const handleClickMenuButton = () => {
+    setEdit(prev => !prev);
+  };
+
+  if (!leagueTeams.length) {
+    return (
+      <Layout navigationTitle="대회 팀 관리">
+        <Flex align="center" justify="center" style={{ height: '100%' }}>
+          팀이 없습니다.
+        </Flex>
+      </Layout>
+    );
+  }
+
   return (
-    <>
-      2024 월드컵
-      <Link href={`${pathname}/1`}>미컴 축구생각</Link>
-      <Link href={`${pathname}/2`}>경영 야생마</Link>
-    </>
+    <Layout
+      navigationTitle="대회 팀 관리"
+      navigationMenu={
+        <Button variant="subtle" onClick={handleClickMenuButton}>
+          {edit ? '완료' : '편집'}
+        </Button>
+      }
+    >
+      <Flex direction="column" gap={rem(4)}>
+        {leagueTeams.map(team => (
+          <Card.Root key={team.id}>
+            <Card.Content component={Link} href={`${pathname}${team.id}`}>
+              <Card.Title style={{ flex: 1 }}>{team.name}</Card.Title>
+              <Card.Action onClick={handleClickCard}>
+                <LeagueTeamActionIcon edit={edit} />
+              </Card.Action>
+            </Card.Content>
+          </Card.Root>
+        ))}
+      </Flex>
+    </Layout>
   );
 }

--- a/apps/manager/app/league/_components/LeagueCard/index.tsx
+++ b/apps/manager/app/league/_components/LeagueCard/index.tsx
@@ -1,7 +1,7 @@
 import { CaretDownIcon } from '@hcc/icons';
 import { Icon } from '@hcc/ui';
 import { Title } from '@mantine/core';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 
 import Card from '@/components/Card';
 import useLeagueQuery from '@/hooks/queries/useLeagueQuery';
@@ -16,8 +16,6 @@ type LeagueCardProps = {
 export default function LeagueCard({ title }: LeagueCardProps) {
   const { data: leagues } = useLeagueQuery();
 
-  const router = useRouter();
-
   return (
     <>
       <Title order={2} className={styles.title}>
@@ -25,7 +23,7 @@ export default function LeagueCard({ title }: LeagueCardProps) {
       </Title>
       {(leagues || []).map(league => (
         <Card.Root key={league.leagueId}>
-          <Card.Content>
+          <Card.Content component={Link} href={`/league/${league.leagueId}`}>
             <div className={styles.content}>
               <Card.Title text="semibold">{league.name}</Card.Title>
               <Card.SubContent>
@@ -33,11 +31,7 @@ export default function LeagueCard({ title }: LeagueCardProps) {
                 {formatTime(league.endAt, 'YYYY.MM.DD')}
               </Card.SubContent>
             </div>
-            <Card.Action
-              onClick={() => router.push(`/league/${league.leagueId}`)}
-            >
-              <Icon source={CaretDownIcon} className={styles.caret} />
-            </Card.Action>
+            <Icon source={CaretDownIcon} className={styles.caret} />
           </Card.Content>
         </Card.Root>
       ))}

--- a/apps/manager/components/Card/index.tsx
+++ b/apps/manager/components/Card/index.tsx
@@ -1,3 +1,4 @@
+import { Flex, FlexProps, createPolymorphicComponent } from '@mantine/core';
 import { ComponentPropsWithoutRef, forwardRef } from 'react';
 
 import * as styles from './Card.css';
@@ -18,21 +19,19 @@ const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
   );
 });
 
-interface CardContentProps extends ComponentPropsWithoutRef<'div'> {
-  left?: React.ReactNode;
-  right?: React.ReactNode;
-}
+interface CardContentProps extends FlexProps {}
 
-const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
-  function CardContent({ left, right, children, ...props }, ref) {
+const CardContent = createPolymorphicComponent<'div', CardContentProps>(
+  forwardRef<HTMLDivElement, CardContentProps>(function CardContent(
+    { children, ...props },
+    ref,
+  ) {
     return (
-      <div ref={ref} className={styles.content} {...props}>
-        {left}
+      <Flex ref={ref} className={styles.content} {...props}>
         <div className={styles.inner}>{children}</div>
-        {right}
-      </div>
+      </Flex>
     );
-  },
+  }),
 );
 
 interface CardActionProps extends ComponentPropsWithoutRef<'button'> {}

--- a/apps/manager/hooks/queries/useLeagueTeamQuery.ts
+++ b/apps/manager/hooks/queries/useLeagueTeamQuery.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getTeamListByLeagueId } from '@/api/team';
+
+export const LEAGUE_TEAM_QUERY_KEY = 'leagueTeamQuery';
+export default function useLeagueTeamQuery(leagueId: string) {
+  const { error } = useQuery({
+    queryKey: [LEAGUE_TEAM_QUERY_KEY, { leagueId }],
+    queryFn: () => getTeamListByLeagueId(leagueId),
+  });
+
+  if (error) throw error;
+
+  return {
+    data: [
+      {
+        id: 1,
+        name: '1번 팀',
+        logoImageUrl: 'string',
+      },
+      {
+        id: 2,
+        name: '2번 팀',
+        logoImageUrl: 'string',
+      },
+    ],
+  };
+
+  // return { data };
+}

--- a/apps/manager/hooks/queries/useLeagueTeamQuery.ts
+++ b/apps/manager/hooks/queries/useLeagueTeamQuery.ts
@@ -4,27 +4,12 @@ import { getTeamListByLeagueId } from '@/api/team';
 
 export const LEAGUE_TEAM_QUERY_KEY = 'leagueTeamQuery';
 export default function useLeagueTeamQuery(leagueId: string) {
-  const { error } = useQuery({
+  const { data, error } = useQuery({
     queryKey: [LEAGUE_TEAM_QUERY_KEY, { leagueId }],
     queryFn: () => getTeamListByLeagueId(leagueId),
   });
 
   if (error) throw error;
 
-  return {
-    data: [
-      {
-        id: 1,
-        name: '1번 팀',
-        logoImageUrl: 'string',
-      },
-      {
-        id: 2,
-        name: '2번 팀',
-        logoImageUrl: 'string',
-      },
-    ],
-  };
-
-  // return { data };
+  return { data };
 }

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -21,6 +21,7 @@ export { ReactComponent as ProfileIcon } from './svg/profile.svg';
 export { ReactComponent as RestoreIcon } from './svg/restore.svg';
 export { ReactComponent as SendIcon } from './svg/send.svg';
 export { ReactComponent as SoccerIcon } from './svg/soccer.svg';
+export { ReactComponent as SubtractIcon } from './svg/subtract.svg';
 export { ReactComponent as SwitchIcon } from './svg/switch.svg';
 export { ReactComponent as SymbolIcon } from './svg/symbol.svg';
 export { ReactComponent as ThumbsUpIcon } from './svg/thumbs-up.svg';

--- a/packages/icons/src/svg/subtract.svg
+++ b/packages/icons/src/svg/subtract.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 12a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-11.5-.5a.5.5 0 0 0 0 1h7a.5.5 0 0 0 0-1h-7z" fill="currentColor"/></svg>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #94 

## ✅ 작업 내용

- 리그 팀 관리 페이지를 생성했습니다.
  - league team 삭제 쿼리가 아직 없어서 일단은 `alert`로 대체해두었습니다.
  - card content의 다형성을 보장합니다.
  - axios response interceptor가 개발 단계에서는 불필요하다고 판단했고, 추후 에러 바운더리로 더 세밀하게 에러 처리를 하면 좋을 것 같아 일단은 제거해두었습니다. 
  - 대회 팀이 없는 경우는 추후 다듬으면 좋을 것 같습니다.

## 📝 참고 자료

![image](https://github.com/hufscheer/client_v2/assets/88662637/5d04849f-6c0a-4a52-bd3c-dd2412242987)
![image](https://github.com/hufscheer/client_v2/assets/88662637/32fdf0ec-c7f8-458b-ba57-05eb498351c9)

## ♾️ 기타

- 추가로 필요한 작업 내용
