### PR TITLE
[REFACTOR] 리그 팀 목록 필터링 조건(round) 추가

### DIFF
--- a/apps/spectator/api/league.ts
+++ b/apps/spectator/api/league.ts
@@ -46,9 +46,13 @@ export const getSports = async (leagueId: number) => {
   return data;
 };
 
-export const getLeagueTeams = async (leagueId: number) => {
+export const getLeagueTeams = async (
+  leagueId: number,
+  round: number | undefined,
+) => {
   const { data } = await instance.get<LeagueTeamType[]>(
     `/leagues/${leagueId}/teams`,
+    { params: { round } },
   );
 
   return data;

--- a/apps/spectator/app/_components/GameFilter/LeagueTeamFilter.tsx
+++ b/apps/spectator/app/_components/GameFilter/LeagueTeamFilter.tsx
@@ -11,7 +11,15 @@ import useLeagueTeams from '@/queries/useLeagueTeams';
 
 import * as styles from './GameFilter.css';
 
-export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
+type LeagueTeamFilterProps = {
+  leagueId: number;
+  round: number;
+};
+
+export default function LeagueTeamFilter({
+  leagueId,
+  round,
+}: LeagueTeamFilterProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const scrollRef = useRef<HTMLUListElement | null>(null);
@@ -54,7 +62,7 @@ export default function LeagueTeamFilter({ leagueId }: { leagueId: number }) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const { leagueTeams } = useLeagueTeams(leagueId);
+  const { leagueTeams } = useLeagueTeams(leagueId, round);
   const selectedLeagueTeam = searchParams.get('leagueTeam')?.split(',') || [];
 
   if (!leagueTeams || !leagueTeams.length) return;

--- a/apps/spectator/app/page.tsx
+++ b/apps/spectator/app/page.tsx
@@ -29,8 +29,11 @@ export default async function Page({ searchParams }: PageProps) {
     leagues.find(league => league.isInProgress) || leagues?.[0];
   const initialLeagueId = Number(searchParams.league) || inProgress?.leagueId;
 
-  await useLeagueDetailPrefetch(initialLeagueId);
-  await useLeagueTeamsPrefetch(initialLeagueId);
+  const leagueDetail = await useLeagueDetailPrefetch(initialLeagueId);
+  const currentRound =
+    Number(searchParams.round) || leagueDetail.inProgressRound;
+
+  await useLeagueTeamsPrefetch(initialLeagueId, currentRound);
   await useSportsPrefetch(initialLeagueId);
 
   return (
@@ -39,7 +42,9 @@ export default async function Page({ searchParams }: PageProps) {
         <LeagueFilter year={year} />
         {initialLeagueId && <SportFilter leagueId={initialLeagueId} />}
         {initialLeagueId && <RoundFilter initialLeagueId={initialLeagueId} />}
-        {initialLeagueId && <LeagueTeamFilter leagueId={initialLeagueId} />}
+        {initialLeagueId && (
+          <LeagueTeamFilter leagueId={initialLeagueId} round={currentRound} />
+        )}
       </HydrationBoundary>
 
       {GAMES.map(game => (

--- a/apps/spectator/queries/useLeagueDetail.ts
+++ b/apps/spectator/queries/useLeagueDetail.ts
@@ -18,7 +18,7 @@ export default function useLeagueDetailQuery(leagueId: number) {
 export async function useLeagueDetailPrefetch(leagueId: number) {
   const queryClient = getQueryClient();
 
-  await queryClient.prefetchQuery({
+  return await queryClient.fetchQuery({
     queryKey: [LEAGUE_DETAIL_QUERY_KEY, { leagueId }],
     queryFn: () => getLeagueDetail(leagueId),
   });

--- a/apps/spectator/queries/useLeagueTeams.ts
+++ b/apps/spectator/queries/useLeagueTeams.ts
@@ -4,10 +4,10 @@ import { getLeagueTeams } from '@/api/league';
 import getQueryClient from '@/app/getQueryClient';
 
 export const LEAGUE_TEAMS_QUERY_KEY = 'league-teams';
-export default function useLeagueTeams(leagueId: number) {
+export default function useLeagueTeams(leagueId: number, round: number) {
   const { data, error } = useQuery({
-    queryKey: [LEAGUE_TEAMS_QUERY_KEY, { leagueId }],
-    queryFn: () => getLeagueTeams(leagueId),
+    queryKey: [LEAGUE_TEAMS_QUERY_KEY, { leagueId, round }],
+    queryFn: () => getLeagueTeams(leagueId, round),
   });
 
   if (error) throw error;
@@ -15,13 +15,11 @@ export default function useLeagueTeams(leagueId: number) {
   return { leagueTeams: data };
 }
 
-export async function useLeagueTeamsPrefetch(leagueId: number | undefined) {
-  if (!leagueId) return;
-
+export async function useLeagueTeamsPrefetch(leagueId: number, round: number) {
   const queryClient = getQueryClient();
 
   await queryClient.prefetchQuery({
-    queryKey: [LEAGUE_TEAMS_QUERY_KEY, { leagueId }],
-    queryFn: () => getLeagueTeams(leagueId),
+    queryKey: [LEAGUE_TEAMS_QUERY_KEY, { leagueId, round }],
+    queryFn: () => getLeagueTeams(leagueId, round),
   });
 }


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #267

## ✅ 작업 내용

- 리그 팀을 표시하는 경우 라운드에 포함되지 않은 팀까지 표시할 필요는 없다고 팀 내부적으로 결정되었고, 이에 맞게 API가 수정되었습니다.
- 프론트엔드 팀에서도 이를 반영하여 일부 코드를 수정합니다.
  - getLeagueTeam() API의 파라미터로 round 추가
  - 현재 선택된 round 정보를 알 수 있도록 useLeagueDetailQuery의 프리패치 부분에서 실제 데이터 패칭 작업을 동시에 수행
  - useLeagueTeamQuery()에 round 파라미터 추가
  - LeagueTeamFilter 컴포넌트에 round props 추가

## 📝 참고 자료

## ♾️ 기타
