### PR TITLE
[REFACTOR] 불필요한 스포츠 상수 제거

### DIFF
--- a/apps/manager/constants/games.ts
+++ b/apps/manager/constants/games.ts
@@ -5,11 +5,7 @@ const ROUND = [
   { value: '2', label: '결승' },
 ];
 
-const SPORTS = [
-  { value: '4', label: '축구' },
-  { value: '2', label: '농구' },
-  { value: '3', label: '야구' },
-];
+const SPORTS = [{ value: '4', label: '축구' }];
 
 const STATE = [
   { value: 'SCHEDULED', label: '예정' },


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #183 

## ✅ 작업 내용

- games.ts의 SPORTS 배열에 축구를 제외한 나머지 스포츠 목록을 제거했습니다. 

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
