### PR TITLE
[FIX] 서버 시간 동기화 문제 해결

### DIFF
--- a/apps/manager/app/game/[leagueId]/[gameId]/timeline/[recordType]/page.tsx
+++ b/apps/manager/app/game/[leagueId]/[gameId]/timeline/[recordType]/page.tsx
@@ -15,6 +15,7 @@ import useCreateTimelineMutation from '@/hooks/mutations/useCreateTimelineMutati
 import useGameQuarterQuery from '@/hooks/queries/useGameQuarterQuery';
 import useGameTeamsQuery from '@/hooks/queries/useGameTeamsQuery';
 import { LowerRecordType } from '@/types/game';
+import { convertToServerTime } from '@/utils/time';
 
 import ReplacementRecord from './_components/ReplacementRecord';
 import ScoreRecord from './_components/ScoreRecord';
@@ -97,7 +98,7 @@ export default function Page({ params }: PageProps) {
         params: {
           gameId,
           gameTeamId: Number(values.gameTeamId),
-          recordedAt: values.recordedAt.toISOString(),
+          recordedAt: convertToServerTime(values.recordedAt),
           recordedQuarterId: Number(values.recordedQuarterId),
           scoreLineupPlayerId: Number(values.scoreLineupPlayerId),
           score: values.score,

--- a/apps/manager/app/league/[leagueId]/detail/_components/Forms.tsx
+++ b/apps/manager/app/league/[leagueId]/detail/_components/Forms.tsx
@@ -4,17 +4,18 @@ import { Icon } from '@hcc/ui';
 import { Box, Flex, Select, Text, TextInput } from '@mantine/core';
 import { DateInput } from '@mantine/dates';
 import { useForm } from '@mantine/form';
-import { Fragment, useEffect, useState } from 'react';
+import { MutableRefObject, Fragment, useEffect, useState } from 'react';
 
 import AddButton from '@/components/AddButton';
 import { GAMES } from '@/constants/games';
 import useUpdateLeagueMutation from '@/hooks/mutations/useUpdateLeagueMutation';
 import { LeagueDataType, LeagueIdType, SportsDataType } from '@/types/league';
+import { convertToServerTime } from '@/utils/time';
 
 type LeagueDetailFormProps = {
   league: LeagueDataType & LeagueIdType;
   edit: boolean;
-  buttonRef: React.MutableRefObject<() => void>;
+  buttonRef: MutableRefObject<() => void>;
   handleClick: () => void;
 };
 
@@ -48,8 +49,8 @@ export default function LeagueDetailForm({
         {
           leagueData: {
             ...leagueData,
-            startAt: leagueData.startAt.toISOString(),
-            endAt: leagueData.endAt.toISOString(),
+            startAt: convertToServerTime(leagueData.startAt),
+            endAt: convertToServerTime(leagueData.endAt),
           },
           sportData: [...sportData],
           leagueId: leagueId,

--- a/apps/manager/app/league/[leagueId]/game/register/page.tsx
+++ b/apps/manager/app/league/[leagueId]/game/register/page.tsx
@@ -7,6 +7,7 @@ import { useParams, useRouter } from 'next/navigation';
 import Layout from '@/components/Layout';
 import useCreateGameMutation from '@/hooks/mutations/useCreateGameMutation';
 import useLeagueTeamQuery from '@/hooks/queries/useLeagueTeamQuery';
+import { convertToServerTime } from '@/utils/time';
 
 import { GameInfoInput } from './_components/GameInfoInput';
 import TeamSelection from './_components/TeamSelection';
@@ -58,7 +59,7 @@ export default function Page() {
           ...form.values,
           sportsId: Number(values.sportsId),
           round: Number(values.round),
-          startTime: values.startTime.toISOString(),
+          startTime: convertToServerTime(values.startTime),
           teamIds: values.teamIds.map(Number),
           videoId: values.videoId || null,
         },

--- a/apps/manager/app/league/register/_components/LeagueInfo/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueInfo/index.tsx
@@ -1,14 +1,6 @@
 import { CalendarIcon } from '@hcc/icons';
 import { Icon } from '@hcc/ui';
-import {
-  Box,
-  Button,
-  Group,
-  MultiSelect,
-  Select,
-  Text,
-  TextInput,
-} from '@mantine/core';
+import { Box, Button, Group, Select, Text, TextInput } from '@mantine/core';
 import { DateInput } from '@mantine/dates';
 import { useForm } from '@mantine/form';
 import dayjs from 'dayjs';
@@ -16,6 +8,7 @@ import dayjs from 'dayjs';
 import { GAMES } from '@/constants/games';
 import useCreateLeagueMutation from '@/hooks/mutations/useCreateLeagueMutation';
 import { NewLeaguePayload } from '@/types/league';
+import { convertToServerTime } from '@/utils/time';
 
 type LeagueInfoProps = {
   handleLeagueId: (id: number) => void;
@@ -34,7 +27,7 @@ export default function LeagueInfo({
         endAt: '',
         maxRound: -1,
       },
-      sportData: [],
+      sportData: [4],
     },
     validate: {
       leagueData: {
@@ -50,17 +43,29 @@ export default function LeagueInfo({
       sportData: value => !value.length && '종목을 선택해주세요.',
     },
   });
+
   const { mutate: mutateCreateLeague, isPending } = useCreateLeagueMutation();
+
   const handleClickButton = () => {
     if (isPending) return;
     if (form.validate().hasErrors) return;
 
-    mutateCreateLeague(form.values, {
-      onSuccess: ({ leagueId }) => {
-        handleLeagueId(leagueId);
-        nextStep();
+    mutateCreateLeague(
+      {
+        ...form.values,
+        leagueData: {
+          ...form.values.leagueData,
+          startAt: convertToServerTime(form.values.leagueData.startAt),
+          endAt: convertToServerTime(form.values.leagueData.endAt),
+        },
       },
-    });
+      {
+        onSuccess: ({ leagueId }) => {
+          handleLeagueId(leagueId);
+          nextStep();
+        },
+      },
+    );
   };
 
   return (
@@ -86,12 +91,12 @@ export default function LeagueInfo({
         />
       </Group>
 
-      <MultiSelect
-        checkIconPosition="left"
-        label="종목"
-        data={GAMES.SPORTS}
-        {...form.getInputProps('sportData')}
-      />
+      {/*<MultiSelect*/}
+      {/*  checkIconPosition="left"*/}
+      {/*  label="종목"*/}
+      {/*  data={GAMES.SPORTS}*/}
+      {/*  {...form.getInputProps('sportData')}*/}
+      {/*/>*/}
 
       <Select
         label="라운드"

--- a/apps/manager/app/league/register/_components/LeagueInfo/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueInfo/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mantine/core';
 import { DateInput } from '@mantine/dates';
 import { useForm } from '@mantine/form';
+import dayjs from 'dayjs';
 
 import { GAMES } from '@/constants/games';
 import useCreateLeagueMutation from '@/hooks/mutations/useCreateLeagueMutation';
@@ -31,15 +32,28 @@ export default function LeagueInfo({
         name: '',
         startAt: '',
         endAt: '',
-        maxRound: 16,
+        maxRound: -1,
       },
       sportData: [],
     },
+    validate: {
+      leagueData: {
+        name: value => !value && '이름을 입력해주세요.',
+        startAt: value => !value && '시작일을 선택해주세요.',
+        endAt: (value, values) => {
+          if (!value) return '종료일을 선택해주세요.';
+          if (dayjs(value).isBefore(dayjs(values.leagueData.startAt)))
+            return '종료일은 시작일 이후여야 합니다.';
+        },
+        maxRound: value => (!value || value === -1) && '라운드를 입력해주세요.',
+      },
+      sportData: value => !value.length && '종목을 선택해주세요.',
+    },
   });
-
   const { mutate: mutateCreateLeague, isPending } = useCreateLeagueMutation();
   const handleClickButton = () => {
     if (isPending) return;
+    if (form.validate().hasErrors) return;
 
     mutateCreateLeague(form.values, {
       onSuccess: ({ leagueId }) => {

--- a/apps/manager/utils/time.ts
+++ b/apps/manager/utils/time.ts
@@ -1,10 +1,10 @@
-import dayjs, { locale } from 'dayjs';
+import dayjs, { Dayjs, locale } from 'dayjs';
 import 'dayjs/locale/ko';
 
 locale('ko');
 
 export const formatTime = (
-  time: string | Date,
+  time: string | Date | Dayjs,
   format: string,
   locale = 'ko',
 ) => {
@@ -24,4 +24,8 @@ export const isCurrentTimeBetween = (
   end: string | Date,
 ) => {
   return isPastFromNow(start) && isFutureFromNow(end);
+};
+
+export const convertToServerTime = (time: string | Date | Dayjs) => {
+  return formatTime(time, 'YYYY-MM-DDTHH:mm:ss');
 };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #145 

## ✅ 작업 내용

- `convertToServerTime` 함수를 추가하여, 서버에 시간 전송 시 한국 시간으로 전달할 수 있게 변경했습니다.
- 대회 팀 생성 부분에서, 종료 시각이 시작 시각을 넘어갈 수 있는 문제를 해결했습니다. 
- 대회 생성 시 '축구' 종목을 기본적으로 선택되게 하고, 종목 선택 박스를 보이지 않게 했습니다. 

## ♾️ 기타

- 타임라인, 게임 생성 부분에 함수를 적용했습니다. 서버로 시간을 넘기는 부분이 더 있다면 반영하도록 하겠습니다. 
