### PR TITLE
[FIX] 초기 라운드 쿼리 반영

### DIFF
--- a/apps/spectator/app/_components/GameList/index.tsx
+++ b/apps/spectator/app/_components/GameList/index.tsx
@@ -15,14 +15,19 @@ import * as styles from './GameList.css';
 type GameListProps = {
   state: GameState;
   initialLeagueId: string;
+  initialRound: number;
 };
 
-export default function GameList({ state, initialLeagueId }: GameListProps) {
+export default function GameList({
+  state,
+  initialLeagueId,
+  initialRound,
+}: GameListProps) {
   const searchParams = useSearchParams();
   const { data: groupedGameList, ...rest } = useGameList({
     league_id: searchParams.get('league') || initialLeagueId,
     sport_id: searchParams.get('sports') || undefined,
-    round: searchParams.get('round') || undefined,
+    round: searchParams.get('round') || initialRound.toString(),
     league_team_id: searchParams.get('leagueTeam') || undefined,
     state,
   });

--- a/apps/spectator/app/page.tsx
+++ b/apps/spectator/app/page.tsx
@@ -27,6 +27,9 @@ export default async function Page({ searchParams }: PageProps) {
   const inProgress =
     leagues.find(league => league.isInProgress) || leagues?.[0];
   const initialLeagueId = Number(searchParams.league) || inProgress?.leagueId;
+  const initialRound = inProgress.isInProgress
+    ? inProgress.inProgressRound
+    : inProgress.maxRound;
 
   await useLeagueTeamsPrefetch(initialLeagueId);
   await useSportsPrefetch(initialLeagueId);
@@ -49,6 +52,7 @@ export default async function Page({ searchParams }: PageProps) {
         <GameList
           key={game.key}
           state={game.key}
+          initialRound={initialRound}
           initialLeagueId={initialLeagueId.toString()}
         />
       ))}


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #162 

## ✅ 작업 내용

- 현재 initial round query parameter가 제대로 반영되고 있지 않습니다.
- 대회가 현재 진행 중이라면(isInProgress) 현재 진행 중인 라운드(inProgress)를, 그렇지 않다면 최대 라운드(maxRound)를 추가합니다.

## 📝 참고 자료

![image](https://github.com/hufscheer/client_v2/assets/88662637/e8b09e11-315b-4fed-828d-66a77013bdd7)

round query parameter가 없어도 기존에 포함되어 있던 결승 게임 정보가 표시되지 않습니다.

## ♾️ 기타
