### PR TITLE
[FIX] 리그 별 라운드 정보 반영

### DIFF
--- a/apps/spectator/api/league.ts
+++ b/apps/spectator/api/league.ts
@@ -1,7 +1,12 @@
 import { AxiosError } from 'axios';
 
 import instance from '@/api';
-import { LeagueTeamType, LeagueType, SportType } from '@/types/league';
+import {
+  LeagueDetail,
+  LeagueTeamType,
+  LeagueType,
+  SportType,
+} from '@/types/league';
 
 export const getLeagues = async (year: number) => {
   const { data } = await instance.get<LeagueType[]>(`/leagues`, {
@@ -25,6 +30,12 @@ export const getAllLeagues = async () => {
       throw new Error('리그 목록을 불러오는 데에 실패했습니다!');
     }
   }
+};
+
+export const getLeagueDetail = async (leagueId: number) => {
+  const { data } = await instance.get<LeagueDetail>(`/leagues/${leagueId}`);
+
+  return data;
 };
 
 export const getSports = async (leagueId: number) => {

--- a/apps/spectator/app/_components/GameFilter/RoundFilter.tsx
+++ b/apps/spectator/app/_components/GameFilter/RoundFilter.tsx
@@ -5,6 +5,8 @@ import { clsx } from 'clsx';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
 
+import useLeagueDetailQuery from '@/queries/useLeagueDetail';
+
 import * as styles from './GameFilter.css';
 
 function formatRoundLabel(round: number): string {
@@ -12,25 +14,29 @@ function formatRoundLabel(round: number): string {
 }
 
 type RoundFilterProps = {
+  initialLeagueId: number;
   maxRound: number;
   inProgressRound: number;
 };
 
 export default function RoundFilter({
-  maxRound,
+  initialLeagueId,
   inProgressRound,
 }: RoundFilterProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const currentRound = Number(searchParams.get('round')) || inProgressRound;
   const year = Number(searchParams.get('year'));
   const league = searchParams.get('league');
 
-  if (!maxRound) return null;
+  const { data: leagueDetail } = useLeagueDetailQuery(initialLeagueId);
+  const currentRound =
+    Number(searchParams.get('round')) || leagueDetail?.inProgressRound;
+
+  if (!leagueDetail) return null;
 
   const rounds = Array.from(
-    { length: Math.floor(Math.log2(maxRound)) },
-    (_, i) => maxRound / 2 ** i,
+    { length: Math.floor(Math.log2(leagueDetail.maxRound)) },
+    (_, i) => leagueDetail.maxRound / 2 ** i,
   );
 
   return (

--- a/apps/spectator/app/_components/GameList/index.tsx
+++ b/apps/spectator/app/_components/GameList/index.tsx
@@ -7,6 +7,7 @@ import AsyncBoundary from '@/components/AsyncBoundary';
 import Loader from '@/components/Loader';
 import useIntersectionObserver from '@/hooks/useIntersectionObserver';
 import { useGameList } from '@/queries/useGameList';
+import useLeagueDetailQuery from '@/queries/useLeagueDetail';
 import { GameState } from '@/types/game';
 
 import GameCard from './Card';
@@ -18,13 +19,11 @@ type GameListProps = {
   initialRound: number;
 };
 
-export default function GameList({
-  state,
-  initialLeagueId,
-  initialRound,
-}: GameListProps) {
+export default function GameList({ state, initialLeagueId }: GameListProps) {
   const searchParams = useSearchParams();
-  const currentRound = !initialRound ? '' : String(initialRound);
+  const { data: leagueDetail } = useLeagueDetailQuery(Number(initialLeagueId));
+  const currentRound = leagueDetail?.inProgressRound.toString();
+
   const { data: groupedGameList, ...rest } = useGameList({
     league_id: searchParams.get('league') || initialLeagueId,
     sport_id: searchParams.get('sports') || undefined,

--- a/apps/spectator/app/page.tsx
+++ b/apps/spectator/app/page.tsx
@@ -5,6 +5,7 @@ import { ReactElement } from 'react';
 
 import { GAME_STATE } from '@/constants/configs';
 import { useLeaguesPrefetch } from '@/queries/useLeague';
+import { useLeagueDetailPrefetch } from '@/queries/useLeagueDetail';
 import { useLeagueTeamsPrefetch } from '@/queries/useLeagueTeams';
 import { useSportsPrefetch } from '@/queries/useSports';
 import { GameState } from '@/types/game';
@@ -31,6 +32,7 @@ export default async function Page({ searchParams }: PageProps) {
     ? inProgress.inProgressRound
     : inProgress.maxRound;
 
+  await useLeagueDetailPrefetch(initialLeagueId);
   await useLeagueTeamsPrefetch(initialLeagueId);
   await useSportsPrefetch(initialLeagueId);
 
@@ -41,6 +43,7 @@ export default async function Page({ searchParams }: PageProps) {
         {initialLeagueId && <SportFilter leagueId={initialLeagueId} />}
         {inProgress?.inProgressRound && (
           <RoundFilter
+            initialLeagueId={initialLeagueId}
             maxRound={inProgress.maxRound}
             inProgressRound={inProgress.inProgressRound}
           />

--- a/apps/spectator/queries/useLeagueDetail.ts
+++ b/apps/spectator/queries/useLeagueDetail.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getLeagueDetail } from '@/api/league';
+import getQueryClient from '@/app/getQueryClient';
+
+export const LEAGUE_DETAIL_QUERY_KEY = 'league-detail';
+export default function useLeagueDetailQuery(leagueId: number) {
+  const query = useQuery({
+    queryKey: [LEAGUE_DETAIL_QUERY_KEY, { leagueId }],
+    queryFn: () => getLeagueDetail(leagueId),
+  });
+
+  if (query.error) throw query.error;
+
+  return query;
+}
+
+export async function useLeagueDetailPrefetch(leagueId: number) {
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: [LEAGUE_DETAIL_QUERY_KEY, { leagueId }],
+    queryFn: () => getLeagueDetail(leagueId),
+  });
+}

--- a/apps/spectator/types/league.ts
+++ b/apps/spectator/types/league.ts
@@ -6,6 +6,11 @@ export type LeagueType = {
   isInProgress: boolean;
 };
 
+export interface LeagueDetail extends Omit<LeagueType, 'leagueId'> {
+  startAt: '2024-03-25T00:00:00';
+  endAt: '2024-03-26T00:00:00';
+}
+
 export type SportType = {
   name: string;
   sportId: number;


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #188 

## ✅ 작업 내용

- 리그 상세 API 및 쿼리를 추가합니다.
- 선택된 리그의 라운드 정보에 따라 라운드 탭을 재구성합니다.

## 📝 참고 자료

## ♾️ 기타
