### PR TITLE
[FIX] 매니저 타임라인 IN-OUT 오류 수정

### DIFF
--- a/apps/manager/app/game/[leagueId]/[gameId]/timeline/[recordType]/_components/ReplacementRecord/index.tsx
+++ b/apps/manager/app/game/[leagueId]/[gameId]/timeline/[recordType]/_components/ReplacementRecord/index.tsx
@@ -22,7 +22,7 @@ export default function ReplacementRecord({ form }: ReplacementRecordProps) {
           value: String(player.id),
           label: player.name,
         }))}
-        {...form.getInputProps('originLineupPlayerId')}
+        {...form.getInputProps('replacedLineupPlayerId')}
         mb="lg"
       />
 
@@ -33,7 +33,7 @@ export default function ReplacementRecord({ form }: ReplacementRecordProps) {
           value: String(player.id),
           label: player.name,
         }))}
-        {...form.getInputProps('replacedLineupPlayerId')}
+        {...form.getInputProps('originLineupPlayerId')}
         mb="lg"
       />
     </>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #196 

## ✅ 작업 내용

- 타임라인 수정 시 IN, OUT 선수가 반대로 적용되는 오류를 수정했습니다.