### PR TITLE
[FEAT] Form 요소 추가

### DIFF
--- a/docs/storybook/.storybook/preview.tsx
+++ b/docs/storybook/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type { Preview } from '@storybook/react';
 
 import '@hcc/styles/dist/globals.css';
@@ -12,6 +13,13 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [
+    Story => (
+      <div style={{ width: '393px' }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default preview;

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -6,7 +6,10 @@
     "@hcc/icons": "workspace:^",
     "@hcc/styles": "workspace:*",
     "@hcc/ui": "workspace:*",
-    "@vanilla-extract/css": "^1.14.0"
+    "@hookform/resolvers": "^3.6.0",
+    "@vanilla-extract/css": "^1.14.0",
+    "react-hook-form": "^7.51.5",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@hcc/eslint-config": "workspace:*",

--- a/docs/storybook/stories/Form.stories.tsx
+++ b/docs/storybook/stories/Form.stories.tsx
@@ -1,0 +1,256 @@
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormLabel,
+  FormMessage,
+  Input,
+  Toaster,
+  toast,
+} from '@hcc/ui';
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const meta = {
+  title: '@hcc/Form',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Form>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultFormSchema = z.object({
+  name: z.string().min(2, { message: '이름은 2글자 이상이어야 합니다.' }),
+  email: z.string().email({ message: '이메일 형식이 아닙니다.' }),
+});
+
+const defaultValues = {
+  name: '',
+  email: '',
+};
+
+type FormSchema = z.infer<typeof defaultFormSchema>;
+
+export const Default: Story = {
+  render: () => {
+    const methods = useForm<FormSchema>({
+      resolver: zodResolver(defaultFormSchema),
+      defaultValues,
+      mode: 'onSubmit',
+    });
+
+    const onSubmit = (data: FormSchema) => {
+      toast({
+        title: data.name,
+        description: data.email,
+      });
+    };
+
+    return (
+      <>
+        <Form {...methods}>
+          <form
+            onSubmit={methods.handleSubmit(onSubmit)}
+            style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+          >
+            <FormField name="name">
+              <FormLabel>이름</FormLabel>
+              <FormControl>
+                <Input />
+              </FormControl>
+              <FormMessage />
+            </FormField>
+
+            <FormField name="email">
+              <FormLabel>이메일</FormLabel>
+              <FormControl>
+                <Input />
+              </FormControl>
+              <FormMessage />
+            </FormField>
+
+            <button
+              style={{
+                width: '100%',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                backgroundColor: '#141B21',
+                color: '#fff',
+                borderRadius: 8,
+                paddingBlock: 16,
+                marginTop: 8,
+              }}
+            >
+              버튼
+            </button>
+          </form>
+        </Form>
+
+        <Toaster />
+      </>
+    );
+  },
+};
+
+const signupFormSchema = z.object({
+  id: z.string().email({ message: '아이디는 이메일 형식으로 입력해주세요.' }),
+  password: z
+    .string()
+    .min(8, { message: '비밀번호는 8글자 이상이어야 합니다.' })
+    .regex(/^(?=.*[a-zA-Z])(?=.*[!@#$%^&*])/, {
+      message: '영문자 혹은 특수문자를 포함해야 합니다.',
+    }),
+});
+
+const signupValues = {
+  id: '',
+  password: '',
+};
+
+type SignupFormSchema = z.infer<typeof signupFormSchema>;
+
+export const Signup: Story = {
+  render: () => {
+    const methods = useForm<SignupFormSchema>({
+      resolver: zodResolver(signupFormSchema),
+      defaultValues: signupValues,
+      mode: 'onSubmit',
+    });
+
+    const onSubmit = (data: SignupFormSchema) => {
+      toast({
+        title: '입력한 값은',
+        description: `id: ${data.id}, password: ${data.password}입니다.`,
+      });
+    };
+
+    return (
+      <>
+        <Form {...methods}>
+          <form
+            onSubmit={methods.handleSubmit(onSubmit)}
+            style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+          >
+            <FormField name="id">
+              <FormLabel>아이디</FormLabel>
+              <FormControl>
+                <Input />
+              </FormControl>
+              <FormMessage />
+            </FormField>
+
+            <FormField name="password">
+              <FormLabel>비밀번호</FormLabel>
+              <FormControl>
+                <Input type="password" />
+              </FormControl>
+              <FormMessage />
+            </FormField>
+
+            <button
+              style={{
+                width: '100%',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                backgroundColor: '#141B21',
+                color: '#fff',
+                borderRadius: 8,
+                paddingBlock: 16,
+                marginTop: 8,
+              }}
+            >
+              회원가입
+            </button>
+          </form>
+        </Form>
+
+        <Toaster />
+      </>
+    );
+  },
+};
+
+const onChangeFormSchema = z.object({
+  id: z.string().email({ message: '아이디는 이메일 형식으로 입력해주세요.' }),
+  password: z
+    .string()
+    .min(8, { message: '비밀번호는 8글자 이상이어야 합니다.' })
+    .regex(/^(?=.*[a-zA-Z])(?=.*[!@#$%^&*])/, {
+      message: '영문자 혹은 특수문자를 포함해야 합니다.',
+    }),
+});
+
+const onChangeValues = {
+  id: '',
+  password: '',
+};
+
+type OnChangeFormSchema = z.infer<typeof onChangeFormSchema>;
+
+export const OnChangeForm: Story = {
+  render: () => {
+    const methods = useForm<OnChangeFormSchema>({
+      resolver: zodResolver(onChangeFormSchema),
+      defaultValues: onChangeValues,
+      mode: 'onChange',
+    });
+
+    const onSubmit = (data: OnChangeFormSchema) => {
+      toast({
+        title: '입력한 값은',
+        description: `id: ${data.id}, password: ${data.password}입니다.`,
+      });
+    };
+
+    return (
+      <>
+        <Form {...methods}>
+          <form
+            onSubmit={methods.handleSubmit(onSubmit)}
+            style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+          >
+            <FormField name="id">
+              <FormLabel>아이디</FormLabel>
+              <FormControl>
+                <Input />
+              </FormControl>
+              <FormMessage />
+            </FormField>
+
+            <FormField name="password">
+              <FormLabel>비밀번호</FormLabel>
+              <FormControl>
+                <Input type="password" />
+              </FormControl>
+              <FormMessage />
+            </FormField>
+
+            <button
+              style={{
+                width: '100%',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                backgroundColor: '#141B21',
+                color: '#fff',
+                borderRadius: 8,
+                paddingBlock: 16,
+                marginTop: 8,
+              }}
+            >
+              회원가입
+            </button>
+          </form>
+        </Form>
+
+        <Toaster />
+      </>
+    );
+  },
+};

--- a/docs/storybook/stories/Input.stories.tsx
+++ b/docs/storybook/stories/Input.stories.tsx
@@ -1,21 +1,31 @@
 import { Input } from '@hcc/ui';
 import type { Meta, StoryObj } from '@storybook/react';
 
-// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
   title: '@hcc/Input',
   component: Input,
   parameters: {
-    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
     layout: 'centered',
   },
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-  tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  argTypes: {
+    type: {
+      control: {
+        type: 'inline-radio',
+        options: ['text', 'email', 'password'],
+      },
+      placeholder: 'text',
+      disabled: { control: 'boolean' },
+    },
+  },
 } satisfies Meta<typeof Input>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
-export const Primary: Story = {};
+export const Primary: Story = {
+  args: {
+    type: 'text',
+    placeholder: '뭐든 입력해보세요~',
+    disabled: false,
+  },
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,9 +36,11 @@
   "dependencies": {
     "@hcc/icons": "workspace:^",
     "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toast": "^1.1.5",
     "@vanilla-extract/css": "^1.14.0",
     "clsx": "^2.1.0",
-    "framer-motion": "^11.0.5"
+    "framer-motion": "^11.0.5",
+    "react-hook-form": "^7.51.5"
   }
 }

--- a/packages/ui/src/form/form.tsx
+++ b/packages/ui/src/form/form.tsx
@@ -1,0 +1,126 @@
+import { Slot } from '@radix-ui/react-slot';
+import { clsx } from 'clsx';
+import {
+  ComponentProps,
+  ComponentPropsWithoutRef,
+  HTMLAttributes,
+  ReactNode,
+  createContext,
+  forwardRef,
+  useId,
+} from 'react';
+import { FieldPath, FieldValues, FormProvider } from 'react-hook-form';
+
+import * as styles from './styles.css';
+import { useFormField } from './useFormField';
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  id: string;
+  name: TName;
+};
+
+export const FormFieldContext = createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue,
+);
+
+interface FormFieldProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> {
+  name: TName;
+  children: ReactNode;
+}
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  name,
+  children,
+}: FormFieldProps<TFieldValues, TName>) => {
+  const id = useId();
+
+  return (
+    <FormFieldContext.Provider value={{ name, id }}>
+      <div className={styles.formField}>{children}</div>
+    </FormFieldContext.Provider>
+  );
+};
+
+interface FormLabelProps extends ComponentPropsWithoutRef<'label'> {}
+
+const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(
+  ({ className, children, ...props }, ref) => {
+    const { formItemId, isDirty } = useFormField();
+
+    return (
+      <label
+        ref={ref}
+        htmlFor={formItemId}
+        data-dirty={isDirty ? 'filled' : 'empty'}
+        className={clsx(styles.label, className)}
+        {...props}
+      >
+        {children}
+      </label>
+    );
+  },
+);
+FormLabel.displayName = 'FormLabel';
+
+const FormControl = ({ className, ...props }: ComponentProps<typeof Slot>) => {
+  const {
+    register,
+    name,
+    error,
+    formItemId,
+    formDescriptionId,
+    formMessageId,
+  } = useFormField();
+
+  return (
+    <Slot
+      {...register(name)}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      className={clsx(styles.control, error && styles.errorBorder, className)}
+      aria-invalid={!!error}
+      {...props}
+    />
+  );
+};
+
+const FormMessage = forwardRef<
+  HTMLParagraphElement,
+  HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message) : children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={clsx(error && styles.errorMessage, className)}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+});
+FormMessage.displayName = 'FormMessage';
+
+export { Form, FormLabel, FormControl, FormMessage, FormField };

