### PR TITLE
[STYLE] 관객 앱 UI 개선

### DIFF
--- a/apps/spectator/app/game/[id]/_components/Banner/Banner.css.ts
+++ b/apps/spectator/app/game/[id]/_components/Banner/Banner.css.ts
@@ -31,6 +31,10 @@ export const logo = style({
 
 export const teamName = style({
   fontWeight: 'bold',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  maxWidth: rem(60),
 });
 
 export const scoreBoard = style({

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Banner/Banner.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Banner/Banner.css.ts
@@ -58,6 +58,7 @@ export const banner = styleVariants({
     fontWeight: 500,
     borderRadius: rem(8),
     backgroundColor: theme.colors.primary[3],
+    whiteSpace: 'nowrap',
   },
   gameStartTime: {
     ...theme.textVariants.xs,

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/EntryButton/EntryButton.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/EntryButton/EntryButton.css.ts
@@ -5,6 +5,7 @@ export const entryContainer = style({
   position: 'fixed',
   bottom: rem(16),
   right: rem(16),
+  zIndex: 100,
 });
 
 export const entryButtonContent = style({

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Fallback/Fallback.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Fallback/Fallback.css.ts
@@ -14,7 +14,7 @@ export const talkBox = style({
   padding: `${theme.spaces.xs} ${theme.spaces.sm}`,
   borderRadius: rem(15),
   backgroundColor: '#F2F2F7',
-  ...theme.textVariants.xs,
+  ...theme.textVariants.sm,
 });
 
 export const empty = styleVariants({

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Form/Form.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Form/Form.css.ts
@@ -5,8 +5,7 @@ export const form = style({
   position: 'relative',
   display: 'flex',
   flexDirection: 'column',
-  padding: rem(16),
-  paddingTop: rem(8),
+  padding: `${rem(8)} ${rem(16)}`,
   gap: rem(8),
 });
 
@@ -40,7 +39,6 @@ export const radioInput = style({
 
 export const cheerTalkInputContainer = style({
   display: 'flex',
-  gap: rem(8),
   alignItems: 'center',
 });
 
@@ -51,6 +49,7 @@ export const cheerTalkInput = style({
   borderRadius: rem(12),
   backgroundColor: theme.colors.gray[1],
   ...theme.textVariants.default,
+  transform: 'scale(0.9)',
 });
 
 export const cheerTalkSendButton = style({

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Form/Form.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Form/Form.css.ts
@@ -20,7 +20,7 @@ export const radioField = style({
   alignItems: 'center',
   gap: rem(4),
   cursor: 'pointer',
-  ...theme.textVariants.xs,
+  ...theme.textVariants.sm,
 });
 
 export const radioInput = style({
@@ -46,11 +46,11 @@ export const cheerTalkInputContainer = style({
 
 export const cheerTalkInput = style({
   flex: '1',
-  padding: `${rem(8)} ${rem(12)}`,
+  padding: `${theme.spaces.sm} ${theme.spaces.default}`,
   color: theme.colors.gray[4],
   borderRadius: rem(12),
   backgroundColor: theme.colors.gray[1],
-  ...theme.textVariants.xs,
+  ...theme.textVariants.default,
 });
 
 export const cheerTalkSendButton = style({
@@ -60,8 +60,8 @@ export const cheerTalkSendButton = style({
 });
 
 export const cheerTalkSendIcon = style({
-  width: rem(20),
-  height: rem(20),
+  width: rem(24),
+  height: rem(24),
   color: theme.colors.secondary[2],
 });
 

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Item/Item.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Item/Item.css.ts
@@ -47,7 +47,8 @@ export const item = styleVariants({
     padding: `${theme.spaces.xs} ${theme.spaces.sm}`,
     borderRadius: rem(15),
     backgroundColor: '#F2F2F7',
-    ...theme.textVariants.xs,
+    ...theme.textVariants.sm,
+    color: theme.colors.black,
   },
   blocked: {
     color: theme.colors.gray[4],

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/OnAir/OnAir.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/OnAir/OnAir.css.ts
@@ -1,0 +1,32 @@
+import { rem } from '@hcc/styles';
+import { keyframes, style } from '@vanilla-extract/css';
+
+export const billboard = style({
+  display: 'flex',
+  flexDirection: 'column-reverse',
+  height: rem(30),
+  overflow: 'hidden',
+  position: 'relative',
+});
+
+const slideUp = keyframes({
+  '0%': {
+    maxHeight: '100vmax',
+  },
+  '80%': {
+    transform: 'scale(1.1)',
+  },
+  '100%': {
+    transform: 'scale(1)',
+    maxHeight: '100vmax',
+    overflow: 'visible',
+  },
+});
+
+export const message = style({
+  transformOrigin: '0 100%',
+  transform: 'scale(0)',
+  maxHeight: 0,
+  overflow: 'hidden',
+  animation: `${slideUp} 0.15s ease-out 0s forwards`,
+});

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/OnAir/OnAir.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/OnAir/OnAir.css.ts
@@ -1,5 +1,5 @@
 import { rem } from '@hcc/styles';
-import { keyframes, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 
 export const billboard = style({
   display: 'flex',
@@ -7,26 +7,4 @@ export const billboard = style({
   height: rem(30),
   overflow: 'hidden',
   position: 'relative',
-});
-
-const slideUp = keyframes({
-  '0%': {
-    maxHeight: '100vmax',
-  },
-  '80%': {
-    transform: 'scale(1.1)',
-  },
-  '100%': {
-    transform: 'scale(1)',
-    maxHeight: '100vmax',
-    overflow: 'visible',
-  },
-});
-
-export const message = style({
-  transformOrigin: '0 100%',
-  transform: 'scale(0)',
-  maxHeight: 0,
-  overflow: 'hidden',
-  animation: `${slideUp} 0.15s ease-out 0s forwards`,
 });

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/OnAir/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/OnAir/index.tsx
@@ -1,5 +1,8 @@
+import { motion, AnimatePresence } from 'framer-motion';
+
 import { GameCheerTalkWithTeamInfo } from '@/types/game';
 
+import * as styles from './OnAir.css';
 import CheerTalkFallback from '../Fallback';
 import CheerTalkItem from '../Item';
 
@@ -10,5 +13,42 @@ type CheerTalkInRealProps = {
 export default function CheerTalkOnAir({ cheerTalk }: CheerTalkInRealProps) {
   if (!cheerTalk.length || !cheerTalk.at(-1)) return <CheerTalkFallback />;
 
-  return <CheerTalkItem {...(cheerTalk.at(-1) as GameCheerTalkWithTeamInfo)} />;
+  const transition = {
+    type: 'spring',
+    stiffness: 200,
+    mass: 0.2,
+    damping: 20,
+  };
+
+  const variants = {
+    initial: {
+      opacity: 0,
+      y: 300,
+    },
+    enter: {
+      opacity: 1,
+      y: 0,
+      transition,
+    },
+  };
+
+  return (
+    <AnimatePresence initial={false}>
+      <ol className={styles.billboard}>
+        <motion.div
+          key={cheerTalk.at(-1)?.cheerTalkId}
+          initial="initial"
+          animate="enter"
+          variants={variants}
+          transition={{
+            y: { type: 'spring', stiffness: 200, damping: 20, mass: 0.2 },
+            opacity: { duration: 0.2 },
+          }}
+          layout
+        >
+          <CheerTalkItem {...(cheerTalk.at(-1) as GameCheerTalkWithTeamInfo)} />
+        </motion.div>
+      </ol>
+    </AnimatePresence>
+  );
 }

--- a/apps/spectator/app/game/[id]/_components/Lineup/Lineup.css.ts
+++ b/apps/spectator/app/game/[id]/_components/Lineup/Lineup.css.ts
@@ -49,6 +49,9 @@ const color = {
 const playerBase = style({
   ...theme.textVariants.sm,
   color: theme.colors.gray[6],
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
 });
 
 export const player = styleVariants({
@@ -60,6 +63,7 @@ export const player = styleVariants({
     gap: theme.spaces.default,
 
     paddingInline: theme.spaces.sm,
+    height: rem(32),
   },
   wrapper: {
     display: 'flex',
@@ -71,6 +75,8 @@ export const player = styleVariants({
     {
       fontWeight: 600,
       marginRight: theme.spaces.xxs,
+
+      maxWidth: rem(64),
     },
   ],
 });
@@ -78,9 +84,8 @@ export const player = styleVariants({
 const backNumberBase = style({
   ...theme.textVariants.default,
   backgroundColor: theme.colors.white,
+
   display: 'flex',
-  width: rem(32),
-  height: rem(32),
   justifyContent: 'center',
   alignItems: 'center',
 });
@@ -104,7 +109,7 @@ const captainBase = style({
   borderRadius: rem(4),
   padding: theme.spaces.xxs,
 
-  fontSize: theme.textVariants.sm.fontSize,
+  fontSize: theme.textVariants.xxs.fontSize,
   fontWeight: 700,
   color: theme.colors.white,
 });

--- a/apps/spectator/package.json
+++ b/apps/spectator/package.json
@@ -26,6 +26,7 @@
     "@vercel/analytics": "^1.1.2",
     "axios": "^1.6.5",
     "dayjs": "^1.11.10",
+    "framer-motion": "^11.0.5",
     "next": "^14.0.4",
     "pretendard": "^1.3.9",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^18.4.4
-        version: 18.4.4(@types/node@20.11.16)(typescript@5.4.2)
+        version: 18.4.4(@types/node@20.11.16)(typescript@5.4.3)
       '@commitlint/config-conventional':
         specifier: ^18.4.4
         version: 18.4.4
@@ -177,6 +177,9 @@ importers:
       dayjs:
         specifier: ^1.11.10
         version: 1.11.10
+      framer-motion:
+        specifier: ^11.0.5
+        version: 11.0.5(react-dom@18.2.0)(react@18.2.0)
       next:
         specifier: ^14.0.4
         version: 14.0.4(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
@@ -1907,14 +1910,14 @@ packages:
     dev: true
     optional: true
 
-  /@commitlint/cli@18.4.4(@types/node@20.11.16)(typescript@5.4.2):
+  /@commitlint/cli@18.4.4(@types/node@20.11.16)(typescript@5.4.3):
     resolution: {integrity: sha512-Ro3wIo//fV3XiV1EkdpHog6huaEyNcUAVrSmtgKqYM5g982wOWmP4FXvEDFwRMVgz878CNBvvCc33dMZ5AQJ/g==}
     engines: {node: '>=v18'}
     hasBin: true
     dependencies:
       '@commitlint/format': 18.4.4
       '@commitlint/lint': 18.4.4
-      '@commitlint/load': 18.4.4(@types/node@20.11.16)(typescript@5.4.2)
+      '@commitlint/load': 18.4.4(@types/node@20.11.16)(typescript@5.4.3)
       '@commitlint/read': 18.4.4
       '@commitlint/types': 18.4.4
       execa: 5.1.1
@@ -1985,7 +1988,7 @@ packages:
       '@commitlint/types': 18.4.4
     dev: true
 
-  /@commitlint/load@18.4.4(@types/node@20.11.16)(typescript@5.4.2):
+  /@commitlint/load@18.4.4(@types/node@20.11.16)(typescript@5.4.3):
     resolution: {integrity: sha512-RaDIa9qwOw2xRJ3Jr2DBXd14rmnHJIX2XdZF4kmoF1rgsg/+7cvrExLSUNAkQUNimyjCn1b/bKX2Omm+GdY0XQ==}
     engines: {node: '>=v18'}
     dependencies:
@@ -1994,8 +1997,8 @@ packages:
       '@commitlint/resolve-extends': 18.4.4
       '@commitlint/types': 18.4.4
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.4.2)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.11.16)(cosmiconfig@8.3.6)(typescript@5.4.2)
+      cosmiconfig: 8.3.6(typescript@5.4.3)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.11.16)(cosmiconfig@8.3.6)(typescript@5.4.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -6897,7 +6900,7 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
 
-  /cosmiconfig-typescript-loader@5.0.0(@types/node@20.11.16)(cosmiconfig@8.3.6)(typescript@5.4.2):
+  /cosmiconfig-typescript-loader@5.0.0(@types/node@20.11.16)(cosmiconfig@8.3.6)(typescript@5.4.3):
     resolution: {integrity: sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==}
     engines: {node: '>=v16'}
     peerDependencies:
@@ -6906,9 +6909,9 @@ packages:
       typescript: '>=4'
     dependencies:
       '@types/node': 20.11.16
-      cosmiconfig: 8.3.6(typescript@5.4.2)
+      cosmiconfig: 8.3.6(typescript@5.4.3)
       jiti: 1.21.0
-      typescript: 5.4.2
+      typescript: 5.4.3
     dev: true
 
   /cosmiconfig@8.3.6(typescript@5.3.3):
@@ -6927,7 +6930,7 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /cosmiconfig@8.3.6(typescript@5.4.2):
+  /cosmiconfig@8.3.6(typescript@5.4.3):
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -6940,7 +6943,7 @@ packages:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
-      typescript: 5.4.2
+      typescript: 5.4.3
     dev: true
 
   /create-require@1.1.1:
@@ -12766,8 +12769,8 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.4.2:
-    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
+  /typescript@5.4.3:
+    resolution: {integrity: sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #160 

## ✅ 작업 내용

- 경기 상세페이지 상단 배너 팀명이 긴 경우 말줄임표가 되도록 하였습니다.
- 응원톡 상단 배너에 경기 쿼터(시작 전 등) 글자가 쪼개지지 않도록 `whiteSpace: 'nowrap'` 을 추가했습니다.
- 경기 상세페이지 라인업의 주장 표시에 응원톡 엔트리버튼이 묻히는 현상을 zIndex 추가로 해결했습니다.
- 경기 상세페이지 실시간 응원톡이 업데이트 될 때 spring 애니메이션을 추가했습니다.

## 📝 참고 자료



## ♾️ 기타

- spring 애니메이션의 경우 애니메이션 자체는 만족스러우나, 이전 응원톡이 위로 밀려나고 새 응원톡이 아래에서 올라오도록 제작하고 싶었지만 시간 문제로 우선 새 응원톡이 갱신될 때마다 새롭게 아래에서 튀어나오는 정도로만 제작했습니다.
