### PR TITLE
[STYLE] 관객 응원톡 사용성 향상

### DIFF
--- a/apps/spectator/app/game/[id]/_components/CheerTalk/CheerTalk.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/CheerTalk.css.ts
@@ -6,7 +6,7 @@ export const wrapper = style({
   position: 'relative',
   display: 'flex',
   flexDirection: 'column',
-  height: '100vh',
+  height: '100%',
   maxWidth: theme.sizes.appWidth,
   width: '100%',
   backgroundColor: theme.colors.white,

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Form/Form.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Form/Form.css.ts
@@ -6,7 +6,8 @@ export const form = style({
   display: 'flex',
   flexDirection: 'column',
   padding: rem(16),
-  gap: rem(4),
+  paddingTop: rem(8),
+  gap: rem(8),
 });
 
 export const radioBox = style({

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Form/Form.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Form/Form.css.ts
@@ -77,9 +77,3 @@ export const scrollToBottomButton = style({
   borderRadius: '50%',
   backgroundColor: theme.colors.gray[2],
 });
-
-export const scrollToBottomIcon = style({
-  width: rem(16),
-  height: rem(16),
-  color: theme.colors.gray[4],
-});

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Form/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Form/index.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownIcon, SendIcon } from '@hcc/icons';
+import { SendIcon } from '@hcc/icons';
 import { Icon } from '@hcc/ui';
 import { UseMutateFunction } from '@tanstack/react-query';
 import axios from 'axios';
@@ -89,13 +89,6 @@ const CheerTalkForm = ({
           <Icon source={SendIcon} className={styles.cheerTalkSendIcon} />
         </button>
       </div>
-      <button
-        className={styles.scrollToBottomButton}
-        onClick={scrollToBottom}
-        type="button"
-      >
-        <Icon source={ArrowDownIcon} className={styles.scrollToBottomIcon} />
-      </button>
     </form>
   );
 };

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/List/List.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/List/List.css.ts
@@ -1,5 +1,5 @@
-import { rem } from '@hcc/styles';
-import { styleVariants } from '@vanilla-extract/css';
+import { rem, theme } from '@hcc/styles';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 export const list = styleVariants({
   container: {
@@ -15,4 +15,25 @@ export const list = styleVariants({
     padding: `${rem(16)} ${rem(16)} 0 ${rem(16)}`,
     overflowY: 'auto',
   },
+});
+
+export const scrollToBottomButton = style({
+  position: 'absolute',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  bottom: rem(80),
+  right: rem(10),
+  width: rem(32),
+  height: rem(32),
+  borderRadius: '50%',
+  backgroundColor: theme.colors.gray[2],
+  boxShadow: `0 1px 4px 0 ${theme.colors.gray[4]}`,
+  opacity: 0.9,
+});
+
+export const scrollToBottomIcon = style({
+  width: rem(16),
+  height: rem(16),
+  color: theme.colors.gray[4],
 });

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/List/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/List/index.tsx
@@ -1,3 +1,5 @@
+import { ArrowDownIcon } from '@hcc/icons';
+import { Icon } from '@hcc/ui';
 import { useEffect, useRef, memo, useState } from 'react';
 
 import Loader from '@/components/Loader';
@@ -34,6 +36,9 @@ export default function CheerTalkList({
   isFetchingNextPage,
 }: CheerTalkListProps) {
   const [scrollHeight, setScrollHeight] = useState(0);
+  const [showScrollToBottomButton, setShowScrollToBottomButton] =
+    useState(false);
+
   const { gameDetail } = useGameById(gameId);
   const { mutate } = useSaveCheerTalkMutation();
 
@@ -45,6 +50,16 @@ export default function CheerTalkList({
     bottomRef.current.scrollIntoView(false);
   };
   const [run] = useTimeout(scrollToBottom, 100);
+
+  const checkScrollHeight = () => {
+    if (!scrollRef.current) return;
+
+    const isBottom =
+      scrollRef.current.scrollHeight - scrollRef.current.scrollTop ===
+      scrollRef.current.clientHeight;
+
+    setShowScrollToBottomButton(!isBottom);
+  };
 
   const throttledFetchNextPage = useThrottle(fetchNextPage, 1000);
 
@@ -63,6 +78,19 @@ export default function CheerTalkList({
   }, [cheerTalkList]);
 
   useEffect(() => scrollToBottom(), []);
+
+  useEffect(() => {
+    const scrollElement = scrollRef.current;
+    if (scrollElement) {
+      scrollElement.addEventListener('scroll', checkScrollHeight);
+    }
+
+    return () => {
+      if (scrollElement) {
+        scrollElement.removeEventListener('scroll', checkScrollHeight);
+      }
+    };
+  }, []);
 
   return (
     <div className={styles.list.container}>
@@ -93,6 +121,15 @@ export default function CheerTalkList({
         saveCheerTalkMutate={mutate}
         scrollToBottom={run}
       />
+      {showScrollToBottomButton && (
+        <button
+          className={styles.scrollToBottomButton}
+          onClick={run}
+          type="button"
+        >
+          <Icon source={ArrowDownIcon} className={styles.scrollToBottomIcon} />
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/List/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/List/index.tsx
@@ -51,7 +51,7 @@ export default function CheerTalkList({
   };
   const [run] = useTimeout(scrollToBottom, 100);
 
-  const checkScrollHeight = () => {
+  const checkScrollHeight = useThrottle(() => {
     if (!scrollRef.current) return;
 
     const isBottom =
@@ -59,7 +59,7 @@ export default function CheerTalkList({
       scrollRef.current.clientHeight;
 
     setShowScrollToBottomButton(!isBottom);
-  };
+  }, 250);
 
   const throttledFetchNextPage = useThrottle(fetchNextPage, 1000);
 
@@ -81,6 +81,8 @@ export default function CheerTalkList({
 
   useEffect(() => {
     const scrollElement = scrollRef.current;
+    if (!scrollElement) return;
+
     if (scrollElement) {
       scrollElement.addEventListener('scroll', checkScrollHeight);
     }
@@ -90,7 +92,7 @@ export default function CheerTalkList({
         scrollElement.removeEventListener('scroll', checkScrollHeight);
       }
     };
-  }, []);
+  }, [checkScrollHeight]);
 
   return (
     <div className={styles.list.container}>
@@ -127,7 +129,7 @@ export default function CheerTalkList({
           onClick={run}
           type="button"
         >
-          <Icon source={ArrowDownIcon} className={styles.scrollToBottomIcon} />
+          <Icon source={ArrowDownIcon} size={16} color="black" />
         </button>
       )}
     </div>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #97 

## ✅ 작업 내용

- 응원톡 모달의 높이를 적절히 조절해 모바일 브라우저 화면 안에 모든 요소가 정상적으로 보이도록 수정했습니다.
- 응원톡 스크롤 하단 버튼을 수정했습니다.
  - 스타일: 불투명도와 그림자를 추가해 응원톡과 겹칠 때 구분이 되도록 하였습니다.
  - 스크롤을 올렸을 때만 노출되도록 조건부 함수를 추가했습니다.
- 응원톡 작성 폼의 영역을 소폭 조정해 응원톡과 너무 벌어지지 않도록 고쳤습니다.

## 📝 참고 자료

- 

https://github.com/hufscheer/client_v2/assets/87803596/b4a6689f-b272-4965-84f1-c9b755b484b2



## ♾️ 기타

- 오늘 슬랙에 언급했던 `Runtime.UnhandledPromiseRejection: Error: Either brokerURL or webSocketFactory must be provided` 문제는 좀 더 서치가 필요합니다. 새로고침 시 brokerURL에 넘겨주는 웹소켓 주소가 유실돼 발생하는 문제이므로 새로고침에도 웹소켓 주소를 잃지 않는 방법을 찾아야할 것 같습니다.
