### PR TITLE
[FEAT] 매니저 앱 대회 팀 관리 구현

### DIFF
--- a/apps/manager/api/league.ts
+++ b/apps/manager/api/league.ts
@@ -9,6 +9,7 @@ import {
   NewLeaguePayload,
   UpdateLeaguePayload,
   SportsCategoriesType,
+  LeaguePlayerWithIDPayload,
 } from '@/types/league';
 
 export const getAllLeagues = async () => {
@@ -45,6 +46,41 @@ export const createLeagueTeam = async (leagueId: number, payload: FormData) => {
         'Content-Type': 'multipart/form-data',
       },
     },
+  );
+
+  return data;
+};
+
+export const updateLeagueTeam = async (teamId: string, payload: FormData) => {
+  const { data } = await instance.put(
+    `/league-teams/${teamId}/change/`,
+    payload,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    },
+  );
+
+  return data;
+};
+
+export const getLeagueTeamPlayers = async (teamId: string) => {
+  const { data } = await instance.get<LeaguePlayerWithIDPayload[]>(
+    `/league-teams/${teamId}/player/all/`,
+  );
+
+  return data;
+};
+
+export const updateLeagueTeamPlayers = async (
+  teamId: string,
+  teamPlayerId: string,
+  payload: LeaguePlayerPayload,
+) => {
+  const { data } = await instance.put(
+    `/league-teams/${teamId}/player/${teamPlayerId}/`,
+    payload,
   );
 
   return data;

--- a/apps/manager/api/league.ts
+++ b/apps/manager/api/league.ts
@@ -23,7 +23,7 @@ export const getGameList = async ({
   leagueName,
   ...params
 }: GameListParams & { leagueName: string }) => {
-  const { data } = await instance.get<GameListType[]>('/games', {
+  const { data } = await instance.get<GameListType[]>('/games/', {
     baseURL: process.env.NEXT_PUBLIC_API_URL,
     params: { size, ...params },
   });

--- a/apps/manager/app/league/[leagueId]/game/page.tsx
+++ b/apps/manager/app/league/[leagueId]/game/page.tsx
@@ -22,11 +22,7 @@ export default function Page() {
 
   const Menu = () => {
     return (
-      <Button
-        variant="subtle"
-        size="compact-md"
-        onClick={prev => setEdit(!prev)}
-      >
+      <Button variant="subtle" size="compact-md" onClick={() => setEdit(!edit)}>
         {edit ? '완료' : '편집'}
       </Button>
     );

--- a/apps/manager/app/league/[leagueId]/game/page.tsx
+++ b/apps/manager/app/league/[leagueId]/game/page.tsx
@@ -22,7 +22,11 @@ export default function Page() {
 
   const Menu = () => {
     return (
-      <Button variant="subtle" size="compact-md" onClick={() => setEdit(!edit)}>
+      <Button
+        variant="subtle"
+        size="compact-md"
+        onClick={prev => setEdit(!prev)}
+      >
         {edit ? '완료' : '편집'}
       </Button>
     );

--- a/apps/manager/app/league/[leagueId]/loading.tsx
+++ b/apps/manager/app/league/[leagueId]/loading.tsx
@@ -1,4 +1,6 @@
+import Layout from '@/components/Layout';
+
 export default function Loading() {
   // You can add any UI inside Loading, including a Skeleton.
-  return <div>로딩</div>;
+  return <Layout>로딩</Layout>;
 }

--- a/apps/manager/app/league/[leagueId]/team/[teamId]/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/[teamId]/page.tsx
@@ -1,3 +1,118 @@
+'use client';
+
+import { Button } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import Layout from '@/components/Layout';
+import useUpdateLeagueTeamMutation from '@/hooks/mutations/useUpdateLeagueTeamMutation';
+import useUpdateLeagueTeamPlayerMutation from '@/hooks/mutations/useUpdateLeagueTeamPlayersMutation';
+import useLeagueTeamDetailQuery from '@/hooks/queries/useLeagueTeamDetailQuery';
+import useLeagueTeamPlayersQuery from '@/hooks/queries/useLeagueTeamPlayersQuery';
+
+import TeamForm from '../_components/TeamForm';
+
+type LeagueTeamFormValues = {
+  name: string;
+  logo: File | null;
+  players: {
+    id: number;
+    name: string;
+    description: string;
+    playerNumber: number;
+  }[];
+};
+
 export default function LeagueTeamEdit() {
-  return <>미컴 축구생각</>;
+  const params = useParams();
+  const leagueId = params.leagueId as string;
+  const teamId = params.teamId as string;
+
+  const [edit, setEdit] = useState(false);
+
+  const { data: team } = useLeagueTeamDetailQuery(leagueId, teamId);
+  const { data: players } = useLeagueTeamPlayersQuery(teamId);
+
+  const form = useForm<LeagueTeamFormValues>({
+    initialValues: {
+      name: '',
+      logo: null,
+      players: [],
+    },
+  });
+
+  useEffect(() => {
+    if (!team) return;
+    form.setValues(prevValues => ({ ...prevValues, name: team.name }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [team]);
+
+  useEffect(() => {
+    if (!players) return;
+    form.setValues(prevValues => ({
+      ...prevValues,
+      players: players.map(player => ({
+        id: player.id,
+        name: player.name,
+        description: player.description || '',
+        playerNumber: player.number || 0,
+      })),
+    }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [players]);
+
+  const { mutate: updateLeagueTeam } = useUpdateLeagueTeamMutation();
+  const { mutate: updateLeagueTeamPlayers } =
+    useUpdateLeagueTeamPlayerMutation();
+
+  const handleEdit = () => {
+    if (!edit) {
+      setEdit(edit => !edit);
+      return;
+    }
+
+    const { name, logo, players } = form.values;
+    if (!logo) return alert('로고를 업로드하세요.');
+
+    const payload = new FormData();
+    payload.append('name', name);
+    payload.append('logo', logo as File);
+
+    updateLeagueTeam(
+      { teamId, payload },
+      {
+        onSuccess: () => {
+          players.map(player => {
+            updateLeagueTeamPlayers({
+              teamId: teamId,
+              teamPlayerId: player.id.toString(),
+              payload: {
+                name: player.name,
+                description: player.description,
+                playerNumber: player.playerNumber,
+              },
+            });
+          });
+        },
+      },
+    );
+    setEdit(edit => !edit);
+  };
+
+  const Edit = () => {
+    return (
+      <Button variant="subtle" onClick={handleEdit}>
+        {edit ? '완료' : '편집'}
+      </Button>
+    );
+  };
+
+  if (!team) return null;
+
+  return (
+    <Layout navigationTitle={team.name} navigationMenu={<Edit />}>
+      <TeamForm form={form} edit={edit} />
+    </Layout>
+  );
 }

--- a/apps/manager/app/league/[leagueId]/team/[teamId]/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/[teamId]/page.tsx
@@ -43,24 +43,20 @@ export default function LeagueTeamEdit() {
   });
 
   useEffect(() => {
-    if (!team) return;
-    form.setValues(prevValues => ({ ...prevValues, name: team.name }));
+    if (team && players) {
+      form.setValues({
+        name: team.name,
+        logo: null,
+        players: players.map(player => ({
+          id: player.id,
+          name: player.name,
+          description: player.description || '',
+          playerNumber: player.number || 0,
+        })),
+      });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [team]);
-
-  useEffect(() => {
-    if (!players) return;
-    form.setValues(prevValues => ({
-      ...prevValues,
-      players: players.map(player => ({
-        id: player.id,
-        name: player.name,
-        description: player.description || '',
-        playerNumber: player.number || 0,
-      })),
-    }));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [players]);
+  }, [team, players]);
 
   const { mutate: updateLeagueTeam } = useUpdateLeagueTeamMutation();
   const { mutate: updateLeagueTeamPlayers } =
@@ -108,7 +104,7 @@ export default function LeagueTeamEdit() {
     );
   };
 
-  if (!team) return null;
+  if (!team || !players) return null;
 
   return (
     <Layout navigationTitle={team.name} navigationMenu={<Edit />}>

--- a/apps/manager/app/league/[leagueId]/team/_components/TeamForm.tsx
+++ b/apps/manager/app/league/[leagueId]/team/_components/TeamForm.tsx
@@ -1,0 +1,101 @@
+import { SubtractIcon } from '@hcc/icons';
+import { Icon } from '@hcc/ui';
+import { Flex, Text, TextInput } from '@mantine/core';
+import { Dropzone, IMAGE_MIME_TYPE } from '@mantine/dropzone';
+import { useForm } from '@mantine/form';
+import Image from 'next/image';
+
+import AddButton from '@/components/AddButton';
+
+type TeamFormProps = {
+  form: ReturnType<
+    typeof useForm<{
+      name: string;
+      logo: File | null;
+      players: {
+        id: number;
+        name: string;
+        description: string;
+        playerNumber: number;
+      }[];
+    }>
+  >;
+  edit?: boolean;
+};
+
+export default function TeamForm({ form, edit = true }: TeamFormProps) {
+  const handleDropLogo = (file: File) => {
+    if (file === null) return form.setErrors({ logo: '로고를 업로드하세요.' });
+
+    form.setFieldValue('logo', file);
+  };
+
+  const addPlayer = () => {
+    const players = form.values.players.concat({
+      id: -1,
+      name: '',
+      description: '',
+      playerNumber: 0,
+    });
+    form.setFieldValue('players', players);
+  };
+
+  const removePlayer = (index: number) => {
+    const players = form.values.players.filter((_, i) => i !== index);
+    form.setFieldValue('players', players);
+  };
+
+  return (
+    <>
+      <Text>로고</Text>
+      <Dropzone
+        accept={IMAGE_MIME_TYPE}
+        onDrop={([file]) => handleDropLogo(file)}
+        multiple={false}
+        style={{ width: '100%', height: 'auto' }}
+        disabled={!edit}
+      >
+        {form.values.logo && (
+          <Image
+            src={URL.createObjectURL(form.values.logo)}
+            alt="Team logo"
+            width={100}
+            height={100}
+          />
+        )}
+        {!form.values.logo && <Text>Drop image here</Text>}
+      </Dropzone>
+      <TextInput
+        label="팀명"
+        withAsterisk
+        placeholder="필수 항목"
+        disabled={!edit}
+        {...form.getInputProps('name')}
+      />
+
+      {form.values.players.map((_, index) => (
+        <Flex key={index} align="center" mt="sm">
+          <TextInput
+            label="이름"
+            placeholder="선수 이름"
+            {...form.getInputProps(`players.${index}.name`)}
+            style={{ flex: 1, marginRight: '8px' }}
+            disabled={!edit}
+          />
+          <TextInput
+            label="번호"
+            placeholder="선수 번호"
+            type="number"
+            {...form.getInputProps(`players.${index}.playerNumber`)}
+            style={{ width: '100px', marginRight: '8px' }}
+            disabled={!edit}
+          />
+          <button style={{ flex: '0.1' }} onClick={() => removePlayer(index)}>
+            <Icon source={SubtractIcon} color="error" />
+          </button>
+        </Flex>
+      ))}
+      <AddButton onClick={addPlayer}>선수 추가</AddButton>
+    </>
+  );
+}

--- a/apps/manager/app/league/[leagueId]/team/_components/TeamForm.tsx
+++ b/apps/manager/app/league/[leagueId]/team/_components/TeamForm.tsx
@@ -41,6 +41,7 @@ export default function TeamForm({ form, edit = true }: TeamFormProps) {
   };
 
   const removePlayer = (index: number) => {
+    if (!edit) return;
     const players = form.values.players.filter((_, i) => i !== index);
     form.setFieldValue('players', players);
   };
@@ -90,12 +91,15 @@ export default function TeamForm({ form, edit = true }: TeamFormProps) {
             style={{ width: '100px', marginRight: '8px' }}
             disabled={!edit}
           />
-          <button style={{ flex: '0.1' }} onClick={() => removePlayer(index)}>
-            <Icon source={SubtractIcon} color="error" />
-          </button>
+          {edit && (
+            <button style={{ flex: '0.1' }} onClick={() => removePlayer(index)}>
+              <Icon source={SubtractIcon} color="error" />
+            </button>
+          )}
         </Flex>
       ))}
-      <AddButton onClick={addPlayer}>선수 추가</AddButton>
+
+      {edit && <AddButton onClick={addPlayer}>선수 추가</AddButton>}
     </>
   );
 }

--- a/apps/manager/app/league/[leagueId]/team/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { rem } from '@hcc/styles';
 import { Button, Flex } from '@mantine/core';
 import Link from 'next/link';
 import { useParams, usePathname } from 'next/navigation';
 import { MouseEvent, useState } from 'react';
 
+import AddButton from '@/components/AddButton';
 import Card from '@/components/Card';
 import Layout from '@/components/Layout';
 import useLeagueTeamQuery from '@/hooks/queries/useLeagueTeamQuery';
@@ -34,16 +34,6 @@ export default function LeagueTeamList() {
     setEdit(prev => !prev);
   };
 
-  if (!leagueTeams.length) {
-    return (
-      <Layout navigationTitle="대회 팀 관리">
-        <Flex align="center" justify="center" style={{ height: '100%' }}>
-          팀이 없습니다.
-        </Flex>
-      </Layout>
-    );
-  }
-
   return (
     <Layout
       navigationTitle="대회 팀 관리"
@@ -53,17 +43,33 @@ export default function LeagueTeamList() {
         </Button>
       }
     >
-      <Flex direction="column" gap={rem(4)}>
-        {leagueTeams.map(team => (
-          <Card.Root key={team.id}>
-            <Card.Content component={Link} href={`${pathname}${team.id}`}>
-              <Card.Title style={{ flex: 1 }}>{team.name}</Card.Title>
-              <Card.Action onClick={handleClickCard}>
-                <LeagueTeamActionIcon edit={edit} />
-              </Card.Action>
-            </Card.Content>
-          </Card.Root>
-        ))}
+      <AddButton
+        component={Link}
+        href={{
+          pathname: `${pathname}register`,
+        }}
+      >
+        신규 대회 팀 추가
+      </AddButton>
+      <Flex direction="column" mt="xs" gap="xs">
+        {leagueTeams.length > 0 ? (
+          leagueTeams.map(team => (
+            <Card.Root key={team.id} paddingVertical="sm">
+              <Card.Content component={Link} href={`${pathname}${team.id}`}>
+                <Card.Title text="semibold" style={{ flex: 1 }}>
+                  {team.name}
+                </Card.Title>
+                <Card.Action onClick={handleClickCard}>
+                  <LeagueTeamActionIcon edit={edit} />
+                </Card.Action>
+              </Card.Content>
+            </Card.Root>
+          ))
+        ) : (
+          <Flex align="center" justify="center" style={{ height: '100%' }}>
+            팀이 없습니다.
+          </Flex>
+        )}
       </Flex>
     </Layout>
   );

--- a/apps/manager/app/league/[leagueId]/team/register/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/register/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { SubtractIcon } from '@hcc/icons';
+import { theme } from '@hcc/styles';
+import { Icon } from '@hcc/ui';
+import { Flex, Text, TextInput } from '@mantine/core';
+import { Dropzone, IMAGE_MIME_TYPE } from '@mantine/dropzone';
+import { useForm } from '@mantine/form';
+import Image from 'next/image';
+
+import AddButton from '@/components/AddButton';
+import Layout from '@/components/Layout';
+import { LeagueTeamPayload } from '@/types/league';
+
+export default function Page() {
+  const leagueTeam = useForm<LeagueTeamPayload>({
+    initialValues: {
+      names: [''],
+      logos: [],
+    },
+  });
+
+  const leaguePlayer = useForm({
+    initialValues: {
+      players: [{ name: '', description: null, playerNumber: 0 }],
+    },
+  });
+
+  return (
+    <Layout
+      navigationTitle="대회 팀 생성"
+      navigationMenu={<button>완료</button>}
+    >
+      <Text>로고</Text>
+      <Dropzone
+        accept={IMAGE_MIME_TYPE}
+        onDrop={files => {
+          const newLogoUrl = URL.createObjectURL(files[0]);
+          leagueTeam.setFieldValue('logos', [newLogoUrl]);
+        }}
+        multiple={false}
+        style={{ width: '100%', height: 'auto' }}
+      >
+        {leagueTeam.values.logos.length > 0 && (
+          <Image
+            src={leagueTeam.values.logos[0]}
+            alt="Team logo"
+            onLoad={() => URL.revokeObjectURL(leagueTeam.values.logos[0])}
+            width={100}
+            height={100}
+          />
+        )}
+        {leagueTeam.values.logos.length === 0 && (
+          <Text ta="center">Drop image here</Text>
+        )}
+      </Dropzone>
+
+      <TextInput
+        mt="lg"
+        label="팀명"
+        withAsterisk
+        placeholder="필수 항목"
+        {...leagueTeam.getInputProps('names.0')}
+      />
+
+      <Flex mt="lg">
+        <Text flex={0.6}>이름</Text>
+        <Text flex={0.3}>번호</Text>
+        <Text flex={0.1}>-</Text>
+      </Flex>
+      {leaguePlayer.values.players.map((player, index) => (
+        <Flex key={index} align="center">
+          <TextInput
+            label="이름"
+            {...leaguePlayer.getInputProps(`players.${index}.name`)}
+            placeholder="이름을 입력하세요."
+            flex={0.6}
+          />
+          <TextInput
+            label="번호"
+            type="number"
+            {...leaguePlayer.getInputProps(`players.${index}.playerNumber`)}
+            placeholder="번호"
+            flex={0.3}
+          />
+          <button
+            style={{ flex: '0.1' }}
+            onClick={() => leaguePlayer.removeListItem('players', index)}
+          >
+            <Icon source={SubtractIcon} color="error" />
+          </button>
+        </Flex>
+      ))}
+      <AddButton
+        bg={theme.colors.white}
+        onClick={() =>
+          leaguePlayer.insertListItem('players', {
+            name: '',
+            backNumber: 0,
+          })
+        }
+      >
+        신규 선수 추가
+      </AddButton>
+    </Layout>
+  );
+}

--- a/apps/manager/hooks/mutations/useUpdateLeagueTeamMutation.ts
+++ b/apps/manager/hooks/mutations/useUpdateLeagueTeamMutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updateLeagueTeam } from '@/api/league';
+import { LEAGUE_TEAM_QUERY_KEY } from '@/hooks/queries/useLeagueTeamQuery';
+
+export default function useUpdateLeagueTeamMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (variables: { teamId: string; payload: FormData }) =>
+      updateLeagueTeam(variables.teamId, variables.payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [LEAGUE_TEAM_QUERY_KEY] });
+    },
+  });
+}

--- a/apps/manager/hooks/mutations/useUpdateLeagueTeamPlayersMutation.ts
+++ b/apps/manager/hooks/mutations/useUpdateLeagueTeamPlayersMutation.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updateLeagueTeamPlayers } from '@/api/league';
+import { LEAGUE_TEAM_PLAYERS_QUERY_KEY } from '@/hooks/queries/useLeagueTeamPlayersQuery';
+import { LeaguePlayerPayload } from '@/types/league';
+
+export default function useUpdateLeagueTeamPlayersMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (variables: {
+      teamId: string;
+      teamPlayerId: string;
+      payload: LeaguePlayerPayload;
+    }) =>
+      updateLeagueTeamPlayers(
+        variables.teamId,
+        variables.teamPlayerId,
+        variables.payload,
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [LEAGUE_TEAM_PLAYERS_QUERY_KEY],
+      });
+    },
+  });
+}

