### PR TITLE
[REFACTOR] 관객 가이드 텍스트 형식 변경

### DIFF
--- a/apps/spectator/app/game/[id]/_components/Banner/Banner.css.ts
+++ b/apps/spectator/app/game/[id]/_components/Banner/Banner.css.ts
@@ -120,3 +120,20 @@ export const skeleton = styleVariants({
     },
   ],
 });
+
+export const errorFallback = styleVariants({
+  root: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+    minHeight: rem(95),
+  },
+  message: {
+    color: theme.colors.gray[5],
+    ...theme.textVariants.sm,
+
+    fontWeight: 500,
+    textAlign: 'center',
+  },
+});

--- a/apps/spectator/app/game/[id]/_components/Banner/Error.tsx
+++ b/apps/spectator/app/game/[id]/_components/Banner/Error.tsx
@@ -1,3 +1,11 @@
+import * as styles from './Banner.css';
+
 export default function BannerFallback() {
-  return <div>error fallback</div>;
+  return (
+    <div className={styles.errorFallback.root}>
+      <div className={styles.errorFallback.message}>
+        연결이 원활하지 않습니다. 잠시 후 다시 시도해주세요.
+      </div>
+    </div>
+  );
 }

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Fallback/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Fallback/index.tsx
@@ -10,7 +10,7 @@ export default function CheerTalkFallback() {
         <Icon source={ChatIcon} size="xs" color="white" />
       </div>
       <div className={styles.empty.talkBox}>
-        응원톡에서 여러분의 팀을 응원해보세요! 🙌
+        응원톡에 들어가 여러분의 팀을 응원해보세요! 🙌
       </div>
     </div>
   );

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Fallback/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Fallback/index.tsx
@@ -10,7 +10,7 @@ export default function CheerTalkFallback() {
         <Icon source={ChatIcon} size="xs" color="white" />
       </div>
       <div className={styles.empty.talkBox}>
-        응원톡에 들어가 여러분의 팀을 응원해보세요! 🙌
+        응원톡에서 여러분의 팀을 응원해보세요! 🙌
       </div>
     </div>
   );

--- a/apps/spectator/app/game/[id]/_components/CheerVS/Error.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerVS/Error.tsx
@@ -1,3 +1,3 @@
 export default function CheerVSFallback() {
-  return <div>에러</div>;
+  return <div></div>;
 }

--- a/apps/spectator/app/game/[id]/_components/Highlight/Fallback.tsx
+++ b/apps/spectator/app/game/[id]/_components/Highlight/Fallback.tsx
@@ -1,4 +1,4 @@
-import { ArrowClockwiseIcon, WhistlingIcon } from '@hcc/icons';
+import { ArrowClockwiseIcon } from '@hcc/icons';
 import { Icon } from '@hcc/ui';
 import { AxiosError } from 'axios';
 
