### PR TITLE
[FIX] 라인업 수정 기능 개선

### DIFF
--- a/apps/manager/api/game.ts
+++ b/apps/manager/api/game.ts
@@ -9,7 +9,7 @@ import {
   SportsQuarterType,
   GameTeamType,
   GameUpdatePayload,
-  LineupPayload,
+  OptionalLineup,
 } from '@/types/game';
 
 export const getGameDetail = async (gameId: string) => {
@@ -88,9 +88,9 @@ export const updateGame = async (
 
 export const createLineup = async (
   teamId: string,
-  payload: LineupPayload[],
+  payload: OptionalLineup[],
 ) => {
-  const { data } = await instance.post(
+  const { data } = await instance.put(
     `/games/team/${teamId}/lineup-player/`,
     payload,
   );

--- a/apps/manager/app/game/[leagueId]/[gameId]/lineup/[teamId]/_components/PlayerCard/index.tsx
+++ b/apps/manager/app/game/[leagueId]/[gameId]/lineup/[teamId]/_components/PlayerCard/index.tsx
@@ -3,15 +3,13 @@ import { Icon } from '@hcc/ui';
 import { ActionIcon, Badge, Flex, Text } from '@mantine/core';
 
 import Card from '@/components/Card';
-import { LeaguePlayerWithIDPayload } from '@/types/league';
-
-import { PlayerWithCaptain } from '../../page';
+import { GameLineupType } from '@/types/game';
 
 type PlayerCardProps = {
   removable?: boolean;
-  player: PlayerWithCaptain;
-  handleCaptain: (playerId: number) => void;
-  handleClickAction: (player: LeaguePlayerWithIDPayload) => void;
+  player: GameLineupType;
+  handleCaptain: (leagueTeamPlayerId: number) => void;
+  handleClickAction: (player: GameLineupType) => void;
 };
 
 export default function PlayerCard({
@@ -29,7 +27,7 @@ export default function PlayerCard({
             style={{ cursor: 'pointer' }}
             color={player.isCaptain ? 'blue' : 'gray'}
             variant="filled"
-            onClick={() => handleCaptain(player.id)}
+            onClick={() => handleCaptain(player.leagueTeamPlayerId)}
           >
             주장
           </Badge>

--- a/apps/manager/hooks/mutations/useCreateLineupMutation.ts
+++ b/apps/manager/hooks/mutations/useCreateLineupMutation.ts
@@ -1,13 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { createLineup } from '@/api/game';
-import { LineupPayload } from '@/types/game';
+import { OptionalLineup } from '@/types/game';
 
 import { GAME_LINEUP_QUERY_KEY } from '../queries/useGameLineupQuery';
 
 type Params = {
   teamId: string;
-  payload: LineupPayload[];
+  payload: OptionalLineup[];
 };
 
 export default function useCreateLineupMutation() {

--- a/apps/manager/next.config.js
+++ b/apps/manager/next.config.js
@@ -22,6 +22,11 @@ const nextConfig = {
         hostname: 'hufscheer-server.s3.ap-northeast-2.amazonaws.com',
         port: '',
       },
+      {
+        protocol: 'https',
+        hostname: 'github.com',
+        port: '',
+      },
     ],
   },
 

--- a/apps/manager/types/game.ts
+++ b/apps/manager/types/game.ts
@@ -1,3 +1,5 @@
+import { Optional } from './utils';
+
 export type GameInfoType = {
   sports: SportsType;
   startTime: string;
@@ -132,12 +134,13 @@ export type GameListParams = {
 export type GameLineupType = {
   id: number;
   name: string;
-  description: string;
+  description: string | null;
   number: number;
   isCaptain: boolean;
+  leagueTeamPlayerId: number;
 };
 
-export type LineupPayload = Omit<GameLineupType, 'id'>;
+export type OptionalLineup = Optional<GameLineupType, 'id'>;
 
 // timeline payload
 

--- a/apps/manager/types/league.ts
+++ b/apps/manager/types/league.ts
@@ -44,7 +44,7 @@ export type LeagueRegisterDataType = {
 export type LeaguePlayerPayload = {
   name: string;
   description: string | null;
-  number: number | null;
+  number: number;
 };
 
 export type LeaguePlayerWithIDPayload = LeaguePlayerPayload & {

--- a/apps/manager/types/utils.ts
+++ b/apps/manager/types/utils.ts
@@ -1,0 +1,3 @@
+export type Optional<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]?: T[P];
+};


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #189

## ✅ 작업 내용

- 외부 리소스 주소(github.com)를 허용합니다.
- 라인업 관련 타입을 재정의합니다.
- 이제 라인업 수정 페이지에 진입 시 기존 라인업은 **선발** 탭에 표시되고, 라인업을 수정할 시 추가되는 것이 아니라 덮어씌어집니다.

## 📝 참고 자료

## ♾️ 기타
