### PR TITLE
[FIX] cheer count 중복 요청 버그 수정

### DIFF
--- a/apps/spectator/app/_components/GameFilter/GameFilter.css.ts
+++ b/apps/spectator/app/_components/GameFilter/GameFilter.css.ts
@@ -67,6 +67,18 @@ export const divider = style({
   bottom: 0,
 });
 
+const leagueTeamItemBase = style({
+  paddingBlock: theme.spaces.xs,
+  paddingInline: theme.spaces.sm,
+  whiteSpace: 'nowrap',
+  border: `${rem(1)} solid ${theme.colors.gray[2]}`,
+  borderRadius: rem(16),
+  backgroundColor: theme.colors.white,
+  ...theme.textVariants.xs,
+  color: theme.colors.gray[4],
+  fontWeight: 'bold',
+});
+
 export const leagueTeam = styleVariants({
   wrapper: {
     paddingBlock: theme.spaces.sm,
@@ -77,23 +89,19 @@ export const leagueTeam = styleVariants({
   list: {
     display: 'flex',
     flexWrap: 'nowrap',
-    overflow: 'hidden',
+    overflowY: 'scroll',
+    msOverflowStyle: 'none',
+    scrollbarWidth: 'none',
+    '::-webkit-scrollbar': {
+      display: 'none',
+    },
+    overscrollBehavior: 'none',
     gap: theme.spaces.xs,
   },
-  listExpand: {
+  listExpanded: {
     flexWrap: 'wrap',
   },
-  item: {
-    paddingBlock: theme.spaces.xs,
-    paddingInline: theme.spaces.sm,
-    whiteSpace: 'nowrap',
-    border: `${rem(1)} solid ${theme.colors.gray[2]}`,
-    borderRadius: rem(16),
-    backgroundColor: theme.colors.white,
-    ...theme.textVariants.xs,
-    color: theme.colors.gray[4],
-    fontWeight: 'bold',
-  },
+  itemExpanded: [leagueTeamItemBase],
   itemFocused: {
     borderColor: theme.colors.primary[3],
     backgroundColor: theme.colors.primary[3],

--- a/apps/spectator/app/_components/GameFilter/LeagueTeamFilter.tsx
+++ b/apps/spectator/app/_components/GameFilter/LeagueTeamFilter.tsx
@@ -4,7 +4,7 @@ import { CaretDownIcon } from '@hcc/icons';
 import { Icon } from '@hcc/ui';
 import { clsx } from 'clsx';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { MouseEvent, forwardRef, useEffect, useRef, useState } from 'react';
 
 import useLeagueTeams from '@/queries/useLeagueTeams';
 
@@ -12,6 +12,43 @@ import * as styles from './GameFilter.css';
 
 export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
   const [isExpanded, setIsExpanded] = useState(false);
+
+  const scrollRef = useRef<HTMLUListElement>(null);
+  const itemRef = useRef<HTMLLIElement>(null);
+  const prevScrollLeftRef = useRef(0);
+
+  const toggleExpand = () => {
+    if (!isExpanded && scrollRef.current) {
+      prevScrollLeftRef.current = scrollRef.current.scrollLeft;
+    }
+    setIsExpanded(!isExpanded);
+  };
+
+  useEffect(() => {
+    if (!isExpanded && scrollRef.current) {
+      scrollRef.current.scrollTo({
+        left: prevScrollLeftRef.current,
+        behavior: 'instant',
+      });
+    }
+  }, [isExpanded]);
+
+  const scrollToCenter = (itemElement: HTMLButtonElement) => {
+    if (!itemElement || !scrollRef.current) return;
+
+    const containerWidth =
+      scrollRef.current.parentElement?.clientWidth ??
+      scrollRef.current.clientWidth;
+    const itemWidth = itemElement.offsetWidth;
+    const itemLeft = itemElement.offsetLeft;
+
+    const scrollCoordinate = itemLeft - containerWidth / 2 + itemWidth / 2;
+
+    scrollRef.current.scrollTo({
+      left: scrollCoordinate,
+      behavior: 'smooth',
+    });
+  };
 
   const pathname = usePathname();
   const router = useRouter();
@@ -22,7 +59,10 @@ export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
 
   if (!leagueTeams || !leagueTeams.length) return;
 
-  const handleRouter = (selectedTeamId: number) => {
+  const handleRouter = (
+    event: MouseEvent<HTMLButtonElement>,
+    selectedTeamId: number,
+  ) => {
     const current = new URLSearchParams(Array.from(searchParams.entries()));
     const teamIdParams = current.get('leagueTeam') || null;
     const teamIds = teamIdParams?.split(',').map(Number) || [];
@@ -31,6 +71,8 @@ export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
     const updatedTeamIds = hasTeamId
       ? teamIds.filter(id => id !== selectedTeamId)
       : [...teamIds, selectedTeamId].sort((a, b) => a - b);
+
+    if (!hasTeamId) scrollToCenter(event.currentTarget);
 
     if (!updatedTeamIds.length) current.delete('leagueTeam');
     else current.set('leagueTeam', updatedTeamIds.join(','));
@@ -42,10 +84,7 @@ export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
 
   return (
     <div className={styles.leagueTeam.wrapper}>
-      <button
-        className={clsx(styles.expandable.button)}
-        onClick={() => setIsExpanded(!isExpanded)}
-      >
+      <button className={clsx(styles.expandable.button)} onClick={toggleExpand}>
         <Icon
           source={CaretDownIcon}
           className={clsx(
@@ -56,9 +95,10 @@ export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
       </button>
 
       <ul
+        ref={scrollRef}
         className={clsx(
           styles.leagueTeam.list,
-          isExpanded && styles.leagueTeam.listExpand,
+          isExpanded && styles.leagueTeam.listExpanded,
         )}
       >
         {leagueTeams.map(team => {
@@ -67,20 +107,47 @@ export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
           );
 
           return (
-            <li key={team.leagueTeamId}>
-              <button
-                onClick={() => handleRouter(team.leagueTeamId)}
-                className={clsx(
-                  styles.leagueTeam.item,
-                  isSelected && styles.leagueTeam.itemFocused,
-                )}
-              >
-                {team.teamName}
-              </button>
-            </li>
+            <Item
+              key={team.leagueTeamId}
+              team={team}
+              isSelected={isSelected}
+              handleRouter={handleRouter}
+              ref={itemRef}
+            />
           );
         })}
       </ul>
     </div>
   );
 }
+
+type ItemProps = {
+  isSelected: boolean;
+  handleRouter: (
+    e: MouseEvent<HTMLButtonElement>,
+    selectedTeamId: number,
+  ) => void;
+  team: {
+    leagueTeamId: number;
+    teamName: string;
+  };
+};
+
+const Item = forwardRef<HTMLLIElement, ItemProps>(function Item(
+  { team: { leagueTeamId, teamName }, isSelected, handleRouter },
+  ref,
+) {
+  return (
+    <li ref={ref}>
+      <button
+        onClick={e => handleRouter(e, leagueTeamId)}
+        className={clsx(
+          styles.leagueTeam.itemExpanded,
+          isSelected && styles.leagueTeam.itemFocused,
+        )}
+      >
+        {teamName}
+      </button>
+    </li>
+  );
+});

--- a/apps/spectator/app/_components/GameList/Button.tsx
+++ b/apps/spectator/app/_components/GameList/Button.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 
 import { GAME_STATE, TABS_CONFIG } from '@/constants/configs';
+import useTracker from '@/hooks/useTracker';
 import { GameState } from '@/types/game';
 
 import * as styles from './GameList.css';
@@ -12,6 +13,7 @@ type GameButtonProps = {
 };
 
 export default function GameButton({ id, state, hasVideo }: GameButtonProps) {
+  const { tracker } = useTracker();
   if (state === GAME_STATE.SCHEDULED) {
     return null;
   }
@@ -21,6 +23,7 @@ export default function GameButton({ id, state, hasVideo }: GameButtonProps) {
       {state === GAME_STATE.PLAYING && (
         <Link
           href={{ pathname: `/game/${id}`, query: { cheer: 'open' } }}
+          onClick={() => tracker(`gameList | cheer button ${id}`)}
           className={styles.gameButtonArea.cheer}
         >
           응원
@@ -32,6 +35,7 @@ export default function GameButton({ id, state, hasVideo }: GameButtonProps) {
             pathname: `/game/${id}`,
             query: { tab: TABS_CONFIG.HIGHLIGHT },
           }}
+          onClick={() => tracker(`gameList | video button ${id}`)}
           className={styles.gameButtonArea.record}
         >
           영상
@@ -43,6 +47,7 @@ export default function GameButton({ id, state, hasVideo }: GameButtonProps) {
           pathname: `/game/${id}`,
           query: { tab: TABS_CONFIG.TIMELINE },
         }}
+        onClick={() => tracker(`gameList | timeline card ${id}`)}
         className={styles.gameButtonArea.record}
       >
         기록

--- a/apps/spectator/app/_components/GameList/Info.tsx
+++ b/apps/spectator/app/_components/GameList/Info.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
+import useTracker from '@/hooks/useTracker';
 import { GameListType, GameState } from '@/types/game';
 
 import * as styles from './GameList.css';
@@ -12,12 +13,18 @@ type GameInfoProps = {
 };
 
 export default function GameInfo({ gameTeams, gameId, state }: GameInfoProps) {
+  const { tracker } = useTracker();
+
   // todo: fisished 상태일 때 경기 승패를 score 색상으로 표시
   const [firstTeam, secondTeam] = gameTeams;
   const IMAGE_SIZE = 36;
 
   return (
-    <Link href={`/game/${gameId}`} className={styles.gameInfoArea}>
+    <Link
+      href={`/game/${gameId}`}
+      className={styles.gameInfoArea}
+      onClick={() => tracker(`gameList | ${gameId} ${state} game card`)}
+    >
       <div className={styles.gameInfoRow.root}>
         <div className={styles.gameInfoRow.team}>
           <Image

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/EntryButton/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/EntryButton/index.tsx
@@ -2,11 +2,14 @@ import { ChatIcon } from '@hcc/icons';
 import { Icon, Tooltip } from '@hcc/ui';
 import { useEffect, useState, ComponentProps } from 'react';
 
+import useTracker from '@/hooks/useTracker';
+
 import * as styles from './EntryButton.css';
 
 const TOOLTIP_KEY = 'cheertalk';
 
 export default function CheerTalkEntryButton(props: ComponentProps<'button'>) {
+  const { tracker } = useTracker();
   const [isCheerTalkTooltipVisible, setIsCheerTalkTooltipVisible] =
     useState(true);
 
@@ -17,6 +20,8 @@ export default function CheerTalkEntryButton(props: ComponentProps<'button'>) {
   }, []);
 
   const handleButtonClick = () => {
+    tracker('open cheerTalk', { clickEvent: 'cheerTalk' });
+
     setIsCheerTalkTooltipVisible(false);
     window.localStorage.setItem(TOOLTIP_KEY, String(false));
   };

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Item/Item.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Item/Item.css.ts
@@ -9,15 +9,10 @@ const itemBase = style({
 });
 
 export const itemWrapper = styleVariants({
-  left: [
-    itemBase,
-    {
-      paddingRight: theme.spaces.xl,
-    },
-  ],
+  left: [itemBase, { paddingRight: theme.spaces.lg }],
   right: [
     itemBase,
-    { flexDirection: 'row-reverse', paddingLeft: theme.spaces.xl },
+    { flexDirection: 'row-reverse', paddingLeft: theme.spaces.lg },
   ],
 });
 
@@ -30,6 +25,7 @@ const infoBase = style({
   display: 'flex',
   alignItems: 'center',
   color: theme.colors.gray[4],
+  width: 'max-content',
   gap: rem(2),
 });
 

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Item/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Item/index.tsx
@@ -54,20 +54,21 @@ export default function CheerTalkItem({
       >
         {isBlocked ? '⚠️ 관리자에 의해 차단된 톡입니다.' : content}
       </div>
-      <div className={styles.infoContainer[direction]}>
-        <time className={styles.item.timestamp}>
-          {formatTime(createdAt, 'A hh:mm')}
-        </time>
-        {!isBlocked && hasMenu && (
-          <CheerTalkMenuModal
-            cheerTalkId={cheerTalkId}
-            content={content}
-            className={styles.item.menuButton}
-          >
+
+      {!isBlocked && hasMenu && (
+        <CheerTalkMenuModal
+          cheerTalkId={cheerTalkId}
+          content={content}
+          className={styles.item.menuButton}
+        >
+          <div className={styles.infoContainer[direction]}>
+            <time className={styles.item.timestamp}>
+              {formatTime(createdAt, 'A hh:mm')}
+            </time>
             <Icon source={MenuIcon} className={styles.item.menuButtonIcon} />
-          </CheerTalkMenuModal>
-        )}
-      </div>
+          </div>
+        </CheerTalkMenuModal>
+      )}
     </li>
   );
 }

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/MenuModal/MenuModal.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/MenuModal/MenuModal.css.ts
@@ -18,19 +18,18 @@ export const content = style({
   paddingInline: theme.spaces.default,
   borderRadius: rem(15),
   backgroundColor: theme.colors.gray[2],
-  ...theme.textVariants.xs,
+  ...theme.textVariants.sm,
 });
 
 export const menuBlock = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  paddingBlock: theme.spaces.xs,
-  paddingInline: theme.spaces.default,
+  padding: theme.spaces.default,
   marginTop: theme.spaces.xxs,
   borderRadius: rem(10),
   backgroundColor: 'white',
-  ...theme.textVariants.xs,
+  ...theme.textVariants.sm,
 });
 
 export const menuIcon = style({

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/MenuModal/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/MenuModal/index.tsx
@@ -2,6 +2,7 @@ import { ExclamationCircleFillIcon } from '@hcc/icons';
 import { Icon, Modal } from '@hcc/ui';
 import { ReactNode } from 'react';
 
+import useTracker from '@/hooks/useTracker';
 import useReportCheerTalkMutation from '@/queries/useReportCheerTalkMutation/query';
 
 import * as styles from './MenuModal.css';
@@ -19,6 +20,7 @@ const CheerTalkMenuModal = ({
   className,
   children,
 }: CheerTalkMenuModalProps) => {
+  const { tracker } = useTracker();
   const { mutate, isSuccess } = useReportCheerTalkMutation();
 
   const handleReportButton = async (payload: { cheerTalkId: number }) => {
@@ -27,6 +29,8 @@ const CheerTalkMenuModal = ({
 
       return;
     }
+
+    tracker(`report cheerTalk | "${content}"`, { clickEvent: 'report' });
 
     mutate(payload);
   };

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/OnAir/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/OnAir/index.tsx
@@ -23,7 +23,7 @@ export default function CheerTalkOnAir({ cheerTalk }: CheerTalkInRealProps) {
   const variants = {
     initial: {
       opacity: 0,
-      y: 300,
+      y: 20,
     },
     enter: {
       opacity: 1,

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/index.tsx
@@ -2,6 +2,7 @@ import { Modal } from '@hcc/ui';
 import { useMemo, useState } from 'react';
 
 import useSocket from '@/hooks/useSocket';
+import useTracker from '@/hooks/useTracker';
 import useCheerTalkById from '@/queries/useCheerTalkById';
 import { useGameTeamInfo } from '@/queries/useGameTeamInfo';
 import { GameCheerTalkType, GameCheerTalkWithTeamInfo } from '@/types/game';
@@ -22,6 +23,7 @@ export default function CheerTalk({
   gameId,
   defaultState,
 }: CheerTalkItemProps) {
+  const { tracker } = useTracker();
   const [socketTalkList, setSocketTalkList] = useState<
     GameCheerTalkWithTeamInfo[]
   >([]);
@@ -50,7 +52,7 @@ export default function CheerTalk({
 
   return (
     <Modal defaultState={defaultState}>
-      <Modal.Trigger as="span">
+      <Modal.Trigger as="span" onClick={() => tracker('onAir CheerTalk Modal')}>
         <CheerTalkOnAir
           cheerTalk={
             !socketTalkList.length ? cheerTalkList.pages : socketTalkList

--- a/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
@@ -46,7 +46,7 @@ export default function CheerTeamBox({
       );
     },
     1000,
-    [cheerCount, gameId, gameTeamId, mutate],
+    [gameId, gameTeamId, mutate],
   );
 
   const handleCheerClick = () => {

--- a/apps/spectator/app/game/[id]/page.css.ts
+++ b/apps/spectator/app/game/[id]/page.css.ts
@@ -28,6 +28,7 @@ const panelItemBase = style({
   paddingBlock: rem(12),
   color: theme.colors.gray[4],
   borderBlock: `1px solid ${theme.colors.gray[2]}`,
+  backgroundColor: theme.colors.white,
 });
 
 export const panel = styleVariants({

--- a/apps/spectator/app/providers.tsx
+++ b/apps/spectator/app/providers.tsx
@@ -4,6 +4,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React, { ReactNode, useState } from 'react';
 
+import AmplitudeContextProvider from '@/contexts/AmplitudeContext';
+
 type ProviderProps = {
   children: ReactNode;
 };
@@ -24,9 +26,14 @@ export default function Provider({ children }: ProviderProps) {
   );
 
   return (
-    <QueryClientProvider client={queryClient}>
-      {children}
-      <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
-    </QueryClientProvider>
+    <AmplitudeContextProvider>
+      <QueryClientProvider client={queryClient}>
+        {children}
+        <ReactQueryDevtools
+          initialIsOpen={false}
+          buttonPosition="bottom-left"
+        />
+      </QueryClientProvider>
+    </AmplitudeContextProvider>
   );
 }

--- a/apps/spectator/components/LeagueList/index.tsx
+++ b/apps/spectator/components/LeagueList/index.tsx
@@ -2,6 +2,7 @@ import { Accordion } from '@hcc/ui';
 import dayjs from 'dayjs';
 import Link from 'next/link';
 
+import useTracker from '@/hooks/useTracker';
 import useLeagueArchives from '@/queries/useLeagueArchives';
 
 import * as styles from './LeagueList.css';
@@ -18,7 +19,16 @@ type LeagueListProps = {
 };
 
 export default function LeagueList({ handleClose }: LeagueListProps) {
+  const { tracker } = useTracker();
   const { data: leagues } = useLeagueArchives<typeof YEARS_LIST>(YEARS_LIST);
+
+  const handleClickLeague = (year: number, leagueId: number, name: string) => {
+    tracker(`leagueList | ${year}년도 ${name}(${leagueId})`, {
+      clickEvent: `Select Archived League`,
+    });
+
+    handleClose();
+  };
 
   return (
     <>
@@ -38,7 +48,9 @@ export default function LeagueList({ handleClose }: LeagueListProps) {
                         pathname: '/',
                         query: { year, league: league.leagueId },
                       }}
-                      onClick={handleClose}
+                      onClick={() =>
+                        handleClickLeague(year, league.leagueId, league.name)
+                      }
                     >
                       {league.name}
                     </Link>

--- a/apps/spectator/components/Sidebar/index.tsx
+++ b/apps/spectator/components/Sidebar/index.tsx
@@ -5,12 +5,15 @@ import { theme } from '@hcc/styles';
 import { Icon, Modal } from '@hcc/ui';
 import { useRef } from 'react';
 
+import useTracker from '@/hooks/useTracker';
+
 import * as styles from './Sidebar.css';
 import AsyncBoundary from '../AsyncBoundary';
 import LeagueList from '../LeagueList';
 import LeagueListSkeleton from '../LeagueList/Skeleton';
 
 export default function Sidebar() {
+  const { tracker } = useTracker();
   const ref = useRef<HTMLButtonElement>(null);
   const handleClose = () => {
     ref.current?.click();
@@ -18,7 +21,10 @@ export default function Sidebar() {
 
   return (
     <Modal>
-      <Modal.Trigger className={styles.openIconButton}>
+      <Modal.Trigger
+        className={styles.openIconButton}
+        onClick={() => tracker('sidebar', { clickEvent: 'open sidebar' })}
+      >
         <Icon
           source={HamburgerIcon}
           aria-label="메뉴 열기"

--- a/apps/spectator/components/TeamLogo/index.tsx
+++ b/apps/spectator/components/TeamLogo/index.tsx
@@ -1,0 +1,35 @@
+import { SymbolIcon } from '@hcc/icons';
+import { Icon } from '@hcc/ui';
+import Image from 'next/image';
+import { ComponentPropsWithoutRef, useState } from 'react';
+
+interface TeamLogoProps extends ComponentPropsWithoutRef<typeof Image> {
+  fallback?: string;
+}
+
+export default function TeamLogo({
+  src,
+  alt,
+  width,
+  height,
+  ...props
+}: TeamLogoProps) {
+  const [error, setError] = useState<boolean>(false);
+
+  return (
+    <>
+      {error ? (
+        <Icon source={SymbolIcon} />
+      ) : (
+        <Image
+          src={src}
+          alt={alt}
+          width={width}
+          height={height}
+          onError={() => setError(true)}
+          {...props}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/spectator/contexts/AmplitudeContext.tsx
+++ b/apps/spectator/contexts/AmplitudeContext.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { init, track } from '@amplitude/analytics-browser';
+import { useEffect, createContext } from 'react';
+
+const AMPLITUDE_API_KEY = process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY || '';
+
+type AmplitudeContextType = {
+  tracker(eventName: string, eventProperties?: Record<string, unknown>): void;
+};
+
+export const AmplitudeContext = createContext<AmplitudeContextType>({
+  tracker: () => {},
+});
+
+type AmplitudeContextProviderProps = {
+  children: React.ReactNode;
+};
+
+export default function AmplitudeContextProvider({
+  children,
+}: AmplitudeContextProviderProps) {
+  useEffect(() => {
+    init(AMPLITUDE_API_KEY, undefined, {
+      defaultTracking: {
+        pageViews: false,
+      },
+    });
+  }, []);
+
+  const tracker = (
+    eventName: string,
+    eventProperties: Record<string, unknown>,
+  ) => {
+    track(eventName, eventProperties);
+  };
+
+  const value = { tracker };
+
+  return (
+    <AmplitudeContext.Provider value={value}>
+      {children}
+    </AmplitudeContext.Provider>
+  );
+}

--- a/apps/spectator/hooks/useTracker.ts
+++ b/apps/spectator/hooks/useTracker.ts
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+
+import { AmplitudeContext } from '@/contexts/AmplitudeContext';
+
+export default function useTracker() {
+  const context = useContext(AmplitudeContext);
+
+  if (!context)
+    throw new Error(
+      'useTracker must be used within a AmplitudeContextProvider',
+    );
+
+  return context;
+}

--- a/apps/spectator/queries/useCheerMutation.ts
+++ b/apps/spectator/queries/useCheerMutation.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { postCheer } from '@/api/game';
-import { GameCheerType } from '@/types/game';
 
 type CheerMutationOptions = {
   gameTeamId: number;
@@ -14,42 +13,6 @@ export default function useCheerMutation() {
 
   return useMutation({
     mutationFn: (params: CheerMutationOptions) => postCheer(params),
-    onMutate: async ({ gameId, gameTeamId, cheerCount }) => {
-      // 이전 데이터를 가져옴
-      const previousData = queryClient.getQueryData(['game-cheer', gameId]) as
-        | GameCheerType[]
-        | null;
-
-      // 요청 취소
-      await queryClient.cancelQueries({ queryKey: ['game-cheer', gameId] });
-
-      // 데이터 업데이트
-      if (previousData) {
-        const updatedData = previousData.map(item => {
-          if (item.gameTeamId === gameTeamId) {
-            return {
-              ...item,
-              cheerCount: item.cheerCount + cheerCount,
-            };
-          }
-
-          return item;
-        });
-
-        queryClient.setQueryData(['game-cheer', gameId], updatedData);
-      }
-
-      return { previousData };
-    },
-    onError: (err, variables, context) => {
-      // 에러 발생 시 이전 데이터로 롤백
-      if (context?.previousData) {
-        queryClient.setQueryData(
-          ['game-cheer', variables.gameId],
-          context.previousData,
-        );
-      }
-    },
     onSettled: (data, error, variables) => {
       // 쿼리 갱신
       queryClient.invalidateQueries({

--- a/apps/spectator/queries/useCheerTalkById.ts
+++ b/apps/spectator/queries/useCheerTalkById.ts
@@ -26,6 +26,9 @@ export default function useCheerTalkById(gameId: string) {
       ),
       pageParams: [...data.pageParams].reverse(),
     }),
+
+    // refetch options
+    staleTime: 1000,
   });
 
   if (query.data.pageParams.length === 0) throw query.error;

--- a/apps/spectator/queries/useGameById.ts
+++ b/apps/spectator/queries/useGameById.ts
@@ -2,11 +2,22 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getGameById } from '@/api/game';
 
+const GAME_DETAIL_POLLING_INTERVAL = 1000 * 60;
 export const GAME_DETAIL_QUERY_KEY = 'GAME_DETAIL';
-export default function useGameById(gameId: string) {
+export default function useGameById(
+  gameId: string,
+  interval = GAME_DETAIL_POLLING_INTERVAL,
+) {
   const { data, error } = useSuspenseQuery({
     queryKey: [GAME_DETAIL_QUERY_KEY, gameId],
     queryFn: () => getGameById(gameId),
+
+    // refetch options
+    refetchInterval: interval,
+    refetchOnReconnect: true,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+    staleTime: 1000 * 60,
   });
 
   if (error) throw error;

--- a/packages/ui/src/modal/index.tsx
+++ b/packages/ui/src/modal/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useCallback, useState } from 'react';
+import { createContext, useCallback, useEffect, useState } from 'react';
 
 import ModalClose from './Close';
 import ModalContent from './Content';
@@ -27,6 +27,11 @@ const Modal = ({ defaultState, children }: ModalProps) => {
   const [open, setOpen] = useState(!!defaultState);
   const onOpenChange = useCallback((open: boolean) => setOpen(open), []);
   const onOpenToggle = useCallback(() => setOpen(prev => !prev), []);
+
+  useEffect(() => {
+    if (open) document.body.style.overflow = 'hidden';
+    else document.body.style.overflow = '';
+  }, [open]);
 
   return (
     <ModalContext.Provider value={{ open, onOpenChange, onOpenToggle }}>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #235 

## ✅ 작업 내용

- 한 번 응원하기 요청을 보내면 여러 번 중복해서 응원하기 요청이 발생하는 버그를 제거합니다.
- 원인은 낙관적 업데이트 때문으로 보이며, 쿼리가 발생할 때마다 cheer count를 강제로 변경해주고 있는데 이 부분에서 상태 변경이 감지되어 디바운싱이 시작되고, 그래서 중복 요청이 발생한 것으로 보입니다.
- 자세한 내용은 조금 더 알아봐야 할 것 같습니다.

## 📝 참고 자료

## ♾️ 기타
