### PR TITLE
[REFACTOR] 필터 클릭 시 화면 가운데로 이동

### DIFF
--- a/apps/spectator/app/_components/GameFilter/GameFilter.css.ts
+++ b/apps/spectator/app/_components/GameFilter/GameFilter.css.ts
@@ -6,6 +6,7 @@ export const wrapper = style({
   width: '100%',
   overflow: 'hidden',
   backgroundColor: theme.colors.gray[1],
+  zIndex: 1,
 });
 
 export const filterItemBase = style({
@@ -89,7 +90,7 @@ export const leagueTeam = styleVariants({
   list: {
     display: 'flex',
     flexWrap: 'nowrap',
-    overflowY: 'scroll',
+    overflowX: 'scroll',
     msOverflowStyle: 'none',
     scrollbarWidth: 'none',
     '::-webkit-scrollbar': {

--- a/apps/spectator/app/_components/GameFilter/LeagueTeamFilter.tsx
+++ b/apps/spectator/app/_components/GameFilter/LeagueTeamFilter.tsx
@@ -36,17 +36,10 @@ export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
   const scrollToCenter = (itemElement: HTMLButtonElement) => {
     if (!itemElement || !scrollRef.current) return;
 
-    const containerWidth =
-      scrollRef.current.parentElement?.clientWidth ??
-      scrollRef.current.clientWidth;
-    const itemWidth = itemElement.offsetWidth;
-    const itemLeft = itemElement.offsetLeft;
-
-    const scrollCoordinate = itemLeft - containerWidth / 2 + itemWidth / 2;
-
-    scrollRef.current.scrollTo({
-      left: scrollCoordinate,
+    itemElement.scrollIntoView({
       behavior: 'smooth',
+      block: 'center',
+      inline: 'center',
     });
   };
 

--- a/apps/spectator/app/_components/GameFilter/LeagueTeamFilter.tsx
+++ b/apps/spectator/app/_components/GameFilter/LeagueTeamFilter.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import { useConveyer } from '@egjs/react-conveyer';
 import { CaretDownIcon } from '@hcc/icons';
 import { Icon } from '@hcc/ui';
 import { clsx } from 'clsx';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { MouseEvent, forwardRef, useEffect, useRef, useState } from 'react';
+import { MouseEvent, useEffect, useRef, useState } from 'react';
 
 import useLeagueTeams from '@/queries/useLeagueTeams';
 
@@ -13,9 +14,15 @@ import * as styles from './GameFilter.css';
 export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const scrollRef = useRef<HTMLUListElement>(null);
-  const itemRef = useRef<HTMLLIElement>(null);
+  const scrollRef = useRef<HTMLUListElement | null>(null);
   const prevScrollLeftRef = useRef(0);
+
+  useConveyer(scrollRef, {
+    horizontal: true,
+    useDrag: true,
+    useSideWheel: true,
+    preventClickOnDrag: true,
+  });
 
   const toggleExpand = () => {
     if (!isExpanded && scrollRef.current) {
@@ -94,53 +101,21 @@ export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
           isExpanded && styles.leagueTeam.listExpanded,
         )}
       >
-        {leagueTeams.map(team => {
-          const isSelected = selectedLeagueTeam.includes(
-            team.leagueTeamId.toString(),
-          );
-
-          return (
-            <Item
-              key={team.leagueTeamId}
-              team={team}
-              isSelected={isSelected}
-              handleRouter={handleRouter}
-              ref={itemRef}
-            />
-          );
-        })}
+        {leagueTeams.map(team => (
+          <li key={team.leagueTeamId}>
+            <button
+              onClick={e => handleRouter(e, team.leagueTeamId)}
+              className={clsx(
+                styles.leagueTeam.itemExpanded,
+                selectedLeagueTeam.includes(team.leagueTeamId.toString()) &&
+                  styles.leagueTeam.itemFocused,
+              )}
+            >
+              {team.teamName}
+            </button>
+          </li>
+        ))}
       </ul>
     </div>
   );
 }
-
-type ItemProps = {
-  isSelected: boolean;
-  handleRouter: (
-    e: MouseEvent<HTMLButtonElement>,
-    selectedTeamId: number,
-  ) => void;
-  team: {
-    leagueTeamId: number;
-    teamName: string;
-  };
-};
-
-const Item = forwardRef<HTMLLIElement, ItemProps>(function Item(
-  { team: { leagueTeamId, teamName }, isSelected, handleRouter },
-  ref,
-) {
-  return (
-    <li ref={ref}>
-      <button
-        onClick={e => handleRouter(e, leagueTeamId)}
-        className={clsx(
-          styles.leagueTeam.itemExpanded,
-          isSelected && styles.leagueTeam.itemFocused,
-        )}
-      >
-        {teamName}
-      </button>
-    </li>
-  );
-});

--- a/apps/spectator/package.json
+++ b/apps/spectator/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 3001",
+    "dev": "next dev --port 3001 -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --max-warnings 0"
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-browser": "^2.6.1",
+    "@egjs/react-conveyer": "^1.7.1",
     "@egjs/react-flicking": "^3.8.3",
     "@hcc/icons": "workspace:^",
     "@hcc/styles": "workspace:*",

--- a/packages/ui/src/spinner/spinner.tsx
+++ b/packages/ui/src/spinner/spinner.tsx
@@ -3,11 +3,11 @@ import { clsx } from 'clsx';
 import * as styles from './styles.css';
 
 type SpinnerProps = {
-  size: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg';
   className?: string;
 };
 
-export function Spinner({ size, className }: SpinnerProps) {
+export function Spinner({ size = 'md', className }: SpinnerProps) {
   return (
     <div className={clsx(styles.wrapper, className)}>
       <svg

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@amplitude/analytics-browser':
         specifier: ^2.6.1
         version: 2.6.1
+      '@egjs/react-conveyer':
+        specifier: ^1.7.1
+        version: 1.7.1
       '@egjs/react-flicking':
         specifier: ^3.8.3
         version: 3.8.3
@@ -1744,6 +1747,12 @@ packages:
   '@cfcs/core@0.0.24':
     resolution: {integrity: sha512-feB38qu+eDk0Pggh/yR7gjaNmvUYA2uCxHP3Pz2MLE4LZ/9jPdtu8bzCSI47yTEhWyZCF5Pk698hdz8IN2mTjA==}
 
+  '@cfcs/core@0.1.0':
+    resolution: {integrity: sha512-kvYX0RpL45XTHJ5sW7teNbKeAa7pK3nNqaJPoFfZDPTIBJOkTtRD3QhkBG+O3Hu69a8xeMoPvF6y/RtJ6JUOdA==}
+
+  '@cfcs/react@0.1.0':
+    resolution: {integrity: sha512-3IaDaE1Qn0iLZ1ZqD0cqoiX0Kjzp6/VB56409A963lQ5kK6ONNa3cNbCBqFZccCfPSnyzeSdvPlg75Af3W4raA==}
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -1831,6 +1840,9 @@ packages:
   '@egjs/axes@2.8.0':
     resolution: {integrity: sha512-WPMIM/ExZBS8guD3oeNr6YGDn2xSnj0YUZHWvY/NWvTQIs7A2O7WxJivYgzcg7r2q0RYtzrdpHn+982iaKCLSw==}
 
+  '@egjs/axes@3.9.0':
+    resolution: {integrity: sha512-V+HxHxEGmlu/0yJ9kqlj2doiJt1yVeROTy/0Qf+IaJ9hMabjzUgfYffGR+3atcRpejjGbcpAIiBrGbAkDVaLjg==}
+
   '@egjs/children-differ@1.0.1':
     resolution: {integrity: sha512-DRvyqMf+CPCOzAopQKHtW+X8iN6Hy6SFol+/7zCUiE5y4P/OB8JP8FtU4NxtZwtafvSL4faD5KoQYPj3JHzPFQ==}
 
@@ -1839,6 +1851,9 @@ packages:
 
   '@egjs/component@3.0.5':
     resolution: {integrity: sha512-cLcGizTrrUNA2EYE3MBmEDt2tQv1joVP1Q3oDisZ5nw0MZDx2kcgEXM+/kZpfa/PAkFvYVhRUZwytIQWoN3V/w==}
+
+  '@egjs/conveyer@1.7.1':
+    resolution: {integrity: sha512-09437dICKxuRV/Q/ZpHyzekz8NCBXB5t7KAhmK7BBxwLH0DKrlMWagBiTdeMhgnq4vVpn5CcHvCO9y9SeHbGqQ==}
 
   '@egjs/flicking@3.9.3':
     resolution: {integrity: sha512-KGOSSeGDA9+0m24F3/hC+nc77/kRPuIVM3prTRcPB5jzhWcxJHpP9nyxJvitFJ+Ge4sPbZQxzLzUErgz9rrfWQ==}
@@ -1852,6 +1867,9 @@ packages:
 
   '@egjs/list-differ@1.0.1':
     resolution: {integrity: sha512-OTFTDQcWS+1ZREOdCWuk5hCBgYO4OsD30lXcOCyVOAjXMhgL5rBRDnt/otb6Nz8CzU0L/igdcaQBDLWc4t9gvg==}
+
+  '@egjs/react-conveyer@1.7.1':
+    resolution: {integrity: sha512-V53KUNbrAmL4jOE3Ny3utxPBvgmXOT14K1S3WF721ZU8KaSEVvpQnudBvnbHLpVROzVw3a9VWDQ9mA/zfOCBBw==}
 
   '@egjs/react-flicking@3.8.3':
     resolution: {integrity: sha512-DMvd8ckXD2FxHHneOV5nmowFzq5o5a32585iFAwBaG32H+rpK+UBeR3sqzPNuITysRYmLEOpGhNBa6Afi/Ed/w==}
@@ -9946,6 +9964,14 @@ snapshots:
     dependencies:
       '@egjs/component': 3.0.5
 
+  '@cfcs/core@0.1.0':
+    dependencies:
+      '@egjs/component': 3.0.5
+
+  '@cfcs/react@0.1.0':
+    dependencies:
+      '@cfcs/core': 0.1.0
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -10076,6 +10102,12 @@ snapshots:
       '@egjs/component': 2.2.2
       '@egjs/hammerjs': 2.0.17
 
+  '@egjs/axes@3.9.0':
+    dependencies:
+      '@cfcs/core': 0.1.0
+      '@egjs/agent': 2.4.3
+      '@egjs/component': 3.0.5
+
   '@egjs/children-differ@1.0.1':
     dependencies:
       '@egjs/list-differ': 1.0.1
@@ -10083,6 +10115,13 @@ snapshots:
   '@egjs/component@2.2.2': {}
 
   '@egjs/component@3.0.5': {}
+
+  '@egjs/conveyer@1.7.1':
+    dependencies:
+      '@cfcs/core': 0.1.0
+      '@egjs/axes': 3.9.0
+      '@egjs/children-differ': 1.0.1
+      '@egjs/component': 3.0.5
 
   '@egjs/flicking@3.9.3':
     dependencies:
@@ -10101,6 +10140,11 @@ snapshots:
       '@egjs/component': 3.0.5
 
   '@egjs/list-differ@1.0.1': {}
+
+  '@egjs/react-conveyer@1.7.1':
+    dependencies:
+      '@cfcs/react': 0.1.0
+      '@egjs/conveyer': 1.7.1
 
   '@egjs/react-flicking@3.8.3':
     dependencies:


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #259 

## ✅ 작업 내용

- 필터를 클릭 했을 때 화면 가운데로 이동합니다. 
- 드래그를 통해 필터 동작
- 마우스 휠을 통해 횡스크롤 동작

### 문제 

- `@egjs/Flicking`을 사용했을 때 모바일에서 제대로 동작하지 않는 버그가 있었습니다.
- 이에 따라 가로로 길어질 수 있는 대회 팀 목록에 대해서 제한적으로 커스텀 스크롤 이벤트가 적용되어 있던 상황입니다.
- 하지만 드래그 이벤트를 추가로 적용하지 않아서 현재는 웹 브라우저에서 스크롤 이벤트만 적용이 되고 있었습니다.
- 추가로 가로 스크롤을 발생시키기 위해 `shift + mouse wheel`을 동작시켜야 했기 때문에 해당 커맨드를 모르는 사용자의 경우 불편함을 겪을 수 있었습니다.

### 첫 번째 시도

[embla-carousel](embla-carousel.com), [keen-slider](keen-slider.io) 등의 라이브러리를 이용하여 캐러셀 컴포넌트를 만들어보려 시도했습니다.

하지만 애초에 **캐러셀 혹은 슬라이더**라는 컴포넌트와 우리가 만들고자 하는 필터 컴포넌트의 쓰임새가 달랐기 때문에 라이브러리 내에서 제공하지 않거나, 스펙이 맞지 않는 경우가 많았습니다. 그래서 패키지를 커스텀하거나 일종의 꼼수를 부려 요구사항을 만족하기 위해 시도해보았지만, 말 그대로 꼼수였기 때문에 사이드 이펙트가 발생하기 일쑤였습니다. 

ex) 요소 클릭 시 가운데에 위치하도록 하기 위해 직접 거리를 계산해줘야 하는 문제. 매번 거리를 계산하다 보니 버벅임이 있었음

그래서 해당 방법은 폐기했습니다.

### 두 번째 시도

`Element.scrollIntoView()` 메서드를 이용하여 가독성을 해치거나 성능 저하 없이 요소 클릭 시 화면 중앙에 위치하도록 할 수 있었습니다.

다음으로 고려할 문제는 드래그 이벤트를 통해 필터 목록을 움직일 수 있도록 하는 것이었습니다. 앞선 시도로 인해 가용 시간이 부족하다고 판단해서 라이브러리 사용을 고려했고, 마침 스크롤을 횡스크롤로 바꾸거나 드래그로 스크롤 할 수 있도록 간단한 인터페이스를 제공하는 라이브러리를 발견하여 사용하면 좋을 것이라 생각했습니다. [`@egjs/conveyer`](https://naver.github.io/egjs-conveyer/)

해당 라이브러리를 이용하여 
- 마우스 휠 이벤트만을 이용하여 가로 스크롤 조작
- 드래그를 이용하여 스크롤
할 수 있도록 기능을 수정해두었습니다.

## 📝 참고 자료

### 관련 영상

https://github.com/hufscheer/client_v2/assets/88662637/b24107e0-a70f-48b1-9b49-eab833e35b49

### 추상화 관련

현재 메인 페이지의 네 가지 필터가 모두 비슷한 인터페이스를 갖고 있습니다.
따라서 추후 `@egjs/Flicking`을 제거하고 `@egjs/conveyer + Element.scrollIntoView`를 이용하여 필터를 동작할 수 있는 추상화 컴포넌트(혹은 custom hooks)를 만들면 좋을 것 같다고 판단했습니다. 나중에 시간이 남으면 한 번 해보도록 하겠습니다!

## ♾️ 기타

- spinner 컴포넌트의 size props를 optional로 변환합니다.