### PR TITLE
[FIX] amplitude event name 재설정

### DIFF
--- a/apps/spectator/app/_components/GameList/Button.tsx
+++ b/apps/spectator/app/_components/GameList/Button.tsx
@@ -23,7 +23,9 @@ export default function GameButton({ id, state, hasVideo }: GameButtonProps) {
       {state === GAME_STATE.PLAYING && (
         <Link
           href={{ pathname: `/game/${id}`, query: { cheer: 'open' } }}
-          onClick={() => tracker(`gameList | cheer button ${id}`)}
+          onClick={() =>
+            tracker(`gameList`, { clickEvent: `cheer button ${id}` })
+          }
           className={styles.gameButtonArea.cheer}
         >
           응원
@@ -35,7 +37,11 @@ export default function GameButton({ id, state, hasVideo }: GameButtonProps) {
             pathname: `/game/${id}`,
             query: { tab: TABS_CONFIG.HIGHLIGHT },
           }}
-          onClick={() => tracker(`gameList | video button ${id}`)}
+          onClick={() =>
+            tracker(`gameList`, {
+              clickEvent: `highlight button ${id}`,
+            })
+          }
           className={styles.gameButtonArea.record}
         >
           영상
@@ -47,7 +53,9 @@ export default function GameButton({ id, state, hasVideo }: GameButtonProps) {
           pathname: `/game/${id}`,
           query: { tab: TABS_CONFIG.TIMELINE },
         }}
-        onClick={() => tracker(`gameList | timeline card ${id}`)}
+        onClick={() =>
+          tracker(`gameList`, { clickEvent: `timeline button ${id}` })
+        }
         className={styles.gameButtonArea.record}
       >
         기록

--- a/apps/spectator/app/_components/GameList/Info.tsx
+++ b/apps/spectator/app/_components/GameList/Info.tsx
@@ -23,7 +23,9 @@ export default function GameInfo({ gameTeams, gameId, state }: GameInfoProps) {
     <Link
       href={`/game/${gameId}`}
       className={styles.gameInfoArea}
-      onClick={() => tracker(`gameList | ${gameId} ${state} game card`)}
+      onClick={() =>
+        tracker(`gameList`, { clickEvent: `${gameId} ${state} game card` })
+      }
     >
       <div className={styles.gameInfoRow.root}>
         <div className={styles.gameInfoRow.team}>

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/EntryButton/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/EntryButton/index.tsx
@@ -20,7 +20,7 @@ export default function CheerTalkEntryButton(props: ComponentProps<'button'>) {
   }, []);
 
   const handleButtonClick = () => {
-    tracker('open cheerTalk', { clickEvent: 'cheerTalk' });
+    tracker('cheerTalk', { clickEvent: 'open cheerTalk' });
 
     setIsCheerTalkTooltipVisible(false);
     window.localStorage.setItem(TOOLTIP_KEY, String(false));

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/MenuModal/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/MenuModal/index.tsx
@@ -30,7 +30,7 @@ const CheerTalkMenuModal = ({
       return;
     }
 
-    tracker(`report cheerTalk | "${content}"`, { clickEvent: 'report' });
+    tracker(`report`, { clickEvent: `report cheerTalk | "${content}"` });
 
     mutate(payload);
   };

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/index.tsx
@@ -52,7 +52,12 @@ export default function CheerTalk({
 
   return (
     <Modal defaultState={defaultState}>
-      <Modal.Trigger as="span" onClick={() => tracker('onAir CheerTalk Modal')}>
+      <Modal.Trigger
+        as="span"
+        onClick={() =>
+          tracker('onAir', { clickEvent: 'onAir CheerTalk Modal' })
+        }
+      >
         <CheerTalkOnAir
           cheerTalk={
             !socketTalkList.length ? cheerTalkList.pages : socketTalkList

--- a/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
@@ -34,8 +34,8 @@ export default function CheerTeamBox({
     () => {
       if (count === cheerCount) return;
 
-      tracker(`cheerVS | ${gameTeamName}(${gameId}) - ${count - cheerCount}`, {
-        clickEvent: `team (${direction})`,
+      tracker(`cheerVS ${gameTeamName}(${gameId})`, {
+        clickEvent: `${count - cheerCount}`,
       });
 
       mutate(

--- a/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
@@ -34,8 +34,8 @@ export default function CheerTeamBox({
     () => {
       if (count === cheerCount) return;
 
-      tracker(`cheerVS ${gameTeamName}(${gameId})`, {
-        clickEvent: `${count - cheerCount}`,
+      tracker(`cheerVS`, {
+        clickEvent: `${gameTeamName}(${gameId}) | ${count - cheerCount}`,
       });
 
       mutate(

--- a/apps/spectator/components/LeagueList/index.tsx
+++ b/apps/spectator/components/LeagueList/index.tsx
@@ -23,8 +23,8 @@ export default function LeagueList({ handleClose }: LeagueListProps) {
   const { data: leagues } = useLeagueArchives<typeof YEARS_LIST>(YEARS_LIST);
 
   const handleClickLeague = (year: number, leagueId: number, name: string) => {
-    tracker(`leagueList | ${year}년도 ${name}(${leagueId})`, {
-      clickEvent: `Select Archived League`,
+    tracker(`leagueList`, {
+      clickEvent: `Selected ${year}년도 ${name}(${leagueId})`,
     });
 
     handleClose();


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #238 

## ✅ 작업 내용

- 이벤트명을 기능 별로 통일합니다.

ex)

```ts
// cheerVS
tracker(`cheerVS ${gameTeamName}(${gameId})`, {
  clickEvent: `${count - cheerCount}`,
});

// gameList
onClick={() =>
  tracker(`gameList`, { clickEvent: `${gameId} ${state} game card` })
}
```

이제 다음과 같이 이벤트를 모아서 확인할 수 있습니다.

![image](https://github.com/hufscheer/client_v2/assets/88662637/253ea32b-17c5-45d8-936d-55cdd622869a)

## 📝 참고 자료

## ♾️ 기타

