### PR TITLE
[REFACTOR] 대회 팀 생성 API 수정

### DIFF
--- a/apps/manager/api/league.ts
+++ b/apps/manager/api/league.ts
@@ -6,7 +6,6 @@ import {
   LeagueIdType,
   LeagueListType,
   LeaguePlayerPayload,
-  LeagueTeamPayload,
   NewLeaguePayload,
   UpdateLeaguePayload,
   SportsCategoriesType,
@@ -37,13 +36,15 @@ export const createLeague = async (payload: NewLeaguePayload) => {
   return data;
 };
 
-export const createLeagueTeam = async (
-  leagueId: number,
-  payload: LeagueTeamPayload,
-) => {
+export const createLeagueTeam = async (leagueId: number, payload: FormData) => {
   const { data } = await instance.post<{ data: [] }>(
     `/league-teams/register/${leagueId}/`,
     payload,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    },
   );
 
   return data;

--- a/apps/manager/app/league/register/_components/LeagueInfo/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueInfo/index.tsx
@@ -18,9 +18,13 @@ import { NewLeaguePayload } from '@/types/league';
 
 type LeagueInfoProps = {
   handleLeagueId: (id: number) => void;
+  nextStep: () => void;
 };
 
-export default function LeagueInfo({ handleLeagueId }: LeagueInfoProps) {
+export default function LeagueInfo({
+  handleLeagueId,
+  nextStep,
+}: LeagueInfoProps) {
   const form = useForm<NewLeaguePayload>({
     initialValues: {
       leagueData: {
@@ -37,8 +41,8 @@ export default function LeagueInfo({ handleLeagueId }: LeagueInfoProps) {
   const handleClickButton = () => {
     mutateCreateLeague(form.values, {
       onSuccess: ({ leagueId }) => {
-        // router.push(`${pathname}?leagueId=${leagueId}`);
         handleLeagueId(leagueId);
+        nextStep();
       },
     });
   };

--- a/apps/manager/app/league/register/_components/LeagueTeam/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueTeam/index.tsx
@@ -5,19 +5,20 @@ import { Dropzone, IMAGE_MIME_TYPE } from '@mantine/dropzone';
 import Image from 'next/image';
 import { FormEvent, useState } from 'react';
 
-import AddButton from '@/components/AddButton';
 import useCreateLeagueTeamMutation from '@/hooks/mutations/useCreateLeagueTeamMutation';
 
 type LeagueTeamProps = {
   leagueId: number;
+  handleTeamId: (id: number) => void;
+  nextStep: () => void;
 };
 
-export default function LeagueTeam({ leagueId }: LeagueTeamProps) {
+export default function LeagueTeam({
+  leagueId,
+  handleTeamId,
+  nextStep,
+}: LeagueTeamProps) {
   const [formFields, setFormFields] = useState([{ name: '', logo: '' }]);
-
-  const handleButtonPlus = () => {
-    setFormFields(prev => [...prev, { name: '', logo: '' }]);
-  };
 
   const handleChangeName = (index: number, value: string) => {
     setFormFields(prev => {
@@ -46,7 +47,16 @@ export default function LeagueTeam({ leagueId }: LeagueTeamProps) {
       form.append(`logos-${index + 1}`, field.logo);
     });
 
-    createLeagueTeam({ leagueId, payload: form });
+    createLeagueTeam(
+      { leagueId, payload: form },
+      {
+        onSuccess: () => {
+          // ({ data })
+          handleTeamId(1); // data.teamId
+          nextStep();
+        },
+      },
+    );
   };
 
   return (
@@ -91,8 +101,6 @@ export default function LeagueTeam({ leagueId }: LeagueTeamProps) {
         ))}
         <Button type="submit">대회 팀 완료</Button>
       </form>
-
-      <AddButton onClick={handleButtonPlus}>팀 추가</AddButton>
     </Box>
   );
 }

--- a/apps/manager/app/league/register/_components/LeagueTeamPlayers/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueTeamPlayers/index.tsx
@@ -1,21 +1,18 @@
-import { Box, Button, Group, TextInput } from '@mantine/core';
+import { Box, Button, Flex, Group, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 
 import AddButton from '@/components/AddButton';
-import useCreateLeaguePlayersMutation from '@/hooks/mutations/useCreateLeaguePlayersMutation';
-import useLeagueTeamQuery from '@/hooks/queries/useLeagueTeamQuery';
+// import useCreateLeaguePlayersMutation from '@/hooks/mutations/useCreateLeaguePlayersMutation';
 
 type LeagueTeamPlayersProps = {
-  leagueId: number;
+  teamId: number;
+  prevStep: () => void;
 };
 
 export default function LeagueTeamPlayers({
-  leagueId,
+  teamId,
+  prevStep,
 }: LeagueTeamPlayersProps) {
-  const { data } = useLeagueTeamQuery(leagueId.toString());
-
-  console.warn(data);
-
   const form = useForm({
     initialValues: {
       players: [{ name: '', description: null, playerNumber: null }],
@@ -30,34 +27,44 @@ export default function LeagueTeamPlayers({
     });
   };
 
-  const { mutate: muatateLeaguePlayers } = useCreateLeaguePlayersMutation();
+  // const { mutate: muatateLeaguePlayers } = useCreateLeaguePlayersMutation();
+  const handleSubmitForm = () => {
+    // muatateLeaguePlayers(
+    //   { teamId: 1, payload: form.values.players },
+    //   { onSuccess: prevStep },
+    // );
+    console.warn(teamId); // mutateLeaguePlayers에 포함해서 api 호출
+    console.warn(form.values.players);
+    prevStep();
+  };
 
   return (
     <Box>
-      {form.values.players.map((player, index) => (
-        <Group key={index}>
-          <TextInput
-            label="이름"
-            {...form.getInputProps(`players.${index}.name`)}
-            placeholder="이름을 입력하세요."
-          />
-          <TextInput
-            label="번호"
-            type="number"
-            {...form.getInputProps(`players.${index}.playerNumber`)}
-            placeholder="번호"
-          />
-        </Group>
-      ))}
-      <AddButton onClick={handleButtonPlus}>선수 추가</AddButton>
+      <form onSubmit={handleSubmitForm}>
+        {form.values.players.map((player, index) => (
+          <Group key={index}>
+            <TextInput
+              label="이름"
+              {...form.getInputProps(`players.${index}.name`)}
+              placeholder="이름을 입력하세요."
+            />
+            <TextInput
+              label="번호"
+              type="number"
+              {...form.getInputProps(`players.${index}.playerNumber`)}
+              placeholder="번호"
+            />
+          </Group>
+        ))}
 
-      <Button
-        onClick={() =>
-          muatateLeaguePlayers({ teamId: 1, payload: form.values.players })
-        }
-      >
-        클릭
-      </Button>
+        <Flex direction="column">
+          <AddButton type="button" onClick={handleButtonPlus}>
+            선수 추가
+          </AddButton>
+
+          <Button type="submit">팀 선수 생성</Button>
+        </Flex>
+      </form>
     </Box>
   );
 }

--- a/apps/manager/app/league/register/_components/LeagueTeamPlayers/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueTeamPlayers/index.tsx
@@ -3,13 +3,32 @@ import { useForm } from '@mantine/form';
 
 import AddButton from '@/components/AddButton';
 import useCreateLeaguePlayersMutation from '@/hooks/mutations/useCreateLeaguePlayersMutation';
+import useLeagueTeamQuery from '@/hooks/queries/useLeagueTeamQuery';
 
-export default function LeagueTeamPlayers() {
+type LeagueTeamPlayersProps = {
+  leagueId: number;
+};
+
+export default function LeagueTeamPlayers({
+  leagueId,
+}: LeagueTeamPlayersProps) {
+  const { data } = useLeagueTeamQuery(leagueId.toString());
+
+  console.warn(data);
+
   const form = useForm({
     initialValues: {
-      players: [{ name: '', description: null, playerNumber: 0 }],
+      players: [{ name: '', description: null, playerNumber: null }],
     },
   });
+
+  const handleButtonPlus = () => {
+    form.insertListItem('players', {
+      name: '',
+      description: null,
+      playerNumber: null,
+    });
+  };
 
   const { mutate: muatateLeaguePlayers } = useCreateLeaguePlayersMutation();
 
@@ -30,16 +49,7 @@ export default function LeagueTeamPlayers() {
           />
         </Group>
       ))}
-      <AddButton
-        onClick={() =>
-          form.insertListItem('players', {
-            name: '',
-            backNumber: 0,
-          })
-        }
-      >
-        선수 추가
-      </AddButton>
+      <AddButton onClick={handleButtonPlus}>선수 추가</AddButton>
 
       <Button
         onClick={() =>

--- a/apps/manager/app/league/register/page.tsx
+++ b/apps/manager/app/league/register/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, Group, Stepper } from '@mantine/core';
+import { Stepper } from '@mantine/core';
 import { useState } from 'react';
 
 import Layout from '@/components/Layout';
@@ -14,33 +14,37 @@ import { stepperResolver } from './resolvers';
 
 export default function Register() {
   const [leagueId, setLeagueId] = useState<number>(-1);
+  const [teamId, setTeamId] = useState<number>(-1);
 
   const [active, setActive] = useState(0);
-  const nextStep = () =>
-    setActive(current => (current < 3 ? current + 1 : current));
-  const prevStep = () =>
-    setActive(current => (current > 0 ? current - 1 : current));
+  const handleLeagueId = (step: number) => {
+    setActive(step);
+  };
+
   return (
     <Layout navigationTitle="대회 생성">
       <Stepper active={active} vars={stepperResolver}>
         <Stepper.Step label="대회 정보">
-          <LeagueInfo handleLeagueId={(id: number) => setLeagueId(id)} />
+          <LeagueInfo
+            nextStep={() => handleLeagueId(1)}
+            handleLeagueId={(id: number) => setLeagueId(id)}
+          />
         </Stepper.Step>
 
         <Stepper.Step label="대회 팀">
-          <LeagueTeam leagueId={leagueId} />
+          <LeagueTeam
+            leagueId={leagueId}
+            handleTeamId={(id: number) => setTeamId(id)}
+            nextStep={() => handleLeagueId(2)}
+          />
         </Stepper.Step>
         <Stepper.Step label="대회 로고">
-          <LeagueTeamPlayers leagueId={leagueId} />
+          <LeagueTeamPlayers
+            teamId={teamId}
+            prevStep={() => handleLeagueId(1)}
+          />
         </Stepper.Step>
       </Stepper>
-
-      <Group justify="center" mt="xl">
-        <Button variant="default" onClick={prevStep}>
-          Back
-        </Button>
-        <Button onClick={nextStep}>Next step</Button>
-      </Group>
     </Layout>
   );
   // useFunnel 필요

--- a/apps/manager/app/league/register/page.tsx
+++ b/apps/manager/app/league/register/page.tsx
@@ -3,6 +3,8 @@
 import { Button, Group, Stepper } from '@mantine/core';
 import { useState } from 'react';
 
+import Layout from '@/components/Layout';
+
 import LeagueInfo from './_components/LeagueInfo';
 import LeagueTeam from './_components/LeagueTeam';
 import LeagueTeamPlayers from './_components/LeagueTeamPlayers';
@@ -19,7 +21,7 @@ export default function Register() {
   const prevStep = () =>
     setActive(current => (current > 0 ? current - 1 : current));
   return (
-    <>
+    <Layout navigationTitle="대회 생성">
       <Stepper active={active} vars={stepperResolver}>
         <Stepper.Step label="대회 정보">
           <LeagueInfo handleLeagueId={(id: number) => setLeagueId(id)} />
@@ -29,7 +31,7 @@ export default function Register() {
           <LeagueTeam leagueId={leagueId} />
         </Stepper.Step>
         <Stepper.Step label="대회 로고">
-          <LeagueTeamPlayers />
+          <LeagueTeamPlayers leagueId={leagueId} />
         </Stepper.Step>
       </Stepper>
 
@@ -39,7 +41,7 @@ export default function Register() {
         </Button>
         <Button onClick={nextStep}>Next step</Button>
       </Group>
-    </>
+    </Layout>
   );
   // useFunnel 필요
 }

--- a/apps/manager/hooks/mutations/useCreateLeagueTeamMutation.ts
+++ b/apps/manager/hooks/mutations/useCreateLeagueTeamMutation.ts
@@ -1,11 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { createLeagueTeam } from '@/api/league';
-import { LeagueTeamPayload } from '@/types/league';
 
 type Params = {
   leagueId: number;
-  payload: LeagueTeamPayload;
+  payload: FormData;
 };
 
 export default function useCreateLeagueTeamMutation() {

--- a/apps/manager/types/league.ts
+++ b/apps/manager/types/league.ts
@@ -42,8 +42,6 @@ export type LeagueRegisterDataType = {
   sportsListData: SportsCategoriesType[];
 };
 
-export type LeagueTeamPayload = { names: string[]; logos: string[] };
-
 export type LeaguePlayerPayload = {
   name: string;
   description: string | null;


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #111 

## ✅ 작업 내용

- 대회 팀 생성 시 FormData를 입력 받도록 구현합니다.

## 📝 참고 자료

## ♾️ 기타

- 현재 register의 flow가 와이어 프레임과 다릅니다.
- 대회 팀과 팀 선수를 일괄적으로 생성하도록 구현이 되어 있는데, step의 기능을 잘 이용하면 쉽게 수정이 가능하지 않을까 합니다.
- 대회 팀을 생성하면 step을 3번으로 옮겨 대회 팀 선수를 생성하도록 합니다.
- 대회 팀 선수 생성이 마무리 되면 다시 2번으로 옮겨 대회 팀을 생성하도록 합니다.
- 걱정되는 것은 컴포넌트가 언마운트 되기 때문에 기존에 생성했던 대회 팀이 UI 상에는 표시되지 않을 수도 있겠네요. 

---
위에서 언급한대로 플로우 수정해뒀습니다.

`TODO`
- 아예 대회 팀은 여러 개를 한 번에 생성할 수 없다고 이해하기
- 대회 팀이 생성되면 생성된 대회 팀 id를 response로 넘겨달라고 백엔드 팀원에게 요청하기
- api가 수정되면 대회 팀 생성 성공 시 handleTeamId로 현재 teamId 변경
- teamId를 LeagueTeamPlayers 컴포넌트에 전달한 뒤 createLeaguePlayersMutation hook 호출
