### PR TITLE
[FEAT] 매니저 404 페이지 구현

### DIFF
--- a/apps/manager/app/not-found.css.ts
+++ b/apps/manager/app/not-found.css.ts
@@ -1,0 +1,63 @@
+import { rem, theme } from '@hcc/styles';
+import { style } from '@vanilla-extract/css';
+
+export const branding = style({
+  position: 'absolute',
+  top: rem(22),
+  left: '50%',
+  transform: 'translateX(-50%)',
+
+  color: theme.colors.black900,
+  fontSize: rem(20),
+  fontWeight: 600,
+  lineHeight: '110%',
+  textAlign: 'center',
+});
+
+export const errorContainer = style({
+  ...theme.layouts.columnCenterX,
+
+  position: 'absolute',
+  top: '40%',
+  left: '50%',
+  width: '100%',
+  transform: 'translate(-50%, -50%)',
+  gap: rem(8),
+});
+
+export const errorCode = style({
+  color: theme.colors.black900,
+  fontSize: rem(96),
+  fontWeight: 300,
+  lineHeight: '100%',
+});
+
+export const errorMessage = style({
+  color: theme.colors.black400,
+  fontWeight: 500,
+  lineHeight: '100%',
+});
+
+export const homeLinkContainer = style({
+  position: 'absolute',
+  left: 0,
+  bottom: rem(30),
+  width: '100%',
+  paddingInline: theme.sizes.appInlinePadding,
+  paddingBottom: 'env(safe-area-inset-bottom)',
+});
+
+export const homeLink = style({
+  ...theme.layouts.center,
+
+  width: '100%',
+  height: rem(60),
+  maxWidth: theme.sizes.appWidth,
+  marginInline: 'auto',
+
+  color: theme.colors.white,
+  fontWeight: 500,
+  lineHeight: '100%',
+  borderRadius: rem(8),
+  backgroundColor: theme.colors.accent.primary,
+});

--- a/apps/manager/app/not-found.tsx
+++ b/apps/manager/app/not-found.tsx
@@ -1,13 +1,11 @@
 'use client';
 import Link from 'next/link';
 
-import Layout from '@/components/Layout';
-
 import * as styles from './not-found.css';
 
 export default function NotFoundPage() {
   return (
-    <Layout navigationVisible={false}>
+    <>
       <p className={styles.branding}>
         Hufscheers
         <br />
@@ -26,6 +24,6 @@ export default function NotFoundPage() {
           홈으로 돌아가기
         </Link>
       </div>
-    </Layout>
+    </>
   );
 }

--- a/apps/manager/app/not-found.tsx
+++ b/apps/manager/app/not-found.tsx
@@ -1,0 +1,31 @@
+'use client';
+import Link from 'next/link';
+
+import Layout from '@/components/Layout';
+
+import * as styles from './not-found.css';
+
+export default function NotFoundPage() {
+  return (
+    <Layout navigationVisible={false}>
+      <p className={styles.branding}>
+        Hufscheers
+        <br />
+        manager
+      </p>
+
+      <div className={styles.errorContainer}>
+        <h1 className={styles.errorCode}>404</h1>
+        <p className={styles.errorMessage}>
+          요청하신 페이지를 찾을 수 없습니다.
+        </p>
+      </div>
+
+      <div className={styles.homeLinkContainer}>
+        <Link className={styles.homeLink} href="/">
+          홈으로 돌아가기
+        </Link>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #291 

## ✅ 작업 내용

- 매니저 앱에 404 페이지를 추가했습니다.
  - <img width="300" alt="image" src="https://github.com/user-attachments/assets/006635ae-fd9d-4759-a5b9-3144012bf518">

## 📝 참고 자료

- 해당 페이지에서만 사용되는 버튼 색상(홈 버튼)이 존재해서, 따로 `colorScheme`를 만들지 않고, 스타일 링크로 대체했습니다.