### PR TITLE
[PERF] 게임 목록 쿼리 키 정렬

### DIFF
--- a/apps/spectator/app/_components/GameFilter/LeagueTeamFilter.tsx
+++ b/apps/spectator/app/_components/GameFilter/LeagueTeamFilter.tsx
@@ -22,20 +22,19 @@ export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
 
   if (!leagueTeams || !leagueTeams.length) return;
 
-  const handleRouter = (teamId: number) => {
+  const handleRouter = (selectedTeamId: number) => {
     const current = new URLSearchParams(Array.from(searchParams.entries()));
-    const currentTeamIds = current.get('leagueTeam')?.split(',') || [];
+    const teamIdParams = current.get('leagueTeam');
+    const teamIds = teamIdParams?.split(',').map(Number) || [];
 
-    if (currentTeamIds.includes(teamId.toString())) {
-      currentTeamIds.splice(currentTeamIds.indexOf(teamId.toString()), 1);
-    } else {
-      currentTeamIds.push(teamId.toString());
-    }
+    const hasTeamId = teamIds.includes(selectedTeamId);
+    const updatedTeamIds = hasTeamId
+      ? teamIds.filter(id => id !== selectedTeamId)
+      : [...teamIds, selectedTeamId].sort((a, b) => a - b);
 
-    current.set('leagueTeam', `${currentTeamIds.join(',')}`);
+    current.set('leagueTeam', updatedTeamIds.join(','));
 
-    const search = current.toString();
-    const query = search ? `?${search}` : '';
+    const query = current ? `?${current}` : '';
 
     router.push(`${pathname}${query}`);
   };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #105 

## ✅ 작업 내용

- 게임 목록의 리그 팀 리스트 필터를 쿼리 키로 등록할 때, 정렬된 값을 추가합니다.
  - 이 때, 쿼리 키 값이 '2,5,8,11,13,15'과 같이 문자열로 등록되는데, 라이브러리 내부에서 단순 일치 연산으로 쿼리 키를 비교하고 있습니다. 그래서 ['2', '5', ... ]처럼 배열로 비교하는 것에 비해 오히려 성능이 좋을 것 같아 그대로 추가했습니다.

## 📝 참고 자료

## ♾️ 기타