--- a/apps/manager/hooks/queries/useLeagueTeamDetailQuery.ts
+++ b/apps/manager/hooks/queries/useLeagueTeamDetailQuery.ts
@@ -1,0 +1,16 @@
+import useLeagueTeamQuery from './useLeagueTeamQuery';
+
+export default function useLeagueTeamDetailQuery(
+  leagueId: string,
+  teamId: string,
+) {
+  const { data: teams } = useLeagueTeamQuery(leagueId);
+
+  if (!teams) return { data: null };
+
+  const team = Object.values(teams)
+    .flat()
+    ?.find(team => team.id === Number(teamId));
+
+  return { data: team };
+}

--- a/apps/manager/hooks/queries/useLeagueTeamPlayersQuery.ts
+++ b/apps/manager/hooks/queries/useLeagueTeamPlayersQuery.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getLeagueTeamPlayers } from '@/api/league';
+
+export const LEAGUE_TEAM_PLAYERS_QUERY_KEY = 'leagueTeamPlayersQuery';
+export default function useLeagueTeamPlayersQuery(teamId: string) {
+  const { data, error } = useQuery({
+    queryKey: [LEAGUE_TEAM_PLAYERS_QUERY_KEY, { teamId }],
+    queryFn: () => getLeagueTeamPlayers(teamId),
+  });
+
+  if (error) throw error;
+
+  return { data };
+}

--- a/apps/manager/types/league.ts
+++ b/apps/manager/types/league.ts
@@ -48,6 +48,11 @@ export type LeaguePlayerPayload = {
   playerNumber: number | null;
 };
 
+export type LeaguePlayerWithIDPayload = LeaguePlayerPayload & {
+  id: number;
+  number?: number;
+};
+
 export interface GameListType extends GameType {
   id: number;
 }


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #110 

## ✅ 작업 내용

- 매니저 앱의 대회 팀 관리를 구현했습니다.
  - 팀 리스트
  - 팀 리스트 편집 (삭제)
  - 팀 추가, 팀 선수 추가
  - 팀 자세히 보기 및 수정

## 📝 참고 자료

- 현재 팀 추가 및 선수 추가 부분이 대회 생성 시 사용하는 폼과 유사합니다. 리팩토링 시 하나의 파일로 관리하면 좋을 듯 합니다.