--- a/packages/ui/src/form/index.ts
+++ b/packages/ui/src/form/index.ts
@@ -1,0 +1,2 @@
+export * from './form';
+export * from './useFormField';

--- a/packages/ui/src/form/styles.css.ts
+++ b/packages/ui/src/form/styles.css.ts
@@ -1,0 +1,59 @@
+import { rem } from '@hcc/styles';
+import { globalStyle, style } from '@vanilla-extract/css';
+
+const errorColor = '#FC5555';
+
+export const formField = style({
+  position: 'relative',
+  width: '100%',
+});
+
+export const control = style({});
+
+export const label = style({
+  top: 0,
+  left: 0,
+  zIndex: 2,
+  height: '100%',
+  lineHeight: 1,
+  border: '1px solid transparent',
+  color: '#79828C',
+  paddingInline: rem(18),
+  paddingBlock: rem(22),
+  position: 'absolute',
+  pointerEvents: 'none',
+  transformOrigin: 'left top',
+  transition:
+    'border-color .15s ease-in-out, box-shadow .15s ease-in-out, transform .15s ease-in-out',
+});
+
+globalStyle(`${label}[data-dirty="filled"]+input`, {
+  paddingTop: rem(28),
+  paddingBottom: rem(4),
+});
+
+globalStyle(`${label}:has(+ ${control}:focus) + ${control}`, {
+  paddingTop: rem(28),
+  paddingBottom: rem(4),
+});
+
+globalStyle(
+  `${control}:focus+${label}, ${label}[data-dirty="filled"], input:focus+${label}`,
+  {
+    transform: 'scale(.85) translateY(-.5rem) translateX(.25rem)',
+  },
+);
+
+globalStyle(`${label}:has(+ ${control}:focus)`, {
+  transform: 'scale(.85) translateY(-.5rem) translateX(.25rem)',
+});
+
+export const errorBorder = style({
+  borderColor: errorColor,
+});
+
+export const errorMessage = style({
+  color: errorColor,
+  fontSize: rem(14),
+  marginTop: rem(8),
+});

