### PR TITLE
[FIX] cheerVS 음수 데이터 전송 버그 해결

### DIFF
--- a/apps/spectator/app/_components/GameList/Button.tsx
+++ b/apps/spectator/app/_components/GameList/Button.tsx
@@ -23,7 +23,9 @@ export default function GameButton({ id, state, hasVideo }: GameButtonProps) {
       {state === GAME_STATE.PLAYING && (
         <Link
           href={{ pathname: `/game/${id}`, query: { cheer: 'open' } }}
-          onClick={() => tracker(`gameList | cheer button ${id}`)}
+          onClick={() =>
+            tracker(`gameList`, { clickEvent: `cheer button ${id}` })
+          }
           className={styles.gameButtonArea.cheer}
         >
           응원
@@ -35,7 +37,11 @@ export default function GameButton({ id, state, hasVideo }: GameButtonProps) {
             pathname: `/game/${id}`,
             query: { tab: TABS_CONFIG.HIGHLIGHT },
           }}
-          onClick={() => tracker(`gameList | video button ${id}`)}
+          onClick={() =>
+            tracker(`gameList`, {
+              clickEvent: `highlight button ${id}`,
+            })
+          }
           className={styles.gameButtonArea.record}
         >
           영상
@@ -47,7 +53,9 @@ export default function GameButton({ id, state, hasVideo }: GameButtonProps) {
           pathname: `/game/${id}`,
           query: { tab: TABS_CONFIG.TIMELINE },
         }}
-        onClick={() => tracker(`gameList | timeline card ${id}`)}
+        onClick={() =>
+          tracker(`gameList`, { clickEvent: `timeline button ${id}` })
+        }
         className={styles.gameButtonArea.record}
       >
         기록

--- a/apps/spectator/app/_components/GameList/Info.tsx
+++ b/apps/spectator/app/_components/GameList/Info.tsx
@@ -23,7 +23,9 @@ export default function GameInfo({ gameTeams, gameId, state }: GameInfoProps) {
     <Link
       href={`/game/${gameId}`}
       className={styles.gameInfoArea}
-      onClick={() => tracker(`gameList | ${gameId} ${state} game card`)}
+      onClick={() =>
+        tracker(`gameList`, { clickEvent: `${gameId} ${state} game card` })
+      }
     >
       <div className={styles.gameInfoRow.root}>
         <div className={styles.gameInfoRow.team}>

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/EntryButton/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/EntryButton/index.tsx
@@ -20,7 +20,7 @@ export default function CheerTalkEntryButton(props: ComponentProps<'button'>) {
   }, []);
 
   const handleButtonClick = () => {
-    tracker('open cheerTalk', { clickEvent: 'cheerTalk' });
+    tracker('cheerTalk', { clickEvent: 'open cheerTalk' });
 
     setIsCheerTalkTooltipVisible(false);
     window.localStorage.setItem(TOOLTIP_KEY, String(false));

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/MenuModal/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/MenuModal/index.tsx
@@ -30,7 +30,7 @@ const CheerTalkMenuModal = ({
       return;
     }
 
-    tracker(`report cheerTalk | "${content}"`, { clickEvent: 'report' });
+    tracker(`report`, { clickEvent: `report cheerTalk | "${content}"` });
 
     mutate(payload);
   };

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/index.tsx
@@ -52,7 +52,12 @@ export default function CheerTalk({
 
   return (
     <Modal defaultState={defaultState}>
-      <Modal.Trigger as="span" onClick={() => tracker('onAir CheerTalk Modal')}>
+      <Modal.Trigger
+        as="span"
+        onClick={() =>
+          tracker('onAir', { clickEvent: 'onAir CheerTalk Modal' })
+        }
+      >
         <CheerTalkOnAir
           cheerTalk={
             !socketTalkList.length ? cheerTalkList.pages : socketTalkList

--- a/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
@@ -34,8 +34,8 @@ export default function CheerTeamBox({
     () => {
       if (count === cheerCount) return;
 
-      tracker(`cheerVS | ${gameTeamName}(${gameId}) - ${count - cheerCount}`, {
-        clickEvent: `team (${direction})`,
+      tracker(`cheerVS ${gameTeamName}(${gameId})`, {
+        clickEvent: `${count - cheerCount}`,
       });
 
       mutate(

--- a/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
@@ -44,7 +44,7 @@ export default function CheerTeamBox({
       );
     },
     1000,
-    [cheerCount, gameId, gameTeamId, mutate],
+    [gameId, gameTeamId, mutate],
   );
 
   const handleCheerClick = () => {

--- a/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
@@ -34,8 +34,8 @@ export default function CheerTeamBox({
     () => {
       if (count === cheerCount) return;
 
-      tracker(`cheerVS ${gameTeamName}(${gameId})`, {
-        clickEvent: `${count - cheerCount}`,
+      tracker(`cheerVS`, {
+        clickEvent: `${gameTeamName}(${gameId}) | ${count - cheerCount}`,
       });
 
       mutate(

--- a/apps/spectator/components/LeagueList/index.tsx
+++ b/apps/spectator/components/LeagueList/index.tsx
@@ -23,8 +23,8 @@ export default function LeagueList({ handleClose }: LeagueListProps) {
   const { data: leagues } = useLeagueArchives<typeof YEARS_LIST>(YEARS_LIST);
 
   const handleClickLeague = (year: number, leagueId: number, name: string) => {
-    tracker(`leagueList | ${year}년도 ${name}(${leagueId})`, {
-      clickEvent: `Select Archived League`,
+    tracker(`leagueList`, {
+      clickEvent: `Selected ${year}년도 ${name}(${leagueId})`,
     });
 
     handleClose();

--- a/apps/spectator/queries/useCheerMutation.ts
+++ b/apps/spectator/queries/useCheerMutation.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { postCheer } from '@/api/game';
-import { GameCheerType } from '@/types/game';
 
 type CheerMutationOptions = {
   gameTeamId: number;
@@ -14,48 +13,11 @@ export default function useCheerMutation() {
 
   return useMutation({
     mutationFn: (params: CheerMutationOptions) => postCheer(params),
-    onMutate: async ({ gameId, gameTeamId, cheerCount }) => {
-      // 이전 데이터를 가져옴
-      const previousData = queryClient.getQueryData(['game-cheer', gameId]) as
-        | GameCheerType[]
-        | null;
-
-      // 요청 취소
-      await queryClient.cancelQueries({ queryKey: ['game-cheer', gameId] });
-
-      // 데이터 업데이트
-      if (previousData) {
-        const updatedData = previousData.map(item => {
-          if (item.gameTeamId === gameTeamId) {
-            return {
-              ...item,
-              cheerCount: item.cheerCount + cheerCount,
-            };
-          }
-
-          return item;
-        });
-
-        queryClient.setQueryData(['game-cheer', gameId], updatedData);
-      }
-
-      return { previousData };
-    },
-    onError: (err, variables, context) => {
-      // 에러 발생 시 이전 데이터로 롤백
-      if (context?.previousData) {
-        queryClient.setQueryData(
-          ['game-cheer', variables.gameId],
-          context.previousData,
-        );
-      }
-    },
     onSettled: (data, error, variables) => {
       // 쿼리 갱신
       queryClient.invalidateQueries({
         queryKey: ['game-cheer', variables.gameId],
       });
     },
-    retry: 1,
   });
 }


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #240 

## ✅ 작업 내용

- 응원하기에서 더 이상 음수 데이터를 전송하지 않습니다.
  - 응원하기 API를 호출할 때마다 쿼리 캐시를 무효화 하여 최신 데이터로 유지합니다.
  - 따라서 cheerCount가 매 응원하기 호출 시 변경됩니다.
  - useEffect를 통해 cheerCount가 변경될 때마다 count 상태를 업데이트합니다.
  - 이제 더이상 응원하기 호출 시 cheerCount와 count 간의 격차가 발생하지 않습니다.
  - 따라서 음수 데이터를 전송하는 경우도 사라집니다.

## 📝 참고 자료

## ♾️ 기타
