### PR TITLE
[REFACTOR] 매니저 앱 

### DIFF
--- a/apps/manager/api/game.ts
+++ b/apps/manager/api/game.ts
@@ -2,12 +2,12 @@ import instance from '@/api/index';
 import {
   GameCreatePayload,
   GameLineupType,
-  GameTeamType,
   GameTimelineType,
   GenericRecordPayload,
   LowerRecordType,
   GameInfoType,
   SportsQuarterType,
+  GameTeamType,
 } from '@/types/game';
 
 export const getGameDetail = async (gameId: string) => {

--- a/apps/manager/api/league.ts
+++ b/apps/manager/api/league.ts
@@ -27,7 +27,7 @@ export const getGameList = async ({
     params: { size, ...params },
   });
 
-  return { leagueName, data };
+  return { leagueId: params.league_id, leagueName, data };
 };
 
 export const createLeague = async (payload: NewLeaguePayload) => {

--- a/apps/manager/app/_components/PlayingCard/index.tsx
+++ b/apps/manager/app/_components/PlayingCard/index.tsx
@@ -20,7 +20,7 @@ export default function PlayingCard({ leagues }: PlayingCardProps) {
 
   return (
     <>
-      {playingLeagues.map(({ data, leagueName }) => (
+      {playingLeagues.map(({ leagueId, data, leagueName }) => (
         <Fragment key={leagueName}>
           <Title order={3} mt="lg" mb="xs" size={rem(20)}>
             {leagueName}
@@ -28,7 +28,10 @@ export default function PlayingCard({ leagues }: PlayingCardProps) {
           <Flex direction="column" gap="xs">
             {data.map(game => (
               <Card.Root key={game.id}>
-                <Card.Content component={Link} href={`/game/${game.id}`}>
+                <Card.Content
+                  component={Link}
+                  href={`/game/${leagueId}/${game.id}`}
+                >
                   <div style={{ flex: 1 }}>
                     <Card.Title text="semibold">{game.gameName}</Card.Title>
                     <Card.SubContent>
@@ -45,7 +48,7 @@ export default function PlayingCard({ leagues }: PlayingCardProps) {
                       fullWidth
                       component={Link}
                       variant="light"
-                      href={`/game/${game.id}/timeline`}
+                      href={`/game/${leagueId}/${game.id}/timeline`}
                     >
                       타임 라인
                     </Button>

--- a/apps/manager/app/game/[leagueId]/[gameId]/timeline/_components/List/index.tsx
+++ b/apps/manager/app/game/[leagueId]/[gameId]/timeline/_components/List/index.tsx
@@ -1,5 +1,5 @@
 import { theme } from '@hcc/styles';
-import { Box, Text } from '@mantine/core';
+import { Box, Flex, Text } from '@mantine/core';
 import { Fragment } from 'react';
 
 import { useTimelineQuery } from '@/hooks/queries/useTimelineQuery';
@@ -21,8 +21,10 @@ export default function TimelineList({ gameId }: TimelineListProps) {
     <ul>
       {timelines?.map(timeline => (
         <li key={timeline.gameQuarter}>
-          <Text c={theme.colors.gray[4]}>{timeline.gameQuarter}</Text>
-          <ul>
+          <Text mt="lg" mb="xs" c={theme.colors.gray[4]}>
+            {timeline.gameQuarter}
+          </Text>
+          <Flex component="ul" direction="column" gap="xs">
             {!timeline.records.length ? (
               <Box
                 component="li"
@@ -47,7 +49,7 @@ export default function TimelineList({ gameId }: TimelineListProps) {
                 </Fragment>
               ))
             )}
-          </ul>
+          </Flex>
         </li>
       ))}
     </ul>

--- a/apps/manager/app/game/[leagueId]/[gameId]/timeline/_components/ReplacementItem/index.tsx
+++ b/apps/manager/app/game/[leagueId]/[gameId]/timeline/_components/ReplacementItem/index.tsx
@@ -1,4 +1,5 @@
-import { CaretDownIcon, SoccerIcon } from '@hcc/icons';
+import { CaretDownIcon, SwitchIcon } from '@hcc/icons';
+import { rem } from '@hcc/styles';
 import { Icon } from '@hcc/ui';
 import { Flex } from '@mantine/core';
 import Image from 'next/image';
@@ -21,10 +22,13 @@ export default function ReplacementItem({
   return (
     <li>
       <Card.Root>
-        <Card.Content component={Link} href={`${pathname}${record.recordId}`}>
-          <Flex>
-            <Flex direction="column">
-              <Card.Title>
+        <Card.Content
+          component={Link}
+          href={`${pathname}update/${record.recordId}`}
+        >
+          <Flex w="100%" justify="space-between" align="center">
+            <Flex direction="column" gap={rem(4)}>
+              <Card.Title text="semibold">
                 {record.playerName} OUT /{' '}
                 {record.replacementRecord.replacedPlayerName} IN
               </Card.Title>
@@ -32,19 +36,19 @@ export default function ReplacementItem({
                 {quarter} ′{record.recordedAt}
               </Card.SubContent>
             </Flex>
-            <Flex>
+            <Flex gap="xs" align="center">
               <Image
                 src={record.teamImageUrl}
                 alt={`${record.teamName} logo`}
                 width={24}
                 height={24}
               />
-              <Icon source={SoccerIcon} />
+              <Icon source={SwitchIcon} />
+              <Card.Action>
+                <Icon source={CaretDownIcon} transform="rotate(-90)" />
+              </Card.Action>
             </Flex>
           </Flex>
-          <Card.Action>
-            <Icon source={CaretDownIcon} rotate="-90deg" />
-          </Card.Action>
         </Card.Content>
       </Card.Root>
     </li>

--- a/apps/manager/app/game/[leagueId]/[gameId]/timeline/_components/ScoreItem/index.tsx
+++ b/apps/manager/app/game/[leagueId]/[gameId]/timeline/_components/ScoreItem/index.tsx
@@ -1,4 +1,5 @@
 import { CaretDownIcon, SoccerIcon } from '@hcc/icons';
+import { rem } from '@hcc/styles';
 import { Icon } from '@hcc/ui';
 import { Flex } from '@mantine/core';
 import Image from 'next/image';
@@ -18,15 +19,18 @@ export default function ScoreItem({ quarter, ...record }: ScoreItemProps) {
   return (
     <li>
       <Card.Root>
-        <Card.Content component={Link} href={`${pathname}${record.recordId}`}>
-          <Flex>
-            <Flex direction="column">
-              <Card.Title>{record.playerName}</Card.Title>
+        <Card.Content
+          component={Link}
+          href={`${pathname}update/${record.recordId}`}
+        >
+          <Flex w="100%" justify="space-between" align="center">
+            <Flex direction="column" gap={rem(4)}>
+              <Card.Title text="semibold">{record.playerName}</Card.Title>
               <Card.SubContent>
                 {quarter} ′{record.recordedAt}
               </Card.SubContent>
             </Flex>
-            <Flex>
+            <Flex gap="xs" align="center">
               <Image
                 src={record.teamImageUrl}
                 alt={`${record.teamName} logo`}
@@ -34,11 +38,11 @@ export default function ScoreItem({ quarter, ...record }: ScoreItemProps) {
                 height={24}
               />
               <Icon source={SoccerIcon} />
+              <Card.Action>
+                <Icon source={CaretDownIcon} transform="rotate(-90)" />
+              </Card.Action>
             </Flex>
           </Flex>
-          <Card.Action>
-            <Icon source={CaretDownIcon} rotate="-90deg" />
-          </Card.Action>
         </Card.Content>
       </Card.Root>
     </li>

--- a/apps/manager/app/game/[leagueId]/[gameId]/timeline/page.tsx
+++ b/apps/manager/app/game/[leagueId]/[gameId]/timeline/page.tsx
@@ -4,7 +4,7 @@ import { SoccerIcon, SwitchIcon } from '@hcc/icons';
 import { Icon } from '@hcc/ui';
 import { Button, Flex } from '@mantine/core';
 import Link from 'next/link';
-import { useParams, usePathname } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 
 import AsyncBoundary from '@/components/AsyncBoundary';
 import Layout from '@/components/Layout';
@@ -12,10 +12,12 @@ import Layout from '@/components/Layout';
 import TimelineList from './_components/List';
 import TimelineError from './_components/List/Error';
 
-export default function Timeline() {
+type PageProps = {
+  params: { gameId: string };
+};
+
+export default function Page({ params: { gameId } }: PageProps) {
   const pathname = usePathname();
-  const params = useParams();
-  const gameId = params.gameId as string;
 
   if (!gameId) return null;
 

--- a/apps/manager/app/game/[leagueId]/page.tsx
+++ b/apps/manager/app/game/[leagueId]/page.tsx
@@ -3,13 +3,14 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
-export default function GameList({
+export default function Page({
   params: { leagueId },
 }: {
   params: { leagueId: number };
 }) {
   const pathname = usePathname();
   const gameData = leagueId;
+
   return (
     <>
       2024 월드컵

--- a/apps/manager/app/league/[leagueId]/game/_components/GameCard.tsx
+++ b/apps/manager/app/league/[leagueId]/game/_components/GameCard.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import Card from '@/components/Card';
 import useDeleteGameMutation from '@/hooks/mutations/useDeleteGameMutation';
 import useGameQuery from '@/hooks/queries/useGameQuery';
-import { GameState } from '@/types/game';
+import { stateMap, StateType } from '@/types/game';
 import { LeagueType } from '@/types/league';
 import { formatTime } from '@/utils/time';
 
@@ -14,7 +14,7 @@ import * as styles from '../page.css';
 
 type PlayingCardProps = {
   league: LeagueType;
-  state: GameState;
+  state: StateType;
   edit: boolean;
 };
 
@@ -35,18 +35,14 @@ export default function GameCard({ league, state, edit }: PlayingCardProps) {
   return (
     <>
       <p className={styles.title}>
-        {state === 'playing'
-          ? '진행중'
-          : state === 'scheduled'
-            ? '예정'
-            : '종료'}
+        {stateMap[state.toUpperCase() as StateType]}
       </p>
       <Flex direction="column" gap="xs" mt="md">
         {data.data.map(game => (
           <Card.Root key={game.id}>
             <Card.Content
               component={Link}
-              href={edit ? `#` : `/game/${game.id}`}
+              href={edit ? `#` : `/game/${league.leagueId}/${game.id}`}
             >
               <div style={{ flex: 1 }}>
                 <Card.Title text="semibold">{game.gameName}</Card.Title>
@@ -101,7 +97,7 @@ export default function GameCard({ league, state, edit }: PlayingCardProps) {
                     fullWidth
                     component={Link}
                     variant="light"
-                    href={`/game/${game.id}/timeline`}
+                    href={`/game/${league.leagueId}/${game.id}/timeline`}
                   >
                     타임 라인
                   </Button>

--- a/apps/manager/app/league/[leagueId]/game/register/_components/GameInfoInput.tsx
+++ b/apps/manager/app/league/[leagueId]/game/register/_components/GameInfoInput.tsx
@@ -1,6 +1,6 @@
 import { theme } from '@hcc/styles';
 import { Text, Select, TextInput } from '@mantine/core';
-import { DateInput } from '@mantine/dates';
+import { DateTimePicker } from '@mantine/dates';
 import { UseFormReturnType } from '@mantine/form';
 import React from 'react';
 
@@ -34,7 +34,7 @@ export function GameInfoInput({ form }: GameInfoInputProps) {
         withAsterisk
         {...form.getInputProps('sportsId')}
       />
-      <DateInput
+      <DateTimePicker
         valueFormat="YYYY.MM.DD HH:mm"
         placeholder="2000.00.00 00:00"
         withAsterisk

--- a/apps/manager/app/league/[leagueId]/game/register/_components/TeamSelection.tsx
+++ b/apps/manager/app/league/[leagueId]/game/register/_components/TeamSelection.tsx
@@ -24,14 +24,14 @@ export default function TeamSelection({
         data={leagueTeamList}
         placeholder="팀을 선택해주세요"
         withAsterisk
-        {...form.getInputProps('teamIds')}
+        {...form.getInputProps('teamIds.0')}
       />
       <Select
         label="팀2"
         data={leagueTeamList}
         placeholder="팀을 선택해주세요"
         withAsterisk
-        {...form.getInputProps('teamIds')}
+        {...form.getInputProps('teamIds.1')}
       />
     </>
   );

--- a/apps/manager/app/league/[leagueId]/team/_components/TeamForm.tsx
+++ b/apps/manager/app/league/[leagueId]/team/_components/TeamForm.tsx
@@ -1,6 +1,6 @@
 import { SubtractIcon } from '@hcc/icons';
 import { Icon } from '@hcc/ui';
-import { Flex, Text, TextInput } from '@mantine/core';
+import { ActionIcon, Grid, Text, TextInput } from '@mantine/core';
 import { Dropzone, IMAGE_MIME_TYPE } from '@mantine/dropzone';
 import { useForm } from '@mantine/form';
 import Image from 'next/image';
@@ -74,29 +74,42 @@ export default function TeamForm({ form, edit = true }: TeamFormProps) {
         {...form.getInputProps('name')}
       />
 
-      {form.values.players.map((_, index) => (
-        <Flex key={index} align="center" mt="sm">
-          <TextInput
-            label="이름"
-            placeholder="선수 이름"
-            {...form.getInputProps(`players.${index}.name`)}
-            style={{ flex: 1, marginRight: '8px' }}
-            disabled={!edit}
-          />
-          <TextInput
-            label="번호"
-            placeholder="선수 번호"
-            type="number"
-            {...form.getInputProps(`players.${index}.playerNumber`)}
-            style={{ width: '100px', marginRight: '8px' }}
-            disabled={!edit}
-          />
-          {edit && (
-            <button style={{ flex: '0.1' }} onClick={() => removePlayer(index)}>
-              <Icon source={SubtractIcon} color="error" />
-            </button>
-          )}
-        </Flex>
+      <Grid grow>
+        <Grid.Col span={7}>이름</Grid.Col>
+        <Grid.Col span={2}>번호</Grid.Col>
+        <Grid.Col span={0.5} />
+      </Grid>
+      {form.values.players.map((values, index) => (
+        <Grid grow key={values.id}>
+          <Grid.Col span={6}>
+            <TextInput
+              placeholder="선수 이름"
+              {...form.getInputProps(`players.${index}.name`)}
+              disabled={!edit}
+            />
+          </Grid.Col>
+          <Grid.Col span={2}>
+            <TextInput
+              placeholder="선수 번호"
+              type="number"
+              {...form.getInputProps(`players.${index}.playerNumber`)}
+              disabled={!edit}
+            />
+          </Grid.Col>
+          <Grid.Col span={0.5}>
+            {
+              <ActionIcon
+                h="100%"
+                w="100%"
+                onClick={() => removePlayer(index)}
+                variant="subtle"
+                disabled={!edit}
+              >
+                <Icon source={SubtractIcon} color={edit ? 'error' : 'gray'} />
+              </ActionIcon>
+            }
+          </Grid.Col>
+        </Grid>
       ))}
 
       {edit && <AddButton onClick={addPlayer}>선수 추가</AddButton>}

--- a/apps/manager/app/league/[leagueId]/team/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/page.tsx
@@ -12,14 +12,13 @@ import useLeagueTeamQuery from '@/hooks/queries/useLeagueTeamQuery';
 
 import LeagueTeamActionIcon from './_components/ActionIcon';
 
-export default function LeagueTeamList() {
+export default function Page() {
   const [edit, setEdit] = useState(false);
   const pathname = usePathname();
   const params = useParams();
   const leagueId = params.leagueId as string;
 
   const { data: leagueTeams } = useLeagueTeamQuery(leagueId);
-  // const {} = useDeleteLeagueTeamMutation()
 
   if (!leagueTeams) return null;
 

--- a/apps/manager/app/league/[leagueId]/team/register/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/register/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useParams, useRouter } from 'next/navigation';
 import React from 'react';
@@ -67,7 +68,11 @@ export default function Page() {
   return (
     <Layout
       navigationTitle="대회 팀 생성"
-      navigationMenu={<button onClick={handleSubmit}>완료</button>}
+      navigationMenu={
+        <Button variant="subtle" onClick={handleSubmit}>
+          완료
+        </Button>
+      }
     >
       <TeamForm form={form} />
     </Layout>

--- a/apps/manager/app/league/_components/LeagueCard/index.tsx
+++ b/apps/manager/app/league/_components/LeagueCard/index.tsx
@@ -6,19 +6,14 @@ import Link from 'next/link';
 import Card from '@/components/Card';
 import useDeleteLeagueMutation from '@/hooks/mutations/useDeleteLeagueMutation';
 import useLeagueQuery from '@/hooks/queries/useLeagueQuery';
+import { StateType, stateMap } from '@/types/game';
 import { formatTime } from '@/utils/time';
 
 import * as styles from './LeagueCard.css';
 
 type LeagueCardProps = {
-  state: 'playing' | 'scheduled' | 'finished';
+  state: StateType;
   edit: boolean;
-};
-
-const titleMap = {
-  playing: '진행 중',
-  scheduled: '예정',
-  finished: '종료',
 };
 
 const alertMessage =
@@ -41,10 +36,10 @@ export default function LeagueCard({ state, edit }: LeagueCardProps) {
   return (
     <>
       <Title order={2} className={styles.title}>
-        {titleMap[state]}
+        {stateMap[state]}
       </Title>
       {!leagues?.[state] ? (
-        <Box>{titleMap[state]} 경기가 없습니다.</Box>
+        <Box>{stateMap[state]} 경기가 없습니다.</Box>
       ) : (
         <Flex direction="column" gap="xs">
           {leagues[state].map(league => (

--- a/apps/manager/app/league/register/_components/LeagueInfo/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueInfo/index.tsx
@@ -37,8 +37,10 @@ export default function LeagueInfo({
     },
   });
 
-  const { mutate: mutateCreateLeague } = useCreateLeagueMutation();
+  const { mutate: mutateCreateLeague, isPending } = useCreateLeagueMutation();
   const handleClickButton = () => {
+    if (isPending) return;
+
     mutateCreateLeague(form.values, {
       onSuccess: ({ leagueId }) => {
         handleLeagueId(leagueId);

--- a/apps/manager/app/league/register/_components/LeagueTeamPlayers/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueTeamPlayers/index.tsx
@@ -33,8 +33,11 @@ export default function LeagueTeamPlayers({
     });
   };
 
-  const { mutate: muatateLeaguePlayers } = useCreateLeaguePlayersMutation();
+  const { mutate: muatateLeaguePlayers, isPending } =
+    useCreateLeaguePlayersMutation();
   const handleSubmitForm = () => {
+    if (isPending) return;
+
     muatateLeaguePlayers(
       { teamId, payload: form.values.players },
       { onSuccess: prevStep },

--- a/apps/manager/app/league/register/page.tsx
+++ b/apps/manager/app/league/register/page.tsx
@@ -15,7 +15,7 @@ export default function Register() {
   const [leagueId, setLeagueId] = useState<number>(-1);
   const [teamId, setTeamId] = useState<number>(-1);
 
-  const [active, setActive] = useState(2);
+  const [active, setActive] = useState(0);
   const handleLeagueId = (step: number) => {
     setActive(step);
   };

--- a/apps/manager/app/loading.tsx
+++ b/apps/manager/app/loading.tsx
@@ -1,4 +1,15 @@
+import { Flex, Loader, LoadingOverlay } from '@mantine/core';
+
+import Layout from '@/components/Layout';
+
 export default function Loading() {
   // You can add any UI inside Loading, including a Skeleton.
-  return <div>로딩</div>;
+  return (
+    <Layout>
+      <Flex justify="center" align="center">
+        <LoadingOverlay />
+        <Loader ta="center" />
+      </Flex>
+    </Layout>
+  );
 }

--- a/apps/manager/components/Layout/Layout.css.ts
+++ b/apps/manager/components/Layout/Layout.css.ts
@@ -5,7 +5,7 @@ export const wrapper = style({
   display: 'flex',
   flexDirection: 'column',
   maxWidth: theme.sizes.appWidth,
-  minHeight: '100vh',
+  height: '100dvh',
   margin: 'auto',
 
   backgroundColor: theme.colors.gray[1],

--- a/apps/manager/components/Layout/index.tsx
+++ b/apps/manager/components/Layout/index.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from '@mantine/core';
 import { ReactNode } from 'react';
 
 import Navigation from '@/components/Layout/Navigation';
@@ -32,7 +33,9 @@ export default function Layout({
           navigationMenu={navigationMenu}
         />
       )}
-      <main className={styles.main}>{children}</main>
+      <ScrollArea component="main" py="sm" className={styles.main}>
+        {children}
+      </ScrollArea>
       {footerVisible && <Footer />}
     </div>
   );

--- a/apps/manager/components/Layout/index.tsx
+++ b/apps/manager/components/Layout/index.tsx
@@ -33,7 +33,12 @@ export default function Layout({
           navigationMenu={navigationMenu}
         />
       )}
-      <ScrollArea component="main" py="sm" className={styles.main}>
+      <ScrollArea
+        scrollbars="y"
+        component="main"
+        py="sm"
+        className={styles.main}
+      >
         {children}
       </ScrollArea>
       {footerVisible && <Footer />}

--- a/apps/manager/hooks/mutations/useCreateLeagueTeamMutation.ts
+++ b/apps/manager/hooks/mutations/useCreateLeagueTeamMutation.ts
@@ -1,6 +1,8 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { createLeagueTeam } from '@/api/league';
+
+import { LEAGUE_TEAM_QUERY_KEY } from '../queries/useLeagueTeamQuery';
 
 type Params = {
   leagueId: number;
@@ -8,8 +10,14 @@ type Params = {
 };
 
 export default function useCreateLeagueTeamMutation() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ leagueId, payload }: Params) =>
       createLeagueTeam(leagueId, payload),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [LEAGUE_TEAM_QUERY_KEY, { leagueId: variables.leagueId }],
+      });
+    },
   });
 }

--- a/apps/manager/hooks/mutations/useCreateTimelineMutation.ts
+++ b/apps/manager/hooks/mutations/useCreateTimelineMutation.ts
@@ -1,9 +1,13 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { createGameTimeline } from '@/api/game';
 import { GenericRecordPayload, LowerRecordType } from '@/types/game';
 
+import { TIMELINE_QUERY_KEY } from '../queries/useTimelineQuery';
+
 export default function useCreateTimelineMutation() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: ({
       recordType,
@@ -11,6 +15,13 @@ export default function useCreateTimelineMutation() {
     }: {
       recordType: LowerRecordType;
       params: GenericRecordPayload<typeof recordType>;
-    }) => createGameTimeline(recordType, params),
+    }) => {
+      return createGameTimeline(recordType, params);
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [TIMELINE_QUERY_KEY, variables.params.gameId],
+      });
+    },
   });
 }

--- a/apps/manager/hooks/mutations/useCreateTimelineMutation.ts
+++ b/apps/manager/hooks/mutations/useCreateTimelineMutation.ts
@@ -20,7 +20,7 @@ export default function useCreateTimelineMutation() {
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
-        queryKey: [TIMELINE_QUERY_KEY, variables.params.gameId],
+        queryKey: [TIMELINE_QUERY_KEY, { gameId: variables.params.gameId }],
       });
     },
   });

--- a/apps/manager/hooks/queries/useGameQuery.ts
+++ b/apps/manager/hooks/queries/useGameQuery.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { getGameList } from '@/api/league';
-import { GameState } from '@/types/game';
+import { StateType } from '@/types/game';
 import { LeagueType } from '@/types/league';
 
-export default function useGameQuery(league: LeagueType, state: GameState) {
+export default function useGameQuery(league: LeagueType, state: StateType) {
   const { data, error, isLoading, refetch } = useQuery({
     queryKey: ['game', { state, ...league }],
     queryFn: () =>

--- a/apps/manager/hooks/queries/useGamesQuery.ts
+++ b/apps/manager/hooks/queries/useGamesQuery.ts
@@ -1,15 +1,16 @@
 import { useSuspenseQueries } from '@tanstack/react-query';
 
 import { getGameList } from '@/api/league';
-import { GameState, LeagueType } from '@/types/league';
+import { StateType } from '@/types/game';
+import { LeagueType } from '@/types/league';
 
-export default function useGamesQuery(leagues: LeagueType[], state: GameState) {
+export default function useGamesQuery(leagues: LeagueType[], state: StateType) {
   const options = leagues.map(league => ({
     queryKey: ['games', { league_id: league.leagueId, state }],
     queryFn: () =>
       getGameList({
         league_id: league.leagueId,
-        state: state,
+        state,
         leagueName: league.name,
       }),
   }));

--- a/apps/manager/hooks/queries/useTimelineQuery.ts
+++ b/apps/manager/hooks/queries/useTimelineQuery.ts
@@ -2,9 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getGameTimeline } from '@/api/game';
 
+export const TIMELINE_QUERY_KEY = 'game-timeline';
 export const useTimelineQuery = (gameId: string) => {
   const query = useQuery({
-    queryKey: ['game-timeline', gameId],
+    queryKey: [TIMELINE_QUERY_KEY, gameId],
     queryFn: () => getGameTimeline(gameId),
   });
 

--- a/apps/manager/hooks/queries/useTimelineQuery.ts
+++ b/apps/manager/hooks/queries/useTimelineQuery.ts
@@ -5,7 +5,7 @@ import { getGameTimeline } from '@/api/game';
 export const TIMELINE_QUERY_KEY = 'game-timeline';
 export const useTimelineQuery = (gameId: string) => {
   const query = useQuery({
-    queryKey: [TIMELINE_QUERY_KEY, gameId],
+    queryKey: [TIMELINE_QUERY_KEY, { gameId }],
     queryFn: () => getGameTimeline(gameId),
   });
 

--- a/apps/manager/next.config.js
+++ b/apps/manager/next.config.js
@@ -6,7 +6,23 @@ const nextConfig = {
   trailingSlash: true,
 
   experimental: {
-    optimizePackageImports: ['@mantine/core', '@mantine/hooks'],
+    optimizePackageImports: [
+      '@mantine/core',
+      '@mantine/hooks',
+      '@mantine/dates',
+      '@mantine/dropzone',
+      '@mantine/form',
+    ],
+  },
+
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'hufscheer-server.s3.ap-northeast-2.amazonaws.com',
+        port: '',
+      },
+    ],
   },
 
   async rewrites() {
@@ -14,6 +30,10 @@ const nextConfig = {
       {
         source: '/api/games/',
         destination: `https://api.hufstreaming.site/games`,
+      },
+      {
+        source: '/api/games/:path*/timeline/',
+        destination: `https://api.hufstreaming.site/games/:path*/timeline`,
       },
       {
         source: '/api/:path*/',

--- a/apps/manager/public/_redirects
+++ b/apps/manager/public/_redirects
@@ -1,3 +1,4 @@
 /api/games/ https://api.hufstreaming.site/games 200!
+/api/games/ https://api.hufstreaming.site/games/:splat/timeline 200!
 
 /api/* https://backoffice.hufstreaming.site/:splat 200!

--- a/apps/manager/types/game.ts
+++ b/apps/manager/types/game.ts
@@ -2,18 +2,18 @@ export type GameInfoType = {
   sports: SportsType;
   startTime: string;
   gameName: string;
-  state: gameStateType;
+  state: StateType;
   videoId: string | null;
   gameQuarter: string;
 };
 
-export const gameState = {
-  PLAYING: '진행중',
-  SCHEDULED: '예정',
-  FINISHED: '종료',
+export const stateMap = {
+  playing: '진행 중',
+  scheduled: '예정',
+  finished: '종료',
 } as const;
 
-export type gameStateType = keyof typeof gameState;
+export type StateType = keyof typeof stateMap;
 
 export type SportsQuarterType = {
   id: number;
@@ -100,15 +100,13 @@ export interface GameListType extends GameType {
 
 export type GameListParams = {
   league_id?: number;
-  state: GameState;
+  state: StateType;
   sport_id?: string;
   cursor?: string | number;
   size?: string;
   league_team_id?: string;
   round?: string;
 };
-
-export type GameState = 'playing' | 'scheduled' | 'finished';
 
 export type GameLineupType = {
   id: number;

--- a/apps/manager/types/league.ts
+++ b/apps/manager/types/league.ts
@@ -1,4 +1,4 @@
-import { SportsQuarterType } from './game';
+import { StateType, SportsQuarterType } from './game';
 
 export type LeagueIdType = {
   leagueId: number;
@@ -19,14 +19,12 @@ export type SportsDataType = number[];
 
 export type SportsCategoriesType = SportIdType & SportsQuarterType;
 
-export type LeagueCategory = 'playing' | 'scheduled' | 'finished';
-
 export type LeagueType = LeagueIdType &
   LeagueDataType & {
     InProgressRound: number;
     maxRound: number;
   };
-export type LeagueListType = Record<LeagueCategory, LeagueType[]>;
+export type LeagueListType = Record<StateType, LeagueType[]>;
 
 export type NewLeaguePayload = {
   leagueData: LeagueDataType;
@@ -59,7 +57,7 @@ export interface GameListType extends GameType {
 
 export type GameListParams = {
   league_id?: number;
-  state: GameState;
+  state: StateType;
   sport_id?: string;
   cursor?: string | number;
   size?: string;
@@ -81,5 +79,3 @@ export type GameTeamType = {
   logoImageUrl: string;
   score: number;
 };
-
-export type GameState = 'playing' | 'scheduled' | 'finished';

--- a/apps/manager/types/league.ts
+++ b/apps/manager/types/league.ts
@@ -50,32 +50,3 @@ export type LeaguePlayerWithIDPayload = LeaguePlayerPayload & {
   id: number;
   number?: number;
 };
-
-export interface GameListType extends GameType {
-  id: number;
-}
-
-export type GameListParams = {
-  league_id?: number;
-  state: StateType;
-  sport_id?: string;
-  cursor?: string | number;
-  size?: string;
-  league_team_id?: string;
-  round?: string;
-};
-
-export interface GameType {
-  gameTeams: GameTeamType[];
-  startTime: string;
-  gameQuarter: string;
-  gameName: string;
-  sportsName: string;
-}
-
-export type GameTeamType = {
-  gameTeamId: number;
-  gameTeamName: string;
-  logoImageUrl: string;
-  score: number;
-};


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- GameState 타입이 중구난방으로 사용되고 있고, 심지어 여러 개 정의되어 있습니다. 이를 하나로 통일합니다.
- 페이지의 헤더, 푸터를 제외한 영역에만 스크롤을 제공합니다.
- 로더 컴포넌트를 추가합니다.
- 경기 생성 기능의 사소한 에러를 제거합니다.
- 타임라인으로 이동하는 경로를 다듬습니다.
- queryKey의 의존값들을 모두 객체로 관리합니다.

## 📝 참고 자료

## ♾️ 기타

