### PR TITLE
[STYLE] 관객앱 신고모달 사이즈업, 응원톡 메뉴 클릭 영역 확대

### DIFF
--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Item/Item.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Item/Item.css.ts
@@ -9,16 +9,8 @@ const itemBase = style({
 });
 
 export const itemWrapper = styleVariants({
-  left: [
-    itemBase,
-    {
-      paddingRight: theme.spaces.xl,
-    },
-  ],
-  right: [
-    itemBase,
-    { flexDirection: 'row-reverse', paddingLeft: theme.spaces.xl },
-  ],
+  left: [itemBase],
+  right: [itemBase, { flexDirection: 'row-reverse' }],
 });
 
 export const clickable = style({
@@ -30,6 +22,7 @@ const infoBase = style({
   display: 'flex',
   alignItems: 'center',
   color: theme.colors.gray[4],
+  width: 'max-content',
   gap: rem(2),
 });
 

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Item/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Item/index.tsx
@@ -54,20 +54,21 @@ export default function CheerTalkItem({
       >
         {isBlocked ? '⚠️ 관리자에 의해 차단된 톡입니다.' : content}
       </div>
-      <div className={styles.infoContainer[direction]}>
-        <time className={styles.item.timestamp}>
-          {formatTime(createdAt, 'A hh:mm')}
-        </time>
-        {!isBlocked && hasMenu && (
-          <CheerTalkMenuModal
-            cheerTalkId={cheerTalkId}
-            content={content}
-            className={styles.item.menuButton}
-          >
+
+      {!isBlocked && hasMenu && (
+        <CheerTalkMenuModal
+          cheerTalkId={cheerTalkId}
+          content={content}
+          className={styles.item.menuButton}
+        >
+          <div className={styles.infoContainer[direction]}>
+            <time className={styles.item.timestamp}>
+              {formatTime(createdAt, 'A hh:mm')}
+            </time>
             <Icon source={MenuIcon} className={styles.item.menuButtonIcon} />
-          </CheerTalkMenuModal>
-        )}
-      </div>
+          </div>
+        </CheerTalkMenuModal>
+      )}
     </li>
   );
 }

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/MenuModal/MenuModal.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/MenuModal/MenuModal.css.ts
@@ -18,19 +18,18 @@ export const content = style({
   paddingInline: theme.spaces.default,
   borderRadius: rem(15),
   backgroundColor: theme.colors.gray[2],
-  ...theme.textVariants.xs,
+  ...theme.textVariants.sm,
 });
 
 export const menuBlock = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  paddingBlock: theme.spaces.xs,
-  paddingInline: theme.spaces.default,
+  padding: theme.spaces.default,
   marginTop: theme.spaces.xxs,
   borderRadius: rem(10),
   backgroundColor: 'white',
-  ...theme.textVariants.xs,
+  ...theme.textVariants.sm,
 });
 
 export const menuIcon = style({


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #208 

## ✅ 작업 내용

- 상기 이슈와 동일

## 📝 참고 자료



## ♾️ 기타

- 현재 사이드바의 대회 목록이 gray[3] 색상으로 맞춰져있으며, hover 시에만 gray[4]로 변하도록 스타일돼있습니다. 이는 데스크탑 유저들에게만 적용되는 효과이며 대다수의 모바일 유저들에게는 적용되지 않는 효과입니다. 제가 테스트하다 사이드바를 펼쳤을 때 올해연도의 대회까지 모두 비활성화돼있다 오해할만큼 적절치 못한 디자인이라 느껴서, hover 애니메이션보다 현재 진행중인 경기나 또는 더 러프하게 올해의 대회들은 검은색으로 구분을 지어주는게 좋을 것 같다는 생각이 들었습니다. 여유 있으신 분께서 작업해주시면 감사하겠습니다!
