### PR TITLE
[FEAT] 경기 영상 버튼 추가

### DIFF
--- a/apps/spectator/app/_components/GameList/Button.tsx
+++ b/apps/spectator/app/_components/GameList/Button.tsx
@@ -8,9 +8,10 @@ import * as styles from './GameList.css';
 type GameButtonProps = {
   id: number;
   state: GameState;
+  hasVideo: boolean;
 };
 
-export default function GameButton({ id, state }: GameButtonProps) {
+export default function GameButton({ id, state, hasVideo }: GameButtonProps) {
   if (state === GAME_STATE.SCHEDULED) {
     return null;
   }
@@ -25,7 +26,7 @@ export default function GameButton({ id, state }: GameButtonProps) {
           응원
         </Link>
       )}
-      {state === GAME_STATE.FINISHED && (
+      {state === GAME_STATE.FINISHED && hasVideo && (
         <Link
           href={{
             pathname: `/game/${id}`,

--- a/apps/spectator/app/_components/GameList/Button.tsx
+++ b/apps/spectator/app/_components/GameList/Button.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { GAME_STATE, TABS_CONFIG } from '@/constants/configs';
 import { GameState } from '@/types/game';
 
 import * as styles from './GameList.css';
@@ -10,13 +11,13 @@ type GameButtonProps = {
 };
 
 export default function GameButton({ id, state }: GameButtonProps) {
-  if (state === 'scheduled') {
+  if (state === GAME_STATE.SCHEDULED) {
     return null;
   }
 
   return (
     <div className={styles.gameButtonArea.root}>
-      {state === 'playing' && (
+      {state === GAME_STATE.PLAYING && (
         <Link
           href={{ pathname: `/game/${id}`, query: { cheer: 'open' } }}
           className={styles.gameButtonArea.cheer}
@@ -24,8 +25,23 @@ export default function GameButton({ id, state }: GameButtonProps) {
           응원
         </Link>
       )}
+      {state === GAME_STATE.FINISHED && (
+        <Link
+          href={{
+            pathname: `/game/${id}`,
+            query: { tab: TABS_CONFIG.HIGHLIGHT },
+          }}
+          className={styles.gameButtonArea.record}
+        >
+          영상
+        </Link>
+      )}
+
       <Link
-        href={{ pathname: `/game/${id}`, query: { tab: 'timeline' } }}
+        href={{
+          pathname: `/game/${id}`,
+          query: { tab: TABS_CONFIG.TIMELINE },
+        }}
         className={styles.gameButtonArea.record}
       >
         기록

--- a/apps/spectator/app/_components/GameList/Card.tsx
+++ b/apps/spectator/app/_components/GameList/Card.tsx
@@ -12,7 +12,7 @@ type GameCardProps = {
 };
 
 export default function GameCard({ info, state }: GameCardProps) {
-  const { id, gameTeams, gameName, startTime } = info;
+  const { id, gameTeams, gameName, startTime, videoId } = info;
 
   return (
     <li className={styles.cardRoot[state]}>
@@ -20,7 +20,7 @@ export default function GameCard({ info, state }: GameCardProps) {
 
       <div className={styles.gameContentArea}>
         <GameInfo gameTeams={gameTeams} gameId={id} state={state} />
-        <GameButton id={id} state={state} />
+        <GameButton id={id} state={state} hasVideo={!!videoId} />
       </div>
     </li>
   );

--- a/apps/spectator/app/_components/GameList/Metadata.tsx
+++ b/apps/spectator/app/_components/GameList/Metadata.tsx
@@ -1,4 +1,5 @@
-import { GameState, GameStateString } from '@/types/game';
+import { GAME_STATE_KR } from '@/constants/configs';
+import { GameState } from '@/types/game';
 import { formatTime } from '@/utils/time';
 
 import * as styles from './GameList.css';
@@ -14,8 +15,9 @@ export default function GameMetadata({
   gameName,
   startTime,
 }: GameMetadataProps) {
-  const gameState = GameStateString[state];
+  const gameState = GAME_STATE_KR[state];
   const startingTime = formatTime(startTime, 'HH:mm');
+
   return (
     // todo: gameName => round 정보로 교체
     <div className={styles.gameMetadata.root}>

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Item/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Item/index.tsx
@@ -3,13 +3,14 @@ import { Icon } from '@hcc/ui';
 import { clsx } from 'clsx';
 import Image from 'next/image';
 
+import { TeamDirection } from '@/types/game';
 import { formatTime } from '@/utils/time';
 
 import * as styles from './Item.css';
 import CheerTalkMenuModal from '../MenuModal';
 
 interface CheerTalkItemProps {
-  direction: 'left' | 'right';
+  direction: TeamDirection;
   logoImageUrl: string;
   cheerTalkId: number;
   content: string;

--- a/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
@@ -6,13 +6,13 @@ import { useState } from 'react';
 
 import { useDebounce } from '@/hooks/useDebounce';
 import useCheerMutation from '@/queries/useCheerMutation';
-import { GameCheerType, GameTeamType } from '@/types/game';
+import { GameCheerType, GameTeamType, TeamDirection } from '@/types/game';
 
 import * as styles from './CheerVS.css';
 
 type CheerTeamProps = (GameCheerType & GameTeamType) & {
   gameId: string;
-  direction: 'left' | 'right';
+  direction: TeamDirection;
   fullCheerCount: number;
 };
 

--- a/apps/spectator/app/game/[id]/_components/Lineup/Captain.tsx
+++ b/apps/spectator/app/game/[id]/_components/Lineup/Captain.tsx
@@ -1,8 +1,10 @@
+import { TeamDirection } from '@/types/game';
+
 import * as styles from './Lineup.css';
 
 type LineupCaptainProps = {
   isCaptain: boolean;
-  direction: 'left' | 'right';
+  direction: TeamDirection;
 };
 
 export default function LineupCaptain({

--- a/apps/spectator/app/game/[id]/_components/Lineup/PlayerList.tsx
+++ b/apps/spectator/app/game/[id]/_components/Lineup/PlayerList.tsx
@@ -1,11 +1,11 @@
-import { GamePlayerType } from '@/types/game';
+import { GamePlayerType, TeamDirection } from '@/types/game';
 
 import LineupCaptain from './Captain';
 import * as styles from './Lineup.css';
 
 type PlayerProps = {
   lineup: GamePlayerType[];
-  direction: 'left' | 'right';
+  direction: TeamDirection;
 };
 
 export default function LineupPlayerList({ lineup, direction }: PlayerProps) {

--- a/apps/spectator/app/game/[id]/page.tsx
+++ b/apps/spectator/app/game/[id]/page.tsx
@@ -6,6 +6,7 @@ import Live from '@/app/_components/Live';
 import CheerTalk from '@/app/game/[id]/_components/CheerTalk';
 import AsyncBoundary from '@/components/AsyncBoundary';
 import Loader from '@/components/Loader';
+import { TABS_CONFIG } from '@/constants/configs';
 
 import Banner from './_components/Banner';
 import BannerFallback from './_components/Banner/Error';
@@ -20,17 +21,17 @@ import * as styles from './page.css';
 
 const tabs = [
   {
-    key: 'lineup',
+    key: TABS_CONFIG.LINEUP,
     label: '라인업',
     renderer: (gameId: string) => <Lineup gameId={gameId} />,
   },
   {
-    key: 'timeline',
+    key: TABS_CONFIG.TIMELINE,
     label: '타임라인',
     renderer: (gameId: string) => <Timeline gameId={gameId} />,
   },
   {
-    key: 'highlight',
+    key: TABS_CONFIG.HIGHLIGHT,
     label: '경기 영상',
     renderer: (gameId: string) => <Highlight gameId={gameId} />,
   },

--- a/apps/spectator/app/page.tsx
+++ b/apps/spectator/app/page.tsx
@@ -3,6 +3,7 @@ import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { ReactElement, Suspense } from 'react';
 
+import { GAME_STATE } from '@/constants/configs';
 import { useLeaguesPrefetch } from '@/queries/useLeague';
 import { useLeagueTeamsPrefetch } from '@/queries/useLeagueTeams';
 import { useSportsPrefetch } from '@/queries/useSports';
@@ -64,15 +65,15 @@ type Games = {
 
 const GAMES: Games[] = [
   {
-    key: 'playing',
+    key: GAME_STATE.PLAYING,
     loadingFallback: <Skeleton />,
   },
   {
-    key: 'scheduled',
+    key: GAME_STATE.SCHEDULED,
     loadingFallback: <Skeleton />,
   },
   {
-    key: 'finished',
+    key: GAME_STATE.FINISHED,
     loadingFallback: <Skeleton />,
   },
 ];

--- a/apps/spectator/constants/configs.ts
+++ b/apps/spectator/constants/configs.ts
@@ -1,0 +1,17 @@
+export const TABS_CONFIG = {
+  LINEUP: 'lineup',
+  TIMELINE: 'timeline',
+  HIGHLIGHT: 'highlight',
+} as const;
+
+export const GAME_STATE = {
+  SCHEDULED: 'scheduled',
+  PLAYING: 'playing',
+  FINISHED: 'finished',
+} as const;
+
+export const GAME_STATE_KR = {
+  SCHEDULED: '예정',
+  PLAYING: '진행 중',
+  FINISHED: '종료',
+} as const;

--- a/apps/spectator/constants/configs.ts
+++ b/apps/spectator/constants/configs.ts
@@ -11,7 +11,7 @@ export const GAME_STATE = {
 } as const;
 
 export const GAME_STATE_KR = {
-  SCHEDULED: '예정',
-  PLAYING: '진행 중',
-  FINISHED: '종료',
+  scheduled: '예정',
+  playing: '진행 중',
+  finished: '종료',
 } as const;

--- a/apps/spectator/constants/gameStatus.ts
+++ b/apps/spectator/constants/gameStatus.ts
@@ -1,7 +1,0 @@
-export const GAME_STATUS = {
-  BEFORE: '경기전',
-  FIRST_HALF: '전반전',
-  SECOND_HALF: '후반전',
-  BREAK_TIME: '쉬는 시간',
-  END: '종료',
-} as const;

--- a/apps/spectator/types/game.ts
+++ b/apps/spectator/types/game.ts
@@ -1,3 +1,5 @@
+import { GAME_STATE } from '@/constants/configs';
+
 export interface GameListType extends GameType {
   id: number;
 }
@@ -40,8 +42,10 @@ type Snapshot = {
   teamImageUrl: string;
 };
 
+export type TeamDirection = 'left' | 'right';
+
 type CommonRecordType = {
-  direction: 'left' | 'right';
+  direction: TeamDirection;
   recordedAt: number;
   gameTeamId: number;
   playerName: string;
@@ -90,7 +94,7 @@ export type GameCheerTalkType = {
 };
 
 export type GameCheerTalkWithTeamInfo = GameCheerTalkType & {
-  direction: 'left' | 'right';
+  direction: TeamDirection;
   logoImageUrl: string;
 };
 
@@ -103,10 +107,4 @@ export type GameVideoType = {
   videoId: string;
 };
 
-export type GameState = 'playing' | 'scheduled' | 'finished';
-
-export const GameStateString = {
-  playing: '진행 중',
-  scheduled: '예정',
-  finished: '종료',
-} as const;
+export type GameState = (typeof GAME_STATE)[keyof typeof GAME_STATE];

--- a/apps/spectator/types/game.ts
+++ b/apps/spectator/types/game.ts
@@ -20,6 +20,7 @@ export interface GameType {
   gameQuarter: string;
   gameName: string;
   sportsName: string;
+  videoId?: string;
 }
 
 export type GameTeamType = {


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #141

## ✅ 작업 내용

- 경기 영상 탭으로 이동할 수 있는 버튼을 추가합니다.
- 각종 타입을 공통으로 관리할 수 있도록 수정합니다.
- 상수 파일을 일괄적으로 관리합니다.

## 📝 참고 자료

## ♾️ 기타
