### PR TITLE
[FEAT] 진행중 경기 카드에 라인업 이동 버튼 추가

### DIFF
--- a/apps/manager/app/_components/PlayingCard/index.tsx
+++ b/apps/manager/app/_components/PlayingCard/index.tsx
@@ -56,9 +56,9 @@ export default function PlayingCard({ leagues }: PlayingCardProps) {
                       fullWidth
                       component={Link}
                       variant="light"
-                      href={`/report`}
+                      href={`/game/${leagueId}/${game.id}/lineup`}
                     >
-                      응원톡
+                      라인업
                     </Button>
                   </Flex>
                 </Card.Footer>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #143 

## ✅ 작업 내용

- 기존의 응원톡 버튼을 라인업 버튼으로 변경하고, 이에 따른 링크 이동을 변경했습니다.