### PR TITLE
[FEAT] 대회 팀 선수 생성 기능 구현

### DIFF
--- a/apps/manager/api/league.ts
+++ b/apps/manager/api/league.ts
@@ -37,7 +37,7 @@ export const createLeague = async (payload: NewLeaguePayload) => {
 };
 
 export const createLeagueTeam = async (leagueId: number, payload: FormData) => {
-  const { data } = await instance.post<{ data: [] }>(
+  const { data } = await instance.post<{ teamIds: number[] }>(
     `/league-teams/register/${leagueId}/`,
     payload,
     {
@@ -54,12 +54,13 @@ export const createLeaguePlayers = async (
   teamId: number,
   payload: LeaguePlayerPayload[],
 ) => {
-  await instance.post(`/league-teams/${teamId}/player/`, {
-    data: payload.map(({ playerNumber, ...player }) => ({
+  await instance.post(
+    `/league-teams/${teamId}/player/`,
+    payload.map(({ playerNumber, ...player }) => ({
       ...player,
       number: playerNumber,
     })),
-  });
+  );
 };
 
 export const deleteLeague = async (body: DeleteLeaguePayload) => {

--- a/apps/manager/app/league/register/_components/Confirm/index.tsx
+++ b/apps/manager/app/league/register/_components/Confirm/index.tsx
@@ -1,0 +1,38 @@
+import { Button, Flex, Modal } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import Link from 'next/link';
+
+export default function ConfirmModal() {
+  const [opened, { open, close }] = useDisclosure(false);
+
+  return (
+    <>
+      <Modal.Root opened={opened} onClose={close}>
+        <Modal.Overlay />
+        <Modal.Content>
+          <Modal.Header>
+            <Modal.Title fw="bold">대회 생성 완료</Modal.Title>
+            <Modal.CloseButton />
+          </Modal.Header>
+          <Modal.Body>
+            <p>대회 팀 및 대회 선수는 추후 수정할 수 있습니다.</p>
+            <p>정말 완료하시겠습니까?</p>
+
+            <Flex gap="sm" mt="lg">
+              <Button fullWidth onClick={close} variant="light" color="red">
+                취소
+              </Button>
+              <Button fullWidth component={Link} href="/" variant="filled">
+                완료
+              </Button>
+            </Flex>
+          </Modal.Body>
+        </Modal.Content>
+      </Modal.Root>
+
+      <Button onClick={open} variant="subtle">
+        완료
+      </Button>
+    </>
+  );
+}

--- a/apps/manager/app/league/register/_components/LeagueInfo/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueInfo/index.tsx
@@ -85,7 +85,9 @@ export default function LeagueInfo({
         {...form.getInputProps('leagueData.maxRound')}
       />
 
-      <Button onClick={handleClickButton}>대회 생성</Button>
+      <Button fullWidth onClick={handleClickButton} mt="lg">
+        대회 생성
+      </Button>
     </Box>
   );
 }

--- a/apps/manager/app/league/register/_components/LeagueTeam/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueTeam/index.tsx
@@ -57,9 +57,12 @@ export default function LeagueTeam({
     createLeagueTeam(
       { leagueId, payload },
       {
-        onSuccess: () => {
-          // ({ data })
-          handleTeamId(1); // data.teamId
+        onSuccess: ({ teamIds }) => {
+          const teamId = teamIds.pop();
+
+          if (!teamId) return alert('팀 생성에 실패했습니다.');
+
+          handleTeamId(teamId);
           nextStep();
         },
       },
@@ -107,7 +110,9 @@ export default function LeagueTeam({
             </Flex>
           </Dropzone>
         </Box>
-        <Button type="submit">대회 팀 완료</Button>
+        <Button fullWidth type="submit">
+          대회 팀 완료
+        </Button>
       </form>
     </Box>
   );

--- a/apps/manager/app/league/register/_components/LeagueTeamPlayers/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueTeamPlayers/index.tsx
@@ -1,8 +1,9 @@
-import { Box, Button, Flex, Group, TextInput } from '@mantine/core';
+import { PlusIcon, SubtractIcon } from '@hcc/icons';
+import { Icon } from '@hcc/ui';
+import { Box, Button, Flex, Grid, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 
-import AddButton from '@/components/AddButton';
-// import useCreateLeaguePlayersMutation from '@/hooks/mutations/useCreateLeaguePlayersMutation';
+import useCreateLeaguePlayersMutation from '@/hooks/mutations/useCreateLeaguePlayersMutation';
 
 type LeagueTeamPlayersProps = {
   teamId: number;
@@ -17,6 +18,11 @@ export default function LeagueTeamPlayers({
     initialValues: {
       players: [{ name: '', description: null, playerNumber: null }],
     },
+    validate: {
+      players: {
+        name: value => value.length < 2 && '이름은 두 글자 이상입니다!',
+      },
+    },
   });
 
   const handleButtonPlus = () => {
@@ -27,40 +33,58 @@ export default function LeagueTeamPlayers({
     });
   };
 
-  // const { mutate: muatateLeaguePlayers } = useCreateLeaguePlayersMutation();
+  const { mutate: muatateLeaguePlayers } = useCreateLeaguePlayersMutation();
   const handleSubmitForm = () => {
-    // muatateLeaguePlayers(
-    //   { teamId: 1, payload: form.values.players },
-    //   { onSuccess: prevStep },
-    // );
-    console.warn(teamId); // mutateLeaguePlayers에 포함해서 api 호출
-    console.warn(form.values.players);
-    prevStep();
+    muatateLeaguePlayers(
+      { teamId, payload: form.values.players },
+      { onSuccess: prevStep },
+    );
+  };
+
+  const handleRemovePlayer = (index: number) => {
+    form.removeListItem('players', index);
   };
 
   return (
     <Box>
-      <form onSubmit={handleSubmitForm}>
-        {form.values.players.map((player, index) => (
-          <Group key={index}>
-            <TextInput
-              label="이름"
-              {...form.getInputProps(`players.${index}.name`)}
-              placeholder="이름을 입력하세요."
-            />
-            <TextInput
-              label="번호"
-              type="number"
-              {...form.getInputProps(`players.${index}.playerNumber`)}
-              placeholder="번호"
-            />
-          </Group>
+      <form onSubmit={form.onSubmit(handleSubmitForm)}>
+        <Grid grow>
+          <Grid.Col span={6}>이름</Grid.Col>
+          <Grid.Col span={3}>번호</Grid.Col>
+          <Grid.Col span={1}></Grid.Col>
+        </Grid>
+        {form.values.players.map((_, index) => (
+          <Grid key={index} grow>
+            <Grid.Col span={6}>
+              <TextInput
+                withAsterisk
+                {...form.getInputProps(`players.${index}.name`)}
+                placeholder="이름을 입력하세요."
+              />
+            </Grid.Col>
+            <Grid.Col span={3}>
+              <TextInput
+                type="number"
+                {...form.getInputProps(`players.${index}.playerNumber`)}
+                placeholder="번호"
+              />
+            </Grid.Col>
+            <Grid.Col span={1}>
+              <Button
+                variant="subtle"
+                color="red"
+                onClick={() => handleRemovePlayer(index)}
+              >
+                <Icon source={SubtractIcon} color="error" />
+              </Button>
+            </Grid.Col>
+          </Grid>
         ))}
 
-        <Flex direction="column">
-          <AddButton type="button" onClick={handleButtonPlus}>
-            선수 추가
-          </AddButton>
+        <Flex direction="column" mt="md" gap="md">
+          <Button type="button" variant="subtle" onClick={handleButtonPlus}>
+            <Icon source={PlusIcon} />
+          </Button>
 
           <Button type="submit">팀 선수 생성</Button>
         </Flex>

--- a/apps/manager/app/league/register/page.tsx
+++ b/apps/manager/app/league/register/page.tsx
@@ -5,24 +5,27 @@ import { useState } from 'react';
 
 import Layout from '@/components/Layout';
 
+import ConfirmModal from './_components/Confirm';
 import LeagueInfo from './_components/LeagueInfo';
 import LeagueTeam from './_components/LeagueTeam';
 import LeagueTeamPlayers from './_components/LeagueTeamPlayers';
 import { stepperResolver } from './resolvers';
 
-// import * as styles from './page.css';
-
 export default function Register() {
   const [leagueId, setLeagueId] = useState<number>(-1);
   const [teamId, setTeamId] = useState<number>(-1);
 
-  const [active, setActive] = useState(0);
+  const [active, setActive] = useState(2);
   const handleLeagueId = (step: number) => {
     setActive(step);
   };
 
+  const RightButton = () => {
+    return <ConfirmModal />;
+  };
+
   return (
-    <Layout navigationTitle="대회 생성">
+    <Layout navigationTitle="대회 생성" navigationMenu={<RightButton />}>
       <Stepper active={active} vars={stepperResolver}>
         <Stepper.Step label="대회 정보">
           <LeagueInfo
@@ -47,5 +50,4 @@ export default function Register() {
       </Stepper>
     </Layout>
   );
-  // useFunnel 필요
 }


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #113 

## ✅ 작업 내용

- 대회 팀 선수 생성 기능 구현
- 대회 등록 플로우를 종료하고자 하면 우측 상단에 완료 버튼 클릭
  - 모달을 통해 재확인
- 대회 팀을 생성하면 대회 팀 선수 스텝으로 이동
- 대회 팀 선수 등록을 마무리 하면 다시 대회 팀 생성 스텝으로 이동

## 📝 참고 자료

- 와이어 프레임과 플로우가 조금 다른데, API로 넘겨 받는 데이터로 작업을 동기적으로 해야 해서 일단 이렇게 구현했습니다.
  - 대회 생성 성공 시 대회 id 발급
  - 발급 받은 대회 id로 대회 팀 생성
  - 대회 팀 생성 성공 시 대회 팀 id 발급
  - 발급 받은 대회 팀 id로 대회 팀 선수 생성

## ♾️ 기타

- 대회 선수를 제거하는 버튼 클릭 시 기존에 작성되었던 선수 번호가 중복해서 등록되는 버그가 있습니다.
- 현재 input의 mapping key를 index로 관리하기 때문인 것 같네요.
- 추후 `uuid` 같은 라이브러리로 고유 식별자를 생성해주는 방법을 고려할 수 있겠습니다.
  - 필요하다면 리뷰 반영하면서 추가해서 올려보도록 하겠습니다.
