### PR TITLE
[FIX] 매니저 게임 기본 정보 저장 오류 해결

### DIFF
--- a/apps/manager/app/game/[leagueId]/[gameId]/detail/page.tsx
+++ b/apps/manager/app/game/[leagueId]/[gameId]/detail/page.tsx
@@ -53,8 +53,8 @@ export default function GameDetail() {
       state: value => !value && '상태를 선택해주세요.',
       videoId: value =>
         value.length !== 0 &&
-        YOUTUBE_BASE_URL_LIST.some(url => url.startsWith(value)) &&
-        '유튜브 전체 URL을 입력해주세요.',
+        !YOUTUBE_BASE_URL_LIST.some(url => value.startsWith(url)) &&
+        '정확한 유튜브 공유 링크를 입력해주세요.',
     },
   });
 
@@ -63,7 +63,7 @@ export default function GameDetail() {
       form.setValues({
         sportsId: String(game.sports.sportsId),
         gameName: game.gameName,
-        videoId: `${SHARED_URL}/${game?.videoId}`,
+        videoId: game.videoId ? `${SHARED_URL}${game?.videoId}` : ``,
         round: String(game.round),
         startTime: new Date(game.startTime),
         gameQuarter: game.gameQuarter,
@@ -93,7 +93,14 @@ export default function GameDetail() {
         state: values.state as 'playing' | 'scheduled' | 'finished',
       };
 
-      updateGameMutation({ gameId, payload });
+      updateGameMutation(
+        { gameId, payload },
+        {
+          onError: () => {
+            alert('오류가 발생했습니다. 정확하게 입력했는지 확인해주세요.');
+          },
+        },
+      );
     }
     setEdit(!edit);
   };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #198 

## ✅ 작업 내용

- 게임 기본 정보 수정 페이지에서 일부 데이터가 잘못 설정되어 저장되지 않는 오류를 수정했습니다. 
  - `videoId`가 `null`일 경우, 유튜브 prefix가 적용되지 않도록 수정했습니다. 
  - 유튜브 링크가 유효하지 않는 경우(videoId에 입력 존재) 텍스트를 출력하도록 변경했습니다.
  - 오류로 인해 저장이 이루어지지 않은 경우 대화 상자가 표시되도록 구현했습니다. 
