### PR TITLE
[FIX] 실 사용 후 문제점 개선

### DIFF
--- a/apps/spectator/app/game/[id]/_components/CheerTalk/OnAir/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/OnAir/index.tsx
@@ -23,7 +23,7 @@ export default function CheerTalkOnAir({ cheerTalk }: CheerTalkInRealProps) {
   const variants = {
     initial: {
       opacity: 0,
-      y: 300,
+      y: 20,
     },
     enter: {
       opacity: 1,

--- a/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
@@ -17,6 +17,8 @@ type CheerTeamProps = (GameCheerType & GameTeamType) & {
   fullCheerCount: number;
 };
 
+const MAX_COUNT = 500;
+
 export default function CheerTeamBox({
   gameId,
   direction,
@@ -50,6 +52,12 @@ export default function CheerTeamBox({
   const handleCheerClick = () => {
     setCount(prev => {
       const nextCount = prev + 1;
+
+      if (nextCount - cheerCount > MAX_COUNT) {
+        alert('잠시 쉬었다가 다시 응원해주세요!');
+
+        return prev;
+      }
 
       debouncedMutateCheerCount();
 

--- a/apps/spectator/app/game/[id]/page.css.ts
+++ b/apps/spectator/app/game/[id]/page.css.ts
@@ -28,6 +28,7 @@ const panelItemBase = style({
   paddingBlock: rem(12),
   color: theme.colors.gray[4],
   borderBlock: `1px solid ${theme.colors.gray[2]}`,
+  backgroundColor: theme.colors.white,
 });
 
 export const panel = styleVariants({

--- a/apps/spectator/queries/useCheerTalkById.ts
+++ b/apps/spectator/queries/useCheerTalkById.ts
@@ -28,9 +28,6 @@ export default function useCheerTalkById(gameId: string) {
     }),
 
     // refetch options
-    refetchOnReconnect: true,
-    refetchOnMount: true,
-    refetchOnWindowFocus: true,
     staleTime: 1000,
   });
 

--- a/apps/spectator/queries/useCheerTalkById.ts
+++ b/apps/spectator/queries/useCheerTalkById.ts
@@ -26,6 +26,12 @@ export default function useCheerTalkById(gameId: string) {
       ),
       pageParams: [...data.pageParams].reverse(),
     }),
+
+    // refetch options
+    refetchOnReconnect: true,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+    staleTime: 1000,
   });
 
   if (query.data.pageParams.length === 0) throw query.error;

--- a/apps/spectator/queries/useGameById.ts
+++ b/apps/spectator/queries/useGameById.ts
@@ -2,11 +2,22 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getGameById } from '@/api/game';
 
+const GAME_DETAIL_POLLING_INTERVAL = 1000 * 60;
 export const GAME_DETAIL_QUERY_KEY = 'GAME_DETAIL';
-export default function useGameById(gameId: string) {
+export default function useGameById(
+  gameId: string,
+  interval = GAME_DETAIL_POLLING_INTERVAL,
+) {
   const { data, error } = useSuspenseQuery({
     queryKey: [GAME_DETAIL_QUERY_KEY, gameId],
     queryFn: () => getGameById(gameId),
+
+    // refetch options
+    refetchInterval: interval,
+    refetchOnReconnect: true,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+    staleTime: 1000 * 60,
   });
 
   if (error) throw error;


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #223 

## ✅ 작업 내용

- 최대 응원 수(500)을 초과할 시 alert을 띄우며 응원하기 수를 제한합니다.
-  On Air의 응원톡이 올라오면서 탭 컴포넌트 배경에 비치는 버그를 수정합니다.
- cheerTalk, gameDetail의 stale time을 단축합니다.
  - 소켓으로 데이터를 쌓다가 페이지 전환이 발생하면 해당 데이터는 소멸합니다.
  - 이 때 응원톡에 대한 쿼리 캐시가 남아 있다면 그 사이에 발생한 응원톡이 누락된 것처럼 보입니다. 이를 해결하기 위해 응원톡의 쿼리 캐시를 제거합니다.
  - gameDetail은 게임 상세 페이지의 배너에 사용되는 데이터입니다.
  - 이는 타임라인과 싱크를 맞춰야 할 필요가 있다 판단했습니다.
  - 때문에 타임라인과 마찬가지로 1분마다 polling합니다.

## 📝 참고 자료

## ♾️ 기타
