### PR TITLE
[FIX] 대회 정보에 종목과 라운드가 보이지 않는 문제 해결

### DIFF
--- a/apps/manager/app/game/[leagueId]/[gameId]/detail/page.tsx
+++ b/apps/manager/app/game/[leagueId]/[gameId]/detail/page.tsx
@@ -11,6 +11,7 @@ import useUpdateGameMutation from '@/hooks/mutations/useUpdateGameMutation';
 import useGameDetailQuery from '@/hooks/queries/useGameDetailQuery';
 import useGameTeamsQuery from '@/hooks/queries/useGameTeamsQuery';
 import { GameUpdatePayload } from '@/types/game';
+import { convertToServerTime } from '@/utils/time';
 
 export default function GameDetail() {
   const params = useParams();
@@ -68,7 +69,7 @@ export default function GameDetail() {
         gameName: values.gameName,
         videoId: values.videoId || null,
         round: Number(values.round),
-        startTime: values.startTime.toISOString(),
+        startTime: convertToServerTime(values.startTime),
         gameQuarter: values.gameQuarter,
         state: values.state as 'playing' | 'scheduled' | 'finished',
       };

--- a/apps/manager/app/league/[leagueId]/detail/page.tsx
+++ b/apps/manager/app/league/[leagueId]/detail/page.tsx
@@ -5,7 +5,6 @@ import { useParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
 import Layout from '@/components/Layout';
-import useLeagueDetailQuery from '@/hooks/queries/useLeagueDetailQuery';
 
 import LeagueDetailForm from './_components/Forms';
 
@@ -13,7 +12,6 @@ export default function LeagueDetail() {
   const [edit, setEdit] = useState(false);
   const params = useParams();
   const leagueId = params.leagueId;
-  const { data: league } = useLeagueDetailQuery(Number(leagueId));
   const buttonRef = useRef(() => {});
 
   useEffect(() => {
@@ -22,8 +20,6 @@ export default function LeagueDetail() {
 
     buttonRef.current = () => setEdit(true);
   }, [edit]);
-
-  if (!league) return null;
 
   const RightButton = () => (
     <Button
@@ -38,7 +34,7 @@ export default function LeagueDetail() {
   return (
     <Layout navigationTitle={'대회 정보 관리'} navigationMenu={<RightButton />}>
       <LeagueDetailForm
-        league={league}
+        leagueId={Number(leagueId)}
         edit={edit}
         handleClick={() => setEdit(false)}
         buttonRef={buttonRef}

--- a/apps/manager/app/league/register/_components/LeagueInfo/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueInfo/index.tsx
@@ -26,6 +26,7 @@ export default function LeagueInfo({
         startAt: '',
         endAt: '',
         maxRound: -1,
+        inProgressRound: -1,
       },
       sportData: [4],
     },
@@ -57,6 +58,7 @@ export default function LeagueInfo({
           ...form.values.leagueData,
           startAt: convertToServerTime(form.values.leagueData.startAt),
           endAt: convertToServerTime(form.values.leagueData.endAt),
+          inProgressRound: form.values.leagueData.maxRound,
         },
       },
       {

--- a/apps/manager/types/league.ts
+++ b/apps/manager/types/league.ts
@@ -9,6 +9,7 @@ export type LeagueDataType = {
   startAt: string;
   endAt: string;
   maxRound: number;
+  inProgressRound: number;
 };
 
 export type SportIdType = {
@@ -21,7 +22,7 @@ export type SportsCategoriesType = SportIdType & SportsQuarterType;
 
 export type LeagueType = LeagueIdType &
   LeagueDataType & {
-    InProgressRound: number;
+    inProgressRound: number;
     maxRound: number;
   };
 export type LeagueListType = Record<StateType, LeagueType[]>;


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #148

## ✅ 작업 내용

- 대회 정보 관리 페이지 진입 시 폼에 리그 데이터를 삽입하도록 변경했습니다.
- 종목은 4(축구)로 고정하였으며, 진행중인 라운드(inProgressRound)를 추가했습니다. 
- 경기 수정 부분에 #147 PR에서 놓친 부분을 수정했습니다. 

## ♾️ 기타

- 폼 데이터 타입과 initial data를 `types/form.ts` 과 같은 파일에서 변수로 관리하면 어떨까요?
