### PR TITLE
build(turbo): 터보레포 의존성 관계 변경 및 매니저 실행 포트 변경

### DIFF
--- a/apps/manager/package.json
+++ b/apps/manager/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack --port 11113 --hostname 0.0.0.0",
+    "dev": "next dev --turbopack --port 11114 --hostname 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "biome lint .",

--- a/turbo.json
+++ b/turbo.json
@@ -12,8 +12,8 @@
       "dependsOn": ["^build", "^lint"]
     },
     "dev": {
-      "dependsOn": ["@hcc/styles#build", "@hcc/ui#build"],
-      "cache": false,
+      "dependsOn": ["@hcc/api-base#build", "@hcc/icons#build", "@hcc/ui#build"],
+      "cache": true,
       "persistent": true
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,7 @@
       "dependsOn": ["^build", "^lint"]
     },
     "dev": {
-      "dependsOn": ["@hcc/api-base#build", "@hcc/icons#build", "@hcc/ui#build"],
+      "dependsOn": ["^build"],
       "cache": true,
       "persistent": true
     }


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #401

## ✅ 작업 내용

- `v1`에서 설정된 터보레포 의존성 관계가 변경된 구조에 호환되지 않아, 일부 설정을 변경했어요.
  - 스타일 패키지 제거
  - 캐시 활성화
  - 아이콘 패키지 추가
- 매니저 앱 실행 포트가 관객 앱과 같아 동시 실행이 안 되는 문제를 해결했어요.
  - `11113` → `11114`