### PR TITLE
[STYLE] 대회 팀 필터 배경 그라데이션 적용

### DIFF
--- a/apps/spectator/app/_components/GameFilter/GameFilter.css.ts
+++ b/apps/spectator/app/_components/GameFilter/GameFilter.css.ts
@@ -73,7 +73,7 @@ export const leagueTeam = styleVariants({
     paddingBlock: theme.spaces.sm,
     paddingInline: rem(10),
     justifyContent: 'start',
-    backgroundColor: theme.colors.gray[1],
+    background: `linear-gradient(${theme.colors.gray[1]}, ${theme.colors.white})`,
   },
   list: {
     display: 'flex',
@@ -108,7 +108,6 @@ export const leagueTeam = styleVariants({
     padding: theme.spaces.default,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: theme.colors.gray[1],
   },
   expandButtonFocused: {
     backgroundColor: 'transparent',


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #160

## ✅ 작업 내용

- 대회 팀 필터의 배경이 와이어프레임과 달라 일치시켜줬습니다.

## 📝 참고 자료

<img width="415" alt="image" src="https://github.com/hufscheer/client_v2/assets/87803596/f09dbd4d-4097-46ef-8e6f-883f18d54f54">


## ♾️ 기타