@@ -14,10 +14,7 @@ export default function HighlightFallback({
   if (error instanceof NotFoundError) {
     return (
       <div className={styles.errorFallback.wrapper}>
-        <div className={styles.errorFallback.message}>
-          <Icon source={WhistlingIcon} size="sm" />
-          {error.message}
-        </div>
+        <div className={styles.errorFallback.message}>{error.message}</div>
       </div>
     );
   }
@@ -26,10 +23,15 @@ export default function HighlightFallback({
     return (
       <div className={styles.errorFallback.wrapper}>
         <div className={styles.errorFallback.message}>
-          <Icon source={WhistlingIcon} size="sm" />
-          {error.message}
+          연결이 원활하지 않습니다.
         </div>
-        <button>다시 시도</button>
+        <button
+          onClick={resetErrorBoundary}
+          className={styles.errorFallback.retry}
+        >
+          재시도
+          <Icon source={ArrowClockwiseIcon} size="xs" color="black" />
+        </button>
       </div>
     );
   }
@@ -39,14 +41,9 @@ export default function HighlightFallback({
       <span className={styles.errorFallback.message}>
         {error?.message || ''}
       </span>
-
-      <button
-        onClick={resetErrorBoundary}
-        className={styles.errorFallback.retry}
-      >
-        재시도
-        <Icon source={ArrowClockwiseIcon} size="xs" color="gray" />
-      </button>
+      <span className={styles.errorFallback.message}>
+        잠시 후 다시 시도해주세요.
+      </span>
     </div>
   );
 }

--- a/apps/spectator/app/game/[id]/_components/Highlight/Highlight.css.ts
+++ b/apps/spectator/app/game/[id]/_components/Highlight/Highlight.css.ts
@@ -17,11 +17,10 @@ export const errorFallback = styleVariants({
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
+    gap: theme.spaces.xs,
 
     minHeight: rem(180),
     paddingInline: theme.spaces.default,
-
-    backgroundColor: theme.colors.gray[2],
   },
   message: {
     display: 'flex',
@@ -30,13 +29,18 @@ export const errorFallback = styleVariants({
     gap: theme.spaces.sm,
 
     color: theme.colors.gray[5],
-    ...theme.textVariants.default,
+    ...theme.textVariants.sm,
 
+    fontWeight: 500,
     textAlign: 'center',
   },
   retry: {
-    ...theme.textVariants.default,
-    color: theme.colors.gray[5],
+    display: 'flex',
+    alignItems: 'center',
     gap: theme.spaces.xs,
+
+    ...theme.textVariants.sm,
+    color: theme.colors.gray[5],
+    fontWeight: 500,
   },
 });

--- a/apps/spectator/app/game/[id]/_components/Lineup/Fallback.tsx
+++ b/apps/spectator/app/game/[id]/_components/Lineup/Fallback.tsx
@@ -1,4 +1,4 @@
-import { ArrowClockwiseIcon, WhistlingIcon } from '@hcc/icons';
+import { ArrowClockwiseIcon } from '@hcc/icons';
 import { Icon } from '@hcc/ui';
 import { AxiosError } from 'axios';
 
@@ -14,10 +14,7 @@ export default function LineupFallback({
   if (error instanceof NotFoundError) {
     return (
       <div className={styles.errorFallback.wrapper}>
-        <div className={styles.errorFallback.message}>
-          <Icon source={WhistlingIcon} size="sm" />
-          {error.message}
-        </div>
+        <div className={styles.errorFallback.message}>{error.message}</div>
       </div>
     );
   }
@@ -26,10 +23,15 @@ export default function LineupFallback({
     return (
       <div className={styles.errorFallback.wrapper}>
         <div className={styles.errorFallback.message}>
-          <Icon source={WhistlingIcon} size="sm" />
-          {error.message}
+          연결이 원활하지 않습니다.
         </div>
-        <button>다시 시도</button>
+        <button
+          onClick={resetErrorBoundary}
+          className={styles.errorFallback.retry}
+        >
+          재시도
+          <Icon source={ArrowClockwiseIcon} size="xs" color="black" />
+        </button>
       </div>
     );
   }
@@ -39,14 +41,9 @@ export default function LineupFallback({
       <span className={styles.errorFallback.message}>
         {error?.message || ''}
       </span>
-
-      <button
-        onClick={resetErrorBoundary}
-        className={styles.errorFallback.retry}
-      >
-        재시도
-        <Icon source={ArrowClockwiseIcon} size="xs" color="gray" />
-      </button>
+      <span className={styles.errorFallback.message}>
+        잠시 후 다시 시도해주세요.
+      </span>
     </div>
   );
 }

--- a/apps/spectator/app/game/[id]/_components/Lineup/Lineup.css.ts
+++ b/apps/spectator/app/game/[id]/_components/Lineup/Lineup.css.ts
@@ -128,7 +128,7 @@ export const errorFallback = styleVariants({
 
     minHeight: rem(180),
     paddingInline: theme.spaces.default,
-    backgroundColor: theme.colors.gray[2],
+    gap: theme.spaces.xs,
   },
   message: {
     display: 'flex',
@@ -137,13 +137,18 @@ export const errorFallback = styleVariants({
     gap: theme.spaces.sm,
 
     color: theme.colors.gray[5],
-    ...theme.textVariants.default,
+    ...theme.textVariants.sm,
 
+    fontWeight: 500,
     textAlign: 'center',
   },
   retry: {
-    ...theme.textVariants.default,
-    color: theme.colors.gray[5],
+    display: 'flex',
+    alignItems: 'center',
     gap: theme.spaces.xs,
+
+    ...theme.textVariants.sm,
+    color: theme.colors.gray[5],
+    fontWeight: 500,
   },
 });

--- a/apps/spectator/app/game/[id]/_components/Timeline/Fallback.tsx
+++ b/apps/spectator/app/game/[id]/_components/Timeline/Fallback.tsx
@@ -1,4 +1,4 @@
-import { WhistlingIcon } from '@hcc/icons';
+import { ArrowClockwiseIcon } from '@hcc/icons';
 import { Icon } from '@hcc/ui';
 import { AxiosError } from 'axios';
 
@@ -15,7 +15,6 @@ export default function TimelineFallback({
     return (
       <div className={styles.errorFallback.wrapper}>
         <div className={styles.errorFallback.message}>
-          <Icon source={WhistlingIcon} size="sm" />
           <span>{error.message}</span>
         </div>
       </div>
@@ -26,28 +25,27 @@ export default function TimelineFallback({
     return (
       <div className={styles.errorFallback.wrapper}>
         <div className={styles.errorFallback.message}>
-          <span>
-            네트워크 에러가 발생했습니다.
-            <br />
-            잠시 후 다시 시도해주세요.
-          </span>
+          연결이 원활하지 않습니다.
         </div>
-        <button onClick={resetErrorBoundary}>다시 시도</button>
+        <button
+          onClick={resetErrorBoundary}
+          className={styles.errorFallback.retry}
+        >
+          재시도
+          <Icon source={ArrowClockwiseIcon} size="xs" color="black" />
+        </button>
       </div>
     );
   }
 
   return (
     <div className={styles.errorFallback.wrapper}>
-      <div className={styles.errorFallback.message}>
-        <span>알 수 없는 오류가 발생했습니다.</span>
-      </div>
-      <button
-        onClick={resetErrorBoundary}
-        className={styles.errorFallback.retry}
-      >
-        다시 시도
-      </button>
+      <span className={styles.errorFallback.message}>
+        {error?.message || ''}
+      </span>
+      <span className={styles.errorFallback.message}>
+        잠시 후 다시 시도해주세요.
+      </span>
     </div>
   );
 }

--- a/apps/spectator/app/game/[id]/_components/Timeline/Timeline.css.ts
+++ b/apps/spectator/app/game/[id]/_components/Timeline/Timeline.css.ts
@@ -85,11 +85,10 @@ export const errorFallback = styleVariants({
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
-    gap: theme.spaces.default,
+    gap: theme.spaces.xs,
 
     minHeight: rem(180),
     paddingInline: theme.spaces.default,
-    backgroundColor: theme.colors.gray[2],
   },
   message: {
     display: 'flex',
@@ -98,13 +97,18 @@ export const errorFallback = styleVariants({
     gap: theme.spaces.sm,
 
     color: theme.colors.gray[5],
-    ...theme.textVariants.default,
+    ...theme.textVariants.sm,
 
+    fontWeight: 500,
     textAlign: 'center',
   },
   retry: {
-    ...theme.textVariants.default,
-    color: theme.colors.primary[3],
+    display: 'flex',
+    alignItems: 'center',
     gap: theme.spaces.xs,
+
+    ...theme.textVariants.sm,
+    color: theme.colors.gray[5],
+    fontWeight: 500,
   },
 });

--- a/apps/spectator/app/game/[id]/_components/Timeline/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/Timeline/index.tsx
@@ -12,7 +12,9 @@ export default function Timeline({ gameId }: TimelineProps) {
   const { data: timelines } = useTimelineById(gameId);
 
   if (timelines.length === 0)
-    throw new NotFoundError('아직 타임라인이 등록되지 않았어요.');
+    throw new NotFoundError(
+      '경기가 시작한 뒤 시간 순으로 타임라인이 업데이트됩니다.',
+    );
 
   return (
     <div className={styles.root}>

--- a/apps/spectator/queries/useGameLineupById.ts
+++ b/apps/spectator/queries/useGameLineupById.ts
@@ -19,7 +19,7 @@ export const useGameLineupById = (gameId: string) => {
   });
 
   if (query.data.length !== 2)
-    throw new NotFoundError('라인업이 등록되지 않았습니다.');
+    throw new NotFoundError('해당 경기의 선수 선발명단 업데이트 전입니다.');
   if (query.error) throw query.error;
 
   return query;

--- a/apps/spectator/queries/useVideoQuery.ts
+++ b/apps/spectator/queries/useVideoQuery.ts
@@ -11,7 +11,9 @@ export const useVideoQuery = (gameId: string) => {
   });
 
   if (!query.data.videoId)
-    throw new NotFoundError('경기 영상이 등록되지 않았습니다.');
+    throw new NotFoundError(
+      '해당 경기의 하이라이트 영상 업데이트 준비 중입니다.',
+    );
   if (query.error) throw query.error;
 
   return query;


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #200 

## ✅ 작업 내용

- 관객 게임 페이지의 가이드 텍스트를 변경하였습니다. 
  - [연결이 원활하지 않습니다.], [해당 경기의 선수 선발명단 업데이트 전입니다.] 등 와이어프레임을 반영하여 `ErrorFallback` 영역의 스타일 및 텍스트를 변경하였습니다. 