### PR TITLE
[FEAT] Badge 컴포넌트 추가

### DIFF
--- a/docs/storybook/stories/Badge.stories.tsx
+++ b/docs/storybook/stories/Badge.stories.tsx
@@ -1,0 +1,24 @@
+import { Badge } from '@hcc/ui';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: '@hcc/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    colorScheme: {
+      options: ['primary', 'accentPrimary', 'alert'],
+      control: { type: 'radio' },
+    },
+  },
+  args: {
+    children: 'Badge',
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/ui/src/badge/badge.tsx
+++ b/packages/ui/src/badge/badge.tsx
@@ -1,0 +1,35 @@
+import { Slot } from '@radix-ui/react-slot';
+import { RecipeVariants } from '@vanilla-extract/recipes';
+import { clsx } from 'clsx';
+import { ComponentPropsWithoutRef, forwardRef } from 'react';
+
+import * as styles from './styles.css';
+
+type BadgeVariants = RecipeVariants<typeof styles.badgeVariants>;
+type BadgeProps = {
+  asChild?: boolean;
+} & ComponentPropsWithoutRef<'span'> &
+  BadgeVariants;
+
+const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
+  (
+    { asChild = false, colorScheme = 'primary', className, children, ...props },
+    ref,
+  ) => {
+    const Comp = asChild ? Slot : 'span';
+
+    return (
+      <Comp
+        ref={ref}
+        className={clsx(styles.badgeVariants({ colorScheme }), className)}
+        {...props}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+
+Badge.displayName = 'Badge';
+
+export { Badge };

--- a/packages/ui/src/badge/index.ts
+++ b/packages/ui/src/badge/index.ts
@@ -1,0 +1,1 @@
+export * from './badge';

--- a/packages/ui/src/badge/styles.css.ts
+++ b/packages/ui/src/badge/styles.css.ts
@@ -23,7 +23,7 @@ export const badgeColorScheme = {
     backgroundColor: theme.colors.black100,
   }),
   accentPrimary: style({
-    backgroundColor: theme.colors.accent.primaryLight,
+    backgroundColor: theme.colors.accent.primary,
   }),
   alert: style({
     backgroundColor: theme.colors.accent.alert,

--- a/packages/ui/src/badge/styles.css.ts
+++ b/packages/ui/src/badge/styles.css.ts
@@ -1,0 +1,41 @@
+import { rem, theme } from '@hcc/styles';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const badgeBase = style({
+  ...theme.layouts.center,
+  width: 'fit-content',
+  paddingBlock: rem(7),
+  paddingInline: rem(6),
+  color: theme.colors.white,
+  fontSize: rem(14),
+  fontWeight: 500,
+  lineHeight: '100%',
+  borderRadius: rem(4),
+  gap: rem(4),
+});
+
+export const badgeColorScheme = {
+  primary: style({
+    backgroundColor: theme.colors.black900,
+  }),
+  secondary: style({
+    backgroundColor: theme.colors.black100,
+  }),
+  accentPrimary: style({
+    backgroundColor: theme.colors.accent.primaryLight,
+  }),
+  alert: style({
+    backgroundColor: theme.colors.accent.alert,
+  }),
+};
+
+export const badgeVariants = recipe({
+  base: badgeBase,
+  variants: {
+    colorScheme: badgeColorScheme,
+  },
+  defaultVariants: {
+    colorScheme: 'primary',
+  },
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,3 +17,4 @@ export * from './select';
 export * from './spinner';
 export * from './toast';
 export * from './tag';
+export * from './badge';


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #296 

## ✅ 작업 내용

- Badge 컴포넌트를 추가했습니다.
  - <img width="89" alt="image" src="https://github.com/user-attachments/assets/0e050c47-47a6-485f-9e95-b44b1c1fe0a0">
  - 기본은 `span`으로 작업했고, `asChild`로 버튼 등 이식해서 사용하면 될 것 같습니다.
  - `colorScheme`는 `primary`, `accentPrimary`, `secondary`, `alert` 입니다.
