### PR TITLE
[FIX] 신규 대회 만들기 페이지 디자인 수정

### DIFF
--- a/apps/manager/app/league/register/page.css.ts
+++ b/apps/manager/app/league/register/page.css.ts
@@ -20,34 +20,3 @@ export const form = style({
 export const button = style({
   marginTop: rem(6),
 });
-
-export const tipBox = style({
-  position: 'absolute',
-  bottom: 0,
-  left: 0,
-  width: 'calc(var(--vw, 1vw) * 100)',
-  backgroundColor: theme.colors.tips,
-});
-
-export const tipInner = style({
-  width: '100%',
-  maxWidth: theme.sizes.appWidth,
-  paddingBlock: rem(26),
-  paddingInline: rem(39),
-  marginInline: 'auto',
-});
-
-export const tipTitle = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: rem(6),
-
-  fontWeight: 600,
-  marginBottom: rem(8),
-});
-
-export const tipDescription = style({
-  fontSize: rem(14),
-  color: theme.colors.black300,
-  wordBreak: 'keep-all',
-});

--- a/apps/manager/app/league/register/page.css.ts
+++ b/apps/manager/app/league/register/page.css.ts
@@ -4,21 +4,37 @@ import { style } from '@vanilla-extract/css';
 export const layout = style({
   display: 'flex',
   flexDirection: 'column',
+  justifyContent: 'space-between',
 
   height: '100%',
   paddingInline: theme.sizes.appInlinePadding,
   paddingTop: theme.sizes.appInlinePadding,
 });
 
+export const form = style({
+  ...theme.layouts.column,
+  gap: rem(12),
+  flex: 1,
+});
+
 export const button = style({
-  marginTop: rem(18),
+  marginTop: rem(6),
 });
 
 export const tipBox = style({
-  backgroundColor: '#FBFBFC',
+  position: 'absolute',
+  bottom: 0,
+  left: 0,
+  width: 'calc(var(--vw, 1vw) * 100)',
+  backgroundColor: theme.colors.tips,
+});
 
