### PR TITLE
[FIX] 잘못된 video id 수정

### DIFF
--- a/apps/spectator/app/game/[id]/_components/Highlight/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/Highlight/index.tsx
@@ -7,12 +7,12 @@ type HighlightProps = {
 };
 
 export default function Highlight({ gameId, ...props }: HighlightProps) {
-  const { data: videoId } = useVideoQuery(gameId);
+  const { data: info } = useVideoQuery(gameId);
 
   return (
     <iframe
       className={styles.highlight}
-      src={`${process.env.NEXT_PUBLIC_YOUTUBE_VIDEO_BASE_SRC}/${videoId}`}
+      src={`${process.env.NEXT_PUBLIC_YOUTUBE_VIDEO_BASE_SRC}/${info.videoId}`}
       title="Match Video"
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
       allowFullScreen


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #152 

## ✅ 작업 내용

- 쿼리 훅 함수의 반환값으로 전달 받는 data는 videoId라는 key를 갖는 객체입니다. 하지만 이를 그대로 사용하고 있어, 에러가 발생하고 있습니다.
- 이를 해결합니다.

기존
```ts
const { data: videoId } = useVideoQuery(gameId);

`youtube.com/~~~~~/${videoId}`
```
변경
```ts
const { data: info} = useVideoQuery(gameId);

`youtube.com/~~~~~/${info.videoId}`
```


## 📝 참고 자료

## ♾️ 기타
