### PR TITLE
[FIX]: 사용하지 않는 query parameter 제거

### DIFF
--- a/apps/spectator/app/_components/GameFilter/LeagueTeamFilter.tsx
+++ b/apps/spectator/app/_components/GameFilter/LeagueTeamFilter.tsx
@@ -24,7 +24,7 @@ export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
 
   const handleRouter = (selectedTeamId: number) => {
     const current = new URLSearchParams(Array.from(searchParams.entries()));
-    const teamIdParams = current.get('leagueTeam');
+    const teamIdParams = current.get('leagueTeam') || null;
     const teamIds = teamIdParams?.split(',').map(Number) || [];
 
     const hasTeamId = teamIds.includes(selectedTeamId);
@@ -32,7 +32,8 @@ export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
       ? teamIds.filter(id => id !== selectedTeamId)
       : [...teamIds, selectedTeamId].sort((a, b) => a - b);
 
-    current.set('leagueTeam', updatedTeamIds.join(','));
+    if (!updatedTeamIds.length) current.delete('leagueTeam');
+    else current.set('leagueTeam', updatedTeamIds.join(','));
 
     const query = current ? `?${current}` : '';
 


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #129 

## ✅ 작업 내용

- QA 도중 팀 필터를 등록한 뒤 모두 제거했다가, 다시 등록하면 전체 팀의 경기 목록을 뿌려주어야 하는데, 아무런 값도 들어가지 않은 것을 확인했습니다.

- 살펴보니 쿼리 파라미터로 관리하는 필터에 값이 아무것도 존재하지 않으면 빈 문자열이 들어가는데, 이 빈 문자열이 searchParams에 의해 파싱 될 때 0으로 변환되고 있었습니다.

  ![image](https://github.com/hufscheer/client_v2/assets/88662637/acfb711a-20ba-4910-a682-09bdbcee8fb2)
  ![image](https://github.com/hufscheer/client_v2/assets/88662637/60d163e7-58b1-4f99-88c0-d749a578cac2)

- 따라서 필터의 값이 아무것도 존재하지 않을 시 빈 문자열이 아니라 쿼리 파라미터 자체를 제거하도록 수정합니다.

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
