### PR TITLE
[FEAT] 진행 전 라운드 비활성화

### DIFF
--- a/apps/spectator/app/_components/GameFilter/GameFilter.css.ts
+++ b/apps/spectator/app/_components/GameFilter/GameFilter.css.ts
@@ -49,6 +49,11 @@ export const roundFilterFocused = style([
   },
 ]);
 
+export const roundFilterDisabled = style({
+  color: theme.colors.gray[3],
+  cursor: 'not-allowed',
+});
+
 export const divider = style({
   position: 'absolute',
   width: '100%',

--- a/apps/spectator/app/_components/GameFilter/GameFilter.css.ts
+++ b/apps/spectator/app/_components/GameFilter/GameFilter.css.ts
@@ -51,7 +51,7 @@ export const roundFilterFocused = style([
 
 export const roundFilterDisabled = style({
   color: theme.colors.gray[3],
-  cursor: 'not-allowed',
+  pointerEvents: 'none',
 });
 
 export const divider = style({

--- a/apps/spectator/app/_components/GameFilter/RoundFilter.tsx
+++ b/apps/spectator/app/_components/GameFilter/RoundFilter.tsx
@@ -43,22 +43,26 @@ export default function RoundFilter({
         autoResize={true}
         bound={true}
       >
-        {rounds.map((roundValue, index) => (
+        {rounds.map(roundValue => (
           <li
-            key={index}
-            className={clsx(
-              styles.roundFilterItem,
-              roundValue === currentRound && styles.roundFilterFocused,
-            )}
+            key={roundValue}
+            className={clsx(styles.roundFilterItem, {
+              [styles.roundFilterFocused]: roundValue === currentRound,
+              [styles.roundFilterDisabled]: roundValue < inProgressRound,
+            })}
           >
-            <Link
-              href={{
-                href: pathname,
-                query: { year, league, round: roundValue },
-              }}
-            >
-              {formatRoundLabel(roundValue)}
-            </Link>
+            {roundValue < inProgressRound ? (
+              formatRoundLabel(roundValue)
+            ) : (
+              <Link
+                href={{
+                  pathname,
+                  query: { year, league, round: roundValue },
+                }}
+              >
+                {formatRoundLabel(roundValue)}
+              </Link>
+            )}
           </li>
         ))}
       </Flicking>

--- a/apps/spectator/app/_components/GameFilter/RoundFilter.tsx
+++ b/apps/spectator/app/_components/GameFilter/RoundFilter.tsx
@@ -51,18 +51,11 @@ export default function RoundFilter({
               [styles.roundFilterDisabled]: roundValue < inProgressRound,
             })}
           >
-            {roundValue < inProgressRound ? (
-              formatRoundLabel(roundValue)
-            ) : (
-              <Link
-                href={{
-                  pathname,
-                  query: { year, league, round: roundValue },
-                }}
-              >
-                {formatRoundLabel(roundValue)}
-              </Link>
-            )}
+            <Link
+              href={{ pathname, query: { year, league, round: roundValue } }}
+            >
+              {formatRoundLabel(roundValue)}
+            </Link>
           </li>
         ))}
       </Flicking>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #135 

## ✅ 작업 내용

- 라운드 필터에 `roundFilterDisabled` 스타일을 추가하고, `Link` 컴포넌트를 조건부로 출력하게 변경했습니다.
  - <img width="373" alt="image" src="https://github.com/hufscheer/client_v2/assets/97780352/aa5acaff-7303-4772-920f-6503d9388907">

