### PR TITLE
[REFACTOR] 사이드바 리그 범위 재설정

### DIFF
--- a/apps/spectator/components/LeagueList/index.tsx
+++ b/apps/spectator/components/LeagueList/index.tsx
@@ -2,7 +2,7 @@ import { Accordion } from '@hcc/ui';
 import dayjs from 'dayjs';
 import Link from 'next/link';
 
-import useLeagues from '@/queries/useLeagues';
+import useLeagueArchives from '@/queries/useLeagueArchives';
 
 import * as styles from './LeagueList.css';
 
@@ -18,7 +18,7 @@ type LeagueListProps = {
 };
 
 export default function LeagueList({ handleClose }: LeagueListProps) {
-  const { leagues } = useLeagues<typeof YEARS_LIST>(YEARS_LIST);
+  const { data: leagues } = useLeagueArchives<typeof YEARS_LIST>(YEARS_LIST);
 
   return (
     <>

--- a/apps/spectator/queries/useLeague.ts
+++ b/apps/spectator/queries/useLeague.ts
@@ -7,7 +7,7 @@ export const LEAGUES_QUERY_KEY = 'leagues';
 export default function useLeague(year: number) {
   const { data, error } = useQuery({
     queryKey: [LEAGUES_QUERY_KEY, year],
-    queryFn: () => (year ? getLeagues(year) : null),
+    queryFn: () => getLeagues(year),
   });
 
   if (error) throw error;

--- a/apps/spectator/queries/useLeagueArchives.ts
+++ b/apps/spectator/queries/useLeagueArchives.ts
@@ -3,12 +3,12 @@ import { useSuspenseQueries } from '@tanstack/react-query';
 import { getLeagues } from '@/api/league';
 import { LeagueType } from '@/types/league';
 
-export default function useLeagues<T extends number[]>(years: T) {
+export default function useLeagueArchives<T extends number[]>(years: T) {
   const options = years.map(year => ({
     queryKey: ['league', year],
     queryFn: () => getLeagues(year),
   }));
-  const { error, ...rest } = useSuspenseQueries({
+  const query = useSuspenseQueries({
     queries: options,
     combine: results => {
       return {
@@ -20,13 +20,14 @@ export default function useLeagues<T extends number[]>(years: T) {
     },
   });
 
-  if (error) throw error;
+  if (query.error) throw query.error;
 
   return {
-    leagues: rest.data.reduce(
+    ...query,
+    data: query.data.reduce(
       (acc, cur, index) => ({
         ...acc,
-        [years[index]]: cur?.filter(league => !league.isInProgress),
+        [years[index]]: cur,
       }),
       {} as Record<keyof T, LeagueType[]>,
     ),


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #137 

## ✅ 작업 내용

- 사이드바에서 제공하는 리그의 범위를 **[진행 중인 대회 제외]**에서 **[모든 대회]**로 재설정합니다.
- 진행되었던 모든 경기를 보관한다는 의미에서 hook 함수의 명칭을 `useLeagueArchives`로 변경합니다.

## 📝 참고 자료

## ♾️ 기타
