### PR TITLE
[FIX] 응원톡 상단 타임라인 수정

### DIFF
--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Timeline/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Timeline/index.tsx
@@ -1,7 +1,6 @@
 import ReplacementTimeline from '@/app/game/[id]/_components/Timeline/Replacement';
 import ScoreTimeline from '@/app/game/[id]/_components/Timeline/Score';
 import { useTimelineById } from '@/queries/useTimelineById';
-import { GameRecordType, GameTimelineType } from '@/types/game';
 
 import * as styles from './Timeline.css';
 
@@ -9,28 +8,17 @@ type TimelineProps = {
   gameId: string;
 };
 
-const getLastRecord = (gameData: GameTimelineType[]): GameRecordType | null => {
-  const lastQuarterWithRecords = [...gameData]
-    .reverse()
-    .find(quarter => quarter.records.length > 0);
-  return lastQuarterWithRecords
-    ? lastQuarterWithRecords.records[lastQuarterWithRecords.records.length - 1]
-    : null;
-};
-
 export default function CheerTalkTimeline({ gameId }: TimelineProps) {
   const { data: timelines } = useTimelineById(gameId);
+  const lastRecord = timelines[0].records[0];
 
-  const record = getLastRecord(timelines);
-
-  if (!record) return null;
+  if (!lastRecord) return null;
 
   return (
     <div className={styles.wrapper}>
-      {record.type === 'SCORE' ? (
-        <ScoreTimeline key={record.recordedAt} {...record} />
-      ) : (
-        <ReplacementTimeline key={record.recordedAt} {...record} />
+      {lastRecord.type === 'SCORE' && <ScoreTimeline {...lastRecord} />}
+      {lastRecord.type === 'REPLACEMENT' && (
+        <ReplacementTimeline {...lastRecord} />
       )}
     </div>
   );

--- a/apps/spectator/queries/useTimelineById.ts
+++ b/apps/spectator/queries/useTimelineById.ts
@@ -4,7 +4,11 @@ import { getGameTimelineById } from '@/api/game';
 
 import { useGameTeamInfo } from './useGameTeamInfo';
 
-export const useTimelineById = (gameId: string) => {
+const TIMELINE_POLLING_INTERVAL = 1000 * 60;
+export const useTimelineById = (
+  gameId: string,
+  interval = TIMELINE_POLLING_INTERVAL,
+) => {
   const { getTeamInfo } = useGameTeamInfo(gameId);
   const { error, ...rest } = useSuspenseQuery({
     queryKey: ['game-timeline', gameId],
@@ -18,6 +22,13 @@ export const useTimelineById = (gameId: string) => {
         })),
       }));
     },
+
+    // refetch options
+    refetchInterval: interval,
+    refetchOnReconnect: true,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+    staleTime: 1000 * 60,
   });
 
   if (error) throw error;


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #139 

## ✅ 작업 내용

- 응원톡 상단 타임라인이 가장 오래된 정보를 제공하고 있습니다. 이를 수정합니다.
- 실시간성을 어느정도 보장하기 위해 다음과 같은 옵션을 추가합니다.
  - 1분에 한 번 refetch
  - window focus 시 refetch
  - reconnect 시 refetch
  - 컴포넌트 mount 시 refetch
  - stale time 1분으로 단축

## 📝 참고 자료

## ♾️ 기타
