### PR TITLE
[FEAT] 대회 팀 관리에 삭제 기능 추가 및 로고 수정

### DIFF
--- a/apps/manager/api/league.ts
+++ b/apps/manager/api/league.ts
@@ -65,6 +65,12 @@ export const updateLeagueTeam = async (teamId: string, payload: FormData) => {
   return data;
 };
 
+export const deleteLeagueTeam = async (teamId: string) => {
+  const { data } = await instance.delete(`/league-teams/${teamId}/delete/`);
+
+  return data;
+};
+
 export const getLeagueTeamPlayers = async (teamId: string) => {
   const { data } = await instance.get<LeaguePlayerWithIDPayload[]>(
     `/league-teams/${teamId}/player/all/`,

--- a/apps/manager/api/league.ts
+++ b/apps/manager/api/league.ts
@@ -103,13 +103,7 @@ export const createLeaguePlayers = async (
   teamId: number,
   payload: LeaguePlayerPayload[],
 ) => {
-  await instance.post(
-    `/league-teams/${teamId}/player/`,
-    payload.map(({ playerNumber, ...player }) => ({
-      ...player,
-      number: playerNumber,
-    })),
-  );
+  await instance.post(`/league-teams/${teamId}/player/`, payload);
 };
 
 export const deleteLeague = async (body: DeleteLeaguePayload) => {

--- a/apps/manager/api/league.ts
+++ b/apps/manager/api/league.ts
@@ -88,12 +88,11 @@ export const getPlayersByTeamId = async (teamId: string) => {
 };
 
 export const updateLeagueTeamPlayers = async (
-  teamId: string,
   teamPlayerId: string,
   payload: LeaguePlayerPayload,
 ) => {
   const { data } = await instance.put(
-    `/league-teams/${teamId}/player/${teamPlayerId}/`,
+    `/league-teams/player/${teamPlayerId}/`,
     payload,
   );
 

--- a/apps/manager/app/league/[leagueId]/team/[teamId]/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/[teamId]/page.tsx
@@ -15,12 +15,12 @@ import TeamForm from '../_components/TeamForm';
 
 type LeagueTeamFormValues = {
   name: string;
-  logo: File | null;
+  logo: File | string | null;
   players: {
     id: number;
     name: string;
     description: string;
-    playerNumber: number;
+    number: number;
   }[];
 };
 
@@ -46,12 +46,12 @@ export default function LeagueTeamEdit() {
     if (team && players) {
       form.setValues({
         name: team.name,
-        logo: null,
+        logo: team.logoImageUrl,
         players: players.map(player => ({
           id: player.id,
           name: player.name,
           description: player.description || '',
-          playerNumber: player.number || 0,
+          number: player.number || 0,
         })),
       });
     }
@@ -73,26 +73,20 @@ export default function LeagueTeamEdit() {
 
     const payload = new FormData();
     payload.append('name', name);
-    payload.append('logo', logo as File);
+    if (typeof logo === 'string') payload.append('logo', logo);
+    else payload.append('logo', logo);
 
-    updateLeagueTeam(
-      { teamId, payload },
-      {
-        onSuccess: () => {
-          players.map(player => {
-            updateLeagueTeamPlayers({
-              teamId: teamId,
-              teamPlayerId: player.id.toString(),
-              payload: {
-                name: player.name,
-                description: player.description,
-                playerNumber: player.playerNumber,
-              },
-            });
-          });
+    updateLeagueTeam({ teamId, payload });
+    players.map(player => {
+      updateLeagueTeamPlayers({
+        teamPlayerId: player.id.toString(),
+        payload: {
+          name: player.name,
+          description: player.description,
+          number: player.number,
         },
-      },
-    );
+      });
+    });
     setEdit(edit => !edit);
   };
 

--- a/apps/manager/app/league/[leagueId]/team/_components/TeamForm.tsx
+++ b/apps/manager/app/league/[leagueId]/team/_components/TeamForm.tsx
@@ -11,12 +11,12 @@ type TeamFormProps = {
   form: ReturnType<
     typeof useForm<{
       name: string;
-      logo: File | null;
+      logo: File | string | null;
       players: {
         id: number;
         name: string;
         description: string;
-        playerNumber: number;
+        number: number;
       }[];
     }>
   >;
@@ -35,7 +35,7 @@ export default function TeamForm({ form, edit = true }: TeamFormProps) {
       id: -1,
       name: '',
       description: '',
-      playerNumber: 0,
+      number: 0,
     });
     form.setFieldValue('players', players);
   };
@@ -58,7 +58,11 @@ export default function TeamForm({ form, edit = true }: TeamFormProps) {
       >
         {form.values.logo && (
           <Image
-            src={URL.createObjectURL(form.values.logo)}
+            src={
+              typeof form.values.logo === 'string'
+                ? form.values.logo
+                : URL.createObjectURL(form.values.logo)
+            }
             alt="Team logo"
             width={100}
             height={100}
@@ -92,7 +96,7 @@ export default function TeamForm({ form, edit = true }: TeamFormProps) {
             <TextInput
               placeholder="선수 번호"
               type="number"
-              {...form.getInputProps(`players.${index}.playerNumber`)}
+              {...form.getInputProps(`players.${index}.number`)}
               disabled={!edit}
             />
           </Grid.Col>

--- a/apps/manager/app/league/[leagueId]/team/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/page.tsx
@@ -8,6 +8,7 @@ import { MouseEvent, useState } from 'react';
 import AddButton from '@/components/AddButton';
 import Card from '@/components/Card';
 import Layout from '@/components/Layout';
+import useDeleteLeagueTeamMutation from '@/hooks/mutations/useDeleteLeagueTeamMutation';
 import useLeagueTeamQuery from '@/hooks/queries/useLeagueTeamQuery';
 
 import LeagueTeamActionIcon from './_components/ActionIcon';
@@ -19,18 +20,21 @@ export default function Page() {
   const leagueId = params.leagueId as string;
 
   const { data: leagueTeams, refetch } = useLeagueTeamQuery(leagueId);
-
+  const { mutate: deleteLeagueTeam } = useDeleteLeagueTeamMutation();
   if (!leagueTeams) return null;
 
   const handleClickCard = async (
     e: MouseEvent<HTMLButtonElement>,
-    teamId: number,
+    teamId: string,
   ) => {
     if (!edit) return;
 
     e.preventDefault();
-    alert(teamId);
-    await refetch();
+    deleteLeagueTeam(teamId, {
+      onSuccess: () => refetch(),
+    });
+
+    alert('삭제되었습니다.');
   };
 
   const handleClickMenuButton = () => {
@@ -62,7 +66,7 @@ export default function Page() {
                 <Card.Title text="semibold" style={{ flex: 1 }}>
                   {team.name}
                 </Card.Title>
-                <Card.Action onClick={e => handleClickCard(e, team.id)}>
+                <Card.Action onClick={e => handleClickCard(e, String(team.id))}>
                   <LeagueTeamActionIcon edit={edit} />
                 </Card.Action>
               </Card.Content>

--- a/apps/manager/app/league/[leagueId]/team/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/page.tsx
@@ -18,15 +18,19 @@ export default function Page() {
   const params = useParams();
   const leagueId = params.leagueId as string;
 
-  const { data: leagueTeams } = useLeagueTeamQuery(leagueId);
+  const { data: leagueTeams, refetch } = useLeagueTeamQuery(leagueId);
 
   if (!leagueTeams) return null;
 
-  const handleClickCard = (e: MouseEvent<HTMLButtonElement>) => {
+  const handleClickCard = async (
+    e: MouseEvent<HTMLButtonElement>,
+    teamId: number,
+  ) => {
     if (!edit) return;
 
     e.preventDefault();
-    alert('팀 삭제 API');
+    alert(teamId);
+    await refetch();
   };
 
   const handleClickMenuButton = () => {
@@ -58,7 +62,7 @@ export default function Page() {
                 <Card.Title text="semibold" style={{ flex: 1 }}>
                   {team.name}
                 </Card.Title>
-                <Card.Action onClick={handleClickCard}>
+                <Card.Action onClick={e => handleClickCard(e, team.id)}>
                   <LeagueTeamActionIcon edit={edit} />
                 </Card.Action>
               </Card.Content>

--- a/apps/manager/app/league/[leagueId]/team/register/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/register/page.tsx
@@ -56,7 +56,7 @@ export default function Page() {
             { teamId: r.teamIds[0], payload: values.players },
             {
               onSuccess: () => {
-                router.push(`/league/${leagueId}/team`);
+                router.back();
               },
             },
           );

--- a/apps/manager/app/league/[leagueId]/team/register/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/register/page.tsx
@@ -13,12 +13,12 @@ import TeamForm from '../_components/TeamForm';
 
 type LeagueTeamFormValues = {
   name: string;
-  logo: File | null;
+  logo: File | string | null;
   players: {
     id: number;
     name: string;
     description: string;
-    playerNumber: number;
+    number: number;
   }[];
 };
 
@@ -34,7 +34,7 @@ export default function Page() {
     initialValues: {
       name: '',
       logo: null,
-      players: [{ id: -1, name: '', description: '', playerNumber: 0 }],
+      players: [{ id: -1, name: '', description: '', number: 0 }],
     },
   });
 

--- a/apps/manager/app/league/register/_components/LeagueTeamPlayers/index.tsx
+++ b/apps/manager/app/league/register/_components/LeagueTeamPlayers/index.tsx
@@ -16,7 +16,7 @@ export default function LeagueTeamPlayers({
 }: LeagueTeamPlayersProps) {
   const form = useForm({
     initialValues: {
-      players: [{ name: '', description: null, playerNumber: null }],
+      players: [{ name: '', description: null, number: null }],
     },
     validate: {
       players: {
@@ -29,7 +29,7 @@ export default function LeagueTeamPlayers({
     form.insertListItem('players', {
       name: '',
       description: null,
-      playerNumber: null,
+      number: null,
     });
   };
 
@@ -68,7 +68,7 @@ export default function LeagueTeamPlayers({
             <Grid.Col span={3}>
               <TextInput
                 type="number"
-                {...form.getInputProps(`players.${index}.playerNumber`)}
+                {...form.getInputProps(`players.${index}.number`)}
                 placeholder="번호"
               />
             </Grid.Col>

--- a/apps/manager/app/league/register/page.tsx
+++ b/apps/manager/app/league/register/page.tsx
@@ -41,7 +41,7 @@ export default function Register() {
             nextStep={() => handleLeagueId(2)}
           />
         </Stepper.Step>
-        <Stepper.Step label="대회 로고">
+        <Stepper.Step label="팀 선수">
           <LeagueTeamPlayers
             teamId={teamId}
             prevStep={() => handleLeagueId(1)}

--- a/apps/manager/hooks/mutations/useCreateLeagueTeamMutation.ts
+++ b/apps/manager/hooks/mutations/useCreateLeagueTeamMutation.ts
@@ -14,10 +14,8 @@ export default function useCreateLeagueTeamMutation() {
   return useMutation({
     mutationFn: ({ leagueId, payload }: Params) =>
       createLeagueTeam(leagueId, payload),
-    onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: [LEAGUE_TEAM_QUERY_KEY, { leagueId: variables.leagueId }],
-      });
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [LEAGUE_TEAM_QUERY_KEY] });
     },
   });
 }

--- a/apps/manager/hooks/mutations/useDeleteLeagueTeamMutation.ts
+++ b/apps/manager/hooks/mutations/useDeleteLeagueTeamMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deleteLeagueTeam } from '@/api/league';
+import { LEAGUE_TEAM_QUERY_KEY } from '@/hooks/queries/useLeagueTeamQuery';
+
+export default function useDeleteLeagueTeamMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteLeagueTeam,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [LEAGUE_TEAM_QUERY_KEY] });
+    },
+  });
+}

--- a/apps/manager/hooks/mutations/useUpdateLeagueTeamPlayersMutation.ts
+++ b/apps/manager/hooks/mutations/useUpdateLeagueTeamPlayersMutation.ts
@@ -8,15 +8,9 @@ export default function useUpdateLeagueTeamPlayersMutation() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (variables: {
-      teamId: string;
       teamPlayerId: string;
       payload: LeaguePlayerPayload;
-    }) =>
-      updateLeagueTeamPlayers(
-        variables.teamId,
-        variables.teamPlayerId,
-        variables.payload,
-      ),
+    }) => updateLeagueTeamPlayers(variables.teamPlayerId, variables.payload),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [LEAGUE_TEAM_PLAYERS_QUERY_KEY],

--- a/apps/manager/hooks/queries/useLeagueTeamQuery.ts
+++ b/apps/manager/hooks/queries/useLeagueTeamQuery.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getTeamListByLeagueId } from '@/api/team';
 
-export const LEAGUE_TEAM_QUERY_KEY = 'leagueTeamQuery';
+export const LEAGUE_TEAM_QUERY_KEY = 'league-team';
 export default function useLeagueTeamQuery(leagueId: string) {
   const { data, error, refetch } = useQuery({
     queryKey: [LEAGUE_TEAM_QUERY_KEY, { leagueId }],

--- a/apps/manager/hooks/queries/useLeagueTeamQuery.ts
+++ b/apps/manager/hooks/queries/useLeagueTeamQuery.ts
@@ -4,12 +4,12 @@ import { getTeamListByLeagueId } from '@/api/team';
 
 export const LEAGUE_TEAM_QUERY_KEY = 'leagueTeamQuery';
 export default function useLeagueTeamQuery(leagueId: string) {
-  const { data, error } = useQuery({
+  const { data, error, refetch } = useQuery({
     queryKey: [LEAGUE_TEAM_QUERY_KEY, { leagueId }],
     queryFn: () => getTeamListByLeagueId(leagueId),
   });
 
   if (error) throw error;
 
-  return { data };
+  return { data, refetch };
 }

--- a/apps/manager/types/league.ts
+++ b/apps/manager/types/league.ts
@@ -44,10 +44,9 @@ export type LeagueRegisterDataType = {
 export type LeaguePlayerPayload = {
   name: string;
   description: string | null;
-  playerNumber: number | null;
+  number: number | null;
 };
 
 export type LeaguePlayerWithIDPayload = LeaguePlayerPayload & {
   id: number;
-  number?: number;
 };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #167

## ✅ 작업 내용

- 대회 팀 삭제 기능을 추가했습니다.
- 대회 팀 정보 페이지에 팀 로고가 나타나지 않는 오류를 해결했습니다. 
- 팀 선수의 등번호와 이름이 변경되지 않는 오류를 해결했습니다. 
- 대회 생성 페이지에서 '대회 로고' 텍스트를 '팀 선수'로 변경했습니다.

## 📝 참고 자료

- 대회 팀 업데이트 API가 명세와 다르게 동작하고 있어, 로고 변경을 하지 않으면 팀 이름이 변경되지 않습니다. 이 부분은 백엔드 쪽에서 해결하면 같이 해결될 거 같습니다. 