### PR TITLE
[CHORE] 응원톡 제거 후 라인업 링크 추가

### DIFF
--- a/apps/manager/app/league/[leagueId]/game/_components/GameCard.tsx
+++ b/apps/manager/app/league/[leagueId]/game/_components/GameCard.tsx
@@ -99,17 +99,17 @@ export default function GameCard({ league, state, edit }: PlayingCardProps) {
                     fullWidth
                     component={Link}
                     variant="light"
-                    href={`/game/${league.leagueId}/${game.id}/timeline`}
+                    href={`/game/${league.leagueId}/${game.id}/lineup`}
                   >
-                    타임 라인
+                    라인업
                   </Button>
                   <Button
                     fullWidth
                     component={Link}
                     variant="light"
-                    href={`/report`}
+                    href={`/game/${league.leagueId}/${game.id}/timeline`}
                   >
-                    응원톡
+                    타임 라인
                   </Button>
                 </Flex>
               </Card.Footer>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #191 

## ✅ 작업 내용

- 대회 경기 관리 페이지에서 응원톡 대신 해당 경기의 라인업 관리 페이지로 이동할 수 있는 링크를 추가합니다.

## 📝 참고 자료

## ♾️ 기타