+export const tipInner = style({
+  width: '100%',
+  maxWidth: theme.sizes.appWidth,
   paddingBlock: rem(26),
   paddingInline: rem(39),
+  marginInline: 'auto',
 });
 
 export const tipTitle = style({
@@ -26,15 +42,12 @@ export const tipTitle = style({
   alignItems: 'center',
   gap: rem(6),
 
-  fontWeight: 'bold',
+  fontWeight: 600,
   marginBottom: rem(8),
-});
-
-export const emoji = style({
-  fontSize: rem(14),
 });
 
 export const tipDescription = style({
   fontSize: rem(14),
   color: theme.colors.black300,
+  wordBreak: 'keep-all',
 });

--- a/apps/manager/app/league/register/page.tsx
+++ b/apps/manager/app/league/register/page.tsx
@@ -23,13 +23,13 @@ import {
   toast,
 } from '@hcc/ui';
 import { zodResolver } from '@hookform/resolvers/zod';
-import dayjs from 'dayjs';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import Layout from '@/components/Layout';
+import Tip from '@/components/Tip';
+import { formatTime } from '@/utils/time';
 
-import 'dayjs/locale/ko';
 import * as styles from './page.css';
 
 const formSchema = z.object({
@@ -98,7 +98,7 @@ export default function Page() {
                         >
                           <span>
                             {field.value
-                              ? dayjs(field.value).format('YYYY. MM. DD')
+                              ? formatTime(field.value, 'YYYY년 MM월 DD일')
                               : ''}
                           </span>
                           <Icon source={CalendarIcon} />
@@ -133,7 +133,7 @@ export default function Page() {
                         >
                           <span>
                             {field.value
-                              ? dayjs(field.value).format('YYYY. MM. DD')
+                              ? formatTime(field.value, 'YYYY년 MM월 DD일')
                               : ''}
                           </span>
                           <Icon source={CalendarIcon} />
@@ -143,9 +143,7 @@ export default function Page() {
                     <PopoverContent className="w-auto p-0" align="start">
                       <Calendar
                         defaultValue={field.value}
-                        onChange={value =>
-                          field.onChange(dayjs(value as Date).toDate())
-                        }
+                        onChange={field.onChange}
                       />
                     </PopoverContent>
                   </Popover>
@@ -190,17 +188,10 @@ export default function Page() {
         </Form>
       </section>
 
-      <div className={styles.tipBox}>
-        <div className={styles.tipInner}>
-          <div className={styles.tipTitle}>
-            🙌🏻 새로운 대회에 팀을 추가하는 방법
-          </div>
-          <p className={styles.tipDescription}>
-            신규 대회를 만든 뒤 참가 팀 관리 탭에서 팀 생성과 편집을 할 수
-            있어요.
-          </p>
-        </div>
-      </div>
+      <Tip
+        title="🙌🏻 새로운 대회에 팀을 추가하는 방법"
+        description="신규 대회를 만든 뒤 참가 팀 관리 탭에서 팀 생성과 편집을 할 수 있어요."
+      />
     </Layout>
   );
 }

--- a/apps/manager/app/league/register/page.tsx
+++ b/apps/manager/app/league/register/page.tsx
@@ -30,7 +30,7 @@ import { z } from 'zod';
 import Layout from '@/components/Layout';
 
 import 'dayjs/locale/ko';
-import * as styles from './styles.css';
+import * as styles from './page.css';
 
 const formSchema = z.object({
   leagueName: z.string().min(1, { message: '대회명을 입력해주세요' }),
@@ -64,7 +64,10 @@ export default function Page() {
     <Layout navigationTitle="신규 대회 만들기">
       <section className={styles.layout}>
         <Form {...methods}>
-          <form onSubmit={methods.handleSubmit(onSubmit)} style={{ flex: 1 }}>
+          <form
+            className={styles.form}
+            onSubmit={methods.handleSubmit(onSubmit)}
+          >
             <FormField
               control={methods.control}
               name="leagueName"
@@ -180,23 +183,24 @@ export default function Page() {
               )}
             />
 
-            <Button fullWidth className={styles.button}>
+            <Button className={styles.button} fullWidth>
               대회 만들기
             </Button>
           </form>
         </Form>
+      </section>
 
-        <div className={styles.tipBox}>
+      <div className={styles.tipBox}>
+        <div className={styles.tipInner}>
           <div className={styles.tipTitle}>
-            <span className={styles.emoji}>🙌🏻</span>
-            <span>새로운 대회에 팀을 추가하는 방법</span>
+            🙌🏻 새로운 대회에 팀을 추가하는 방법
           </div>
           <p className={styles.tipDescription}>
-            신규 대회를 만든 뒤 참가 팀 관리 탭에서 팀 생성과 <br /> 편집을 할
-            수 있어요.
+            신규 대회를 만든 뒤 참가 팀 관리 탭에서 팀 생성과 편집을 할 수
+            있어요.
           </p>
         </div>
-      </section>
+      </div>
     </Layout>
   );
 }

--- a/apps/manager/components/Layout/Navigation/Navigation.css.ts
+++ b/apps/manager/components/Layout/Navigation/Navigation.css.ts
@@ -11,6 +11,7 @@ export const wrapper = style({
   height: rem(69),
   backgroundColor: theme.colors.white,
   borderBottom: `${rem(1)} solid ${theme.colors.black25}`,
+  zIndex: theme.zIndices.navigation,
 });
 
 export const container = style({

--- a/apps/manager/components/Tip/Tip.css.ts
+++ b/apps/manager/components/Tip/Tip.css.ts
@@ -1,0 +1,33 @@
+import { rem, theme } from '@hcc/styles';
+import { style } from '@vanilla-extract/css';
+
+export const root = style({
+  position: 'absolute',
+  bottom: 0,
+  left: 0,
+  width: 'calc(var(--vw, 1vw) * 100)',
+  backgroundColor: theme.colors.tips,
+});
+
+export const innerContainer = style({
+  width: '100%',
+  maxWidth: theme.sizes.appWidth,
+  paddingBlock: rem(26),
+  paddingInline: rem(39),
+  marginInline: 'auto',
+});
+
+export const title = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(6),
+
+  fontWeight: 600,
+  marginBottom: rem(8),
+});
+
+export const description = style({
+  fontSize: rem(14),
+  color: theme.colors.black300,
+  wordBreak: 'keep-all',
+});

--- a/apps/manager/components/Tip/index.tsx
+++ b/apps/manager/components/Tip/index.tsx
@@ -1,0 +1,19 @@
+import * as styles from './Tip.css';
+
+type TipProps = {
+  title: string;
+  description: string;
+};
+
+const Tip = ({ title, description }: TipProps) => {
+  return (
+    <div className={styles.root}>
+      <div className={styles.innerContainer}>
+        <div className={styles.title}>{title}</div>
+        <p className={styles.description}>{description}</p>
+      </div>
+    </div>
+  );
+};
+
+export default Tip;

--- a/packages/ui/src/button/styles.css.ts
+++ b/packages/ui/src/button/styles.css.ts
@@ -3,9 +3,8 @@ import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 export const buttonBase = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
+  ...theme.layouts.center,
+  paddingInline: rem(18),
   fontSize: rem(16),
   fontWeight: '500',
   lineHeight: '100%',

--- a/packages/ui/src/calendar/calendar.tsx
+++ b/packages/ui/src/calendar/calendar.tsx
@@ -1,21 +1,31 @@
 import { CaretDownIcon } from '@hcc/icons';
 import dayjs from 'dayjs';
 import { ComponentProps } from 'react';
-import ReactCalendar from 'react-calendar';
+import ReactCalendar, { TileClassNameFunc } from 'react-calendar';
 
 import './styles.css';
 import Icon from '../icon';
 
 export const Calendar = (props: ComponentProps<typeof ReactCalendar>) => {
+  const tileClassName: TileClassNameFunc = ({ date, view }) => {
+    if (view === 'month') {
+      const day: number = date.getDay();
+      if (day === 0) return 'react-calendar__tile--sunday';
+      if (day === 6) return 'react-calendar__tile--saturday';
+    }
+    return null;
+  };
+
   return (
     <ReactCalendar
-      calendarType="iso8601"
+      calendarType="gregory"
       prev2Label={null}
       next2Label={null}
       minDetail="month"
       maxDetail="month"
       formatDay={(_, date) => dayjs(date).format('D')}
       navigationLabel={({ date }) => dayjs(date).format('M월')}
+      tileClassName={tileClassName}
       nextLabel={
         <Icon
           source={CaretDownIcon}

--- a/packages/ui/src/calendar/styles.css.ts
+++ b/packages/ui/src/calendar/styles.css.ts
@@ -6,6 +6,8 @@ const activeColor = '#141B21';
 const neighboringColor = '#c1c5ca';
 const weekendColor = '#FC5555';
 const weekendNeighboringColor = '#fc555580';
+const saturdayColor = '#007AFF';
+const saturdayNeighboringColor = '#badeff';
 const backgroundColor = '#FFFFFF';
 const hoverBackgroundColor = '#e6e6e6';
 const neighboringBackgroundColor = '#ebecee';
@@ -71,6 +73,7 @@ globalStyle('.react-calendar__navigation', {
 globalStyle(
   '.react-calendar__navigation__label, .react-calendar__navigation button:disabled',
   {
+    fontWeight: 500,
     textAlign: 'center',
     backgroundColor: 'transparent',
     pointerEvents: 'none',
@@ -194,4 +197,15 @@ globalStyle(
   {
     color: weekendNeighboringColor,
   },
+);
+
+globalStyle('.react-calendar__month-view__weekdays__weekday:nth-of-type(7)', {
+  color: saturdayColor,
+});
+
+globalStyle('.react-calendar__tile--saturday', { color: saturdayColor });
+
+globalStyle(
+  '.react-calendar__month-view__days__day--neighboringMonth.react-calendar__tile--saturday',
+  { color: saturdayNeighboringColor },
 );


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #284 

## ✅ 작업 내용

- #280 에서 폼 디자인 변경으로 인해 신규 대회 만들기 페이지의 디자인이 변경되는 문제가 있었습니다.
  - `FormItem`에 존재했던 `marginTop`을 제거하고, 부모 컴포넌트에서 `Gap`으로 관리하도록 변경했습니다.
  - <img width="300" alt="image" src="https://github.com/user-attachments/assets/af1be8b3-a565-4db8-b25e-fcc3882647f0">

- `Tip` 컴포넌트가 `register` 뿐만 아니라, `manage` 페이지에서도 사용되기 때문에 매니저 앱의 공통 컴포넌트로 분리했습니다.
  - 화면 하단에 고정되도록 설정했습니다. 

- `Calendar` 컴포넌트가 토요일, 일요일 관계 없이 `weekdays`인 경우 모두 빨간색으로 표시되고 있었습니다. 
  - 토요일과 일요일의 경계를 확실히 하고자, 토요일의 경우 `colors.accent.priamry` 값을 표시하도록 했습니다.
  - 일반적인 캘린더와 요일 순서를 맞추기 위해 `일 월 화 수 목 금 토` 순으로 날짜를 정렬했습니다. 
  - <img width="250" alt="image" src="https://github.com/user-attachments/assets/d149196d-b801-4164-95a2-07f53f60a068">