--- a/packages/ui/src/form/useFormField.ts
+++ b/packages/ui/src/form/useFormField.ts
@@ -1,0 +1,24 @@
+import { useContext } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { FormFieldContext } from './form';
+
+export const useFormField = () => {
+  const fieldContext = useContext(FormFieldContext);
+  const { register, getFieldState, formState } = useFormContext();
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  if (!fieldContext) {
+    throw new Error('useFormField should be used within <FormField>');
+  }
+
+  return {
+    register,
+    name: fieldContext.name,
+    formItemId: `${fieldContext.id}-form-item`,
+    formDescriptionId: `${fieldContext.id}-form-item-description`,
+    formMessageId: `${fieldContext.id}-form-item-message`,
+    ...fieldState,
+  };
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,13 @@
 export { default as Accordion } from './accordion';
 export { default as Icon } from './icon';
 export { default as Uploader } from './image-uploader';
-export { default as Input } from './input';
 export { default as Modal } from './modal';
-export * from './dialog';
 export { default as Skeleton } from './skeleton';
 export { default as Tabs } from './tabs';
 export { default as Tooltip } from './tooltip';
 
-export * from './toast';
+export * from './input';
+export * from './dialog';
+export * from './form';
 export * from './spinner';
+export * from './toast';

--- a/packages/ui/src/input/index.ts
+++ b/packages/ui/src/input/index.ts
@@ -1,0 +1,1 @@
+export * from './input';

--- a/packages/ui/src/input/index.tsx
+++ b/packages/ui/src/input/index.tsx
@@ -1,5 +1,0 @@
-import { inputStyle } from './styles.css';
-
-export default function Input() {
-  return <input className={inputStyle} />;
-}

--- a/packages/ui/src/input/input.tsx
+++ b/packages/ui/src/input/input.tsx
@@ -1,0 +1,20 @@
+import { clsx } from 'clsx';
+import { ComponentPropsWithoutRef, forwardRef } from 'react';
+
+import * as styles from './styles.css';
+
+export interface InputProps extends ComponentPropsWithoutRef<'input'> {}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = 'text', ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        className={clsx(styles.input, className)}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = 'Input';

--- a/packages/ui/src/input/styles.css.ts
+++ b/packages/ui/src/input/styles.css.ts
@@ -1,19 +1,22 @@
+import { rem } from '@hcc/styles';
 import { style } from '@vanilla-extract/css';
 
-export const inputStyle = style({
-  padding: '8px 12px',
-  fontSize: '16px',
-  border: '1px solid #ccc',
-  borderRadius: '4px',
-  boxSizing: 'border-box',
-  transition: 'border-color 0.3s',
+export const input = style({
+  display: 'flex',
+  width: '100%',
+  height: rem(60),
 
-  ':hover': {
-    borderColor: 'blue',
-  },
+  border: '1px solid #F3F3F5',
+  borderRadius: rem(8),
 
-  ':focus': {
-    borderColor: 'green',
-    outline: 'none',
+  backgroundColor: '#fff',
+
+  paddingInline: rem(18),
+  paddingBlock: rem(22),
+
+  selectors: {
+    '&::placeholder': {
+      color: '#79828C',
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@hcc/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@hookform/resolvers':
+        specifier: ^3.6.0
+        version: 3.6.0(react-hook-form@7.51.5(react@18.2.0))
       '@mantine/core':
         specifier: ^7.6.1
         version: 7.6.1(@mantine/hooks@7.6.1(react@18.2.0))(@types/react@18.2.46)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -98,6 +101,12 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      react-hook-form:
+        specifier: ^7.51.5
+        version: 7.51.5(react@18.2.0)
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@hcc/eslint-config':
         specifier: workspace:*
@@ -244,9 +253,18 @@ importers:
       '@hcc/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@hookform/resolvers':
+        specifier: ^3.6.0
+        version: 3.6.0(react-hook-form@7.51.5(react@18.2.0))
       '@vanilla-extract/css':
         specifier: ^1.14.0
         version: 1.15.2
+      react-hook-form:
+        specifier: ^7.51.5
+        version: 7.51.5(react@18.2.0)
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@hcc/eslint-config':
         specifier: workspace:*
@@ -455,6 +473,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.0.5
         version: 1.0.5(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot':
+        specifier: ^1.0.2
+        version: 1.0.2(@types/react@18.2.46)(react@18.2.0)
       '@radix-ui/react-toast':
         specifier: ^1.1.5
         version: 1.1.5(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -467,6 +488,9 @@ importers:
       framer-motion:
         specifier: ^11.0.5
         version: 11.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-hook-form:
+        specifier: ^7.51.5
+        version: 7.51.5(react@18.2.0)
     devDependencies:
       '@hcc/eslint-config':
         specifier: workspace:*
@@ -2360,6 +2384,11 @@ packages:
 
   '@floating-ui/utils@0.2.2':
     resolution: {integrity: sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==}
+
+  '@hookform/resolvers@3.6.0':
+    resolution: {integrity: sha512-UBcpyOX3+RR+dNnqBd0lchXpoL8p4xC21XP8H6Meb8uve5Br1GCnmg0PcBoKKqPKgGu9GHQ/oygcmPrQhetwqw==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
 
   '@humanwhocodes/config-array@0.11.13':
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
@@ -7030,6 +7059,12 @@ packages:
       react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
       react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
 
+  react-hook-form@7.51.5:
+    resolution: {integrity: sha512-J2ILT5gWx1XUIJRETiA7M19iXHlG74+6O3KApzvqB/w8S5NQR7AbU8HVZrMALdmDgWpRPYiZJl0zx8Z4L2mP6Q==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -8264,6 +8299,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
 snapshots:
 
@@ -10446,6 +10484,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.2': {}
 
+  '@hookform/resolvers@3.6.0(react-hook-form@7.51.5(react@18.2.0))':
+    dependencies:
+      react-hook-form: 7.51.5(react@18.2.0)
+
   '@humanwhocodes/config-array@0.11.13':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.1
@@ -10748,14 +10790,14 @@ snapshots:
 
   '@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.46)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.24.7
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.46
 
   '@radix-ui/react-compose-refs@1.0.1(@types/react@18.3.3)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.24.7
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.3.3
@@ -11016,7 +11058,7 @@ snapshots:
 
   '@radix-ui/react-slot@1.0.2(@types/react@18.2.46)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.24.7
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.46)(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
@@ -11024,7 +11066,7 @@ snapshots:
 
   '@radix-ui/react-slot@1.0.2(@types/react@18.3.3)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.24.7
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.3)(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
@@ -11127,7 +11169,7 @@ snapshots:
 
   '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.2.46)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.24.7
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.46)(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
@@ -11135,7 +11177,7 @@ snapshots:
 
   '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.3.3)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.24.7
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.3)(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
@@ -16374,6 +16416,10 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       react-is: 18.1.0
 
+  react-hook-form@7.51.5(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -16538,7 +16584,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.24.7
 
   regexp-tree@0.1.27: {}
 
@@ -17780,3 +17826,5 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.23.8: {}


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #261 

## ✅ 작업 내용

- [shadcn/ui의 Form 컴포넌트](https://ui.shadcn.com/docs/components/form)를 참고하여 추상화 컴포넌트 제작
  - 다른 UI 라이브러리와의 호환성을 고려하여 react-hook-form의 `Controller` 컴포넌트(제어 컴포넌트)를 이용한 듯 합니다.
  - 하지만 우리는 다른 UI 라이브러리를 사용할 일이 없을 것이라 판단하여 비제어 컴포넌트로 작성해보았습니다.
- [`react-hook-form`](https://react-hook-form.com/get-started)을 사용한 이유는 다음과 같습니다.
  - 비제어 컴포넌트를 활용하기 때문에 입력에 따른 렌더링 최적화를 할 수 있습니다.
  - 다양한 form 관련 훅을 제공하고 form 요소의 유효성 검사를 용이하게 하여 개발 생산성이 대폭 증대합니다.
  - 여기에 [`zod`](https://zod.dev/?id=introduction)라는 스키마 선언 및 유효성 검사 라이브러리를 이용하여 더욱 직관적이고 가독성 좋게 유효성 검사를 할 수 있습니다.

## 📝 참고 자료

- 자세한 내용은 스토리북을 참고해주세요.
- https://65b76a66edbcddcd871355c6-xqjmicaklw.chromatic.com/?path=/story/hcc-form--default

## ♾️ 기타

- Input 컴포넌트나 Button 컴포넌트의 focus, hover 등 사용자 이벤트와 관련한 스타일이 아직 나오지 않아서 가볍게 작성해두었습니다. 추후 수정하면 좋을 것 같습니다.
