### PR TITLE
feat(ui): `Typography`, `Badge` 컴포넌트 추가

### DIFF
--- a/apps/manager/package.json
+++ b/apps/manager/package.json
@@ -19,6 +19,7 @@
     "@bprogress/next": "^3.2.12",
     "@hcc/api-base": "workspace:*",
     "@hcc/icons": "workspace:*",
+    "@lukemorales/query-key-factory": "^1.3.4",
     "@vercel/analytics": "^1.5.0",
     "next": "^15.4.6",
     "react": "^19.1.1",

--- a/apps/manager/package.json
+++ b/apps/manager/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "biome lint .",
+    "lint:fix": "biome lint --fix .",
     "format": "biome format --write ."
   },
   "lint-staged": {
@@ -19,6 +20,7 @@
     "@bprogress/next": "^3.2.12",
     "@hcc/api-base": "workspace:*",
     "@hcc/icons": "workspace:*",
+    "@hcc/ui": "workspace:*",
     "@lukemorales/query-key-factory": "^1.3.4",
     "@vercel/analytics": "^1.5.0",
     "next": "^15.4.6",

--- a/apps/manager/src/app/auth/login/page.tsx
+++ b/apps/manager/src/app/auth/login/page.tsx
@@ -1,0 +1,21 @@
+import { Badge } from '@hcc/ui';
+
+const Page = () => {
+  return (
+    <div className="column-between h-full p-5">
+      <div className="flex w-full justify-between">
+        <h1 className="font-semibold text-neutral-900 text-xl leading-tight">
+          Hufscheer
+          <br />
+          manager
+        </h1>
+        <Badge className="h-fit" size="small" variant="success">
+          매니저 용
+        </Badge>
+      </div>
+      <div className="column w-full" />
+    </div>
+  );
+};
+
+export default Page;

--- a/apps/manager/src/app/auth/page.tsx
+++ b/apps/manager/src/app/auth/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from 'next/navigation';
+import { ROUTES } from '~/constants/routes';
+
+const Page = () => {
+  redirect(ROUTES.LOGIN);
+};
+
+export default Page;

--- a/apps/manager/src/app/layout.tsx
+++ b/apps/manager/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Layout } from '~/components/layout';
 import { Pretendard } from './_fonts';
 import { Provider } from './provider';
 import '~/styles/globals.css';
+import '@hcc/ui/index.css';
 
 export const metadata: Metadata = {
   title: '훕치치 매니저',

--- a/apps/manager/src/app/page.tsx
+++ b/apps/manager/src/app/page.tsx
@@ -1,5 +1,7 @@
+import { Header } from '~/components/layout';
+
 const Page = () => {
-  return <div>Home</div>;
+  return <Header />;
 };
 
 export default Page;

--- a/apps/manager/src/components/layout/header.tsx
+++ b/apps/manager/src/components/layout/header.tsx
@@ -5,8 +5,9 @@ import { ROUTES } from '~/constants/routes';
 export const Header = () => {
   return (
     <header className="sticky top-0 z-header row-between h-12 w-full border-neutral-100 border-b px-5">
-      <Link href={ROUTES.HOME}>
-        <HCCLogo width="71.5" height="21" className="text-primary-500" />
+      <Link className="flex items-end gap-2" href={ROUTES.HOME}>
+        <HCCLogo width="71.5" height="21" className="text-neutral-900" />
+        <span className="font-medium leading-none">매니저</span>
       </Link>
     </header>
   );

--- a/apps/manager/src/components/layout/header.tsx
+++ b/apps/manager/src/components/layout/header.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { HCCLogo } from '@hcc/icons';
 import Link from 'next/link';
 import { ROUTES } from '~/constants/routes';
@@ -5,7 +7,7 @@ import { ROUTES } from '~/constants/routes';
 export const Header = () => {
   return (
     <header className="sticky top-0 z-header row-between h-12 w-full border-neutral-100 border-b px-5">
-      <Link className="flex items-end gap-2" href={ROUTES.HOME}>
+      <Link className="flex select-none items-end gap-2" href={ROUTES.HOME}>
         <HCCLogo width="71.5" height="21" className="text-neutral-900" />
         <span className="font-medium leading-none">매니저</span>
       </Link>

--- a/apps/manager/src/components/layout/index.ts
+++ b/apps/manager/src/components/layout/index.ts
@@ -1,1 +1,2 @@
+export * from './header';
 export * from './root';

--- a/apps/manager/src/components/layout/root.tsx
+++ b/apps/manager/src/components/layout/root.tsx
@@ -1,11 +1,9 @@
 import type { PropsWithChildren } from 'react';
-import { Header } from './header';
 
 export const Layout = ({ children }: PropsWithChildren) => {
   return (
     <div className="column-center-x mx-auto w-full max-w-[var(--app-max-width)] flex-1 bg-white">
-      <Header />
-      <main className="column-center-y w-full">{children}</main>
+      <main className="column-center-y h-full w-full">{children}</main>
     </div>
   );
 };

--- a/apps/manager/src/constants/routes.ts
+++ b/apps/manager/src/constants/routes.ts
@@ -1,3 +1,4 @@
 export const ROUTES = {
   HOME: '/',
+  LOGIN: '/auth/login',
 };

--- a/apps/manager/src/styles/globals.css
+++ b/apps/manager/src/styles/globals.css
@@ -12,7 +12,7 @@
   --app-max-width: 560px;
 
   --color-primary-100: #F2F8FF;
-  --color-primary-500: #007AFF;
+  --color-primary-600: #007AFF;
 }
 
 @layer base {

--- a/apps/spectator/src/components/layout/header.tsx
+++ b/apps/spectator/src/components/layout/header.tsx
@@ -6,7 +6,7 @@ export const Header = () => {
   return (
     <header className="sticky top-0 z-header row-between h-12 w-full border-neutral-100 border-b px-5">
       <Link href={ROUTES.HOME}>
-        <HCCLogo width="71.5" height="21" className="text-primary-500" />
+        <HCCLogo width="71.5" height="21" className="text-primary-600" />
       </Link>
 
       <Link href={ROUTES.CALENDAR}>

--- a/apps/spectator/src/styles/globals.css
+++ b/apps/spectator/src/styles/globals.css
@@ -12,7 +12,7 @@
   --app-max-width: 560px;
 
   --color-primary-100: #F2F8FF;
-  --color-primary-500: #007AFF;
+  --color-primary-600: #007AFF;
 }
 
 @layer base {

--- a/packages/ui/build.js
+++ b/packages/ui/build.js
@@ -22,7 +22,7 @@ const sharedConfig = {
 esbuild
   .build({
     ...sharedConfig,
-    outfile: './lib/index.js',
+    outfile: './dist/index.js',
     format: 'esm',
     platform: 'neutral',
   })
@@ -31,7 +31,7 @@ esbuild
 esbuild
   .build({
     ...sharedConfig,
-    outfile: './lib/index.cjs',
+    outfile: './dist/index.cjs',
     format: 'cjs',
     platform: 'neutral',
   })

--- a/packages/ui/lib/index.cjs
+++ b/packages/ui/lib/index.cjs
@@ -1,1 +1,0 @@
-"use strict";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,7 +26,7 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
-    "./index.css": {
+    "./styles.css": {
       "import": "./dist/index.css"
     }
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,6 +25,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./index.css": {
+      "import": "./dist/index.css"
     }
   },
   "files": [
@@ -40,5 +43,8 @@
     "@types/react-dom": "^19.1.7",
     "esbuild": "^0.25.8",
     "typescript": "^5.9.2"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,6 +45,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.2.3"
+    "@radix-ui/react-slot": "^1.2.3",
+    "clsx": "^2.1.1"
   }
 }

--- a/packages/ui/src/badge/Badge.module.css
+++ b/packages/ui/src/badge/Badge.module.css
@@ -1,0 +1,16 @@
+.badge {
+  display: inline-flex;
+  padding: var(--hcc-badge-padding);
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  border: var(--hcc-badge-border);
+  border-radius: var(--hcc-badge-border-radius);
+  background-color: var(--hcc-badge-bg-color);
+
+  --hcc-badge-padding: inherit;
+  --hcc-badge-border: inherit;
+  --hcc-badge-border-radius: inherit;
+  --hcc-badge-bg-color: inherit;
+}

--- a/packages/ui/src/badge/Badge.tsx
+++ b/packages/ui/src/badge/Badge.tsx
@@ -1,0 +1,81 @@
+import { type ComponentProps, type CSSProperties, forwardRef } from 'react';
+import { Typography } from '../typography';
+import styles from './Badge.module.css';
+
+type BadgeSize = 'small' | 'medium' | 'large';
+
+type BadgeVariant = 'default' | 'danger' | 'success';
+
+export interface BadgeProps extends ComponentProps<'div'> {
+  size?: BadgeSize;
+  variant?: BadgeVariant;
+}
+
+export const Badge = forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, children, size = 'medium', variant = 'default', style: _style, ...props }, ref) => {
+    const backgroundColor = getBackgroundColor(variant);
+    const padding = getPadding(size);
+    const style = {
+      ..._style,
+      '--hcc-badge-padding': padding,
+      '--hcc-badge-border': undefined,
+      '--hcc-badge-border-radius': '8px',
+      '--hcc-badge-bg-color': backgroundColor,
+    } as CSSProperties;
+
+    const fontColor = getFontColor(variant);
+    const fontSize = getFontSize(size);
+
+    return (
+      <div ref={ref} className={`${styles.badge} ${className}`} style={style} {...props}>
+        <Typography color={fontColor} size={fontSize} weight="semiBold" lineHeight="tight" asChild>
+          <span>{children}</span>
+        </Typography>
+      </div>
+    );
+  },
+);
+
+const getPadding = (size: BadgeSize) => {
+  switch (size) {
+    case 'small':
+      return '6px 8px';
+    case 'large':
+      return '10px 16px';
+    default:
+      return '8px 12px';
+  }
+};
+
+const getFontSize = (size: BadgeSize) => {
+  switch (size) {
+    case 'small':
+      return 12;
+    case 'large':
+      return 18;
+    default:
+      return 14;
+  }
+};
+
+const getFontColor = (variant: BadgeVariant) => {
+  switch (variant) {
+    case 'danger':
+      return '#FFFFFF';
+    case 'success':
+      return '#007AFF';
+    default:
+      return '#5F6A75';
+  }
+};
+
+const getBackgroundColor = (variant: BadgeVariant) => {
+  switch (variant) {
+    case 'danger':
+      return '#FC5555';
+    case 'success':
+      return '#F2F8FF';
+    default:
+      return '#F3F3F5';
+  }
+};

--- a/packages/ui/src/badge/Badge.tsx
+++ b/packages/ui/src/badge/Badge.tsx
@@ -42,10 +42,10 @@ const getPadding = (size: BadgeSize) => {
   switch (size) {
     case 'small':
       return '6px 8px';
+    case 'medium':
+      return '8px 12px';
     case 'large':
       return '10px 16px';
-    default:
-      return '8px 12px';
   }
 };
 
@@ -53,31 +53,31 @@ const getFontSize = (size: BadgeSize) => {
   switch (size) {
     case 'small':
       return 12;
+    case 'medium':
+      return 14;
     case 'large':
       return 18;
-    default:
-      return 14;
   }
 };
 
 const getFontColor = (variant: BadgeVariant) => {
   switch (variant) {
+    case 'default':
+      return color.neutral600;
     case 'danger':
       return color.white;
     case 'success':
       return color.primary600;
-    default:
-      return color.neutral600;
   }
 };
 
 const getBackgroundColor = (variant: BadgeVariant) => {
   switch (variant) {
+    case 'default':
+      return color.neutral100;
     case 'danger':
       return color.danger600;
     case 'success':
       return color.primary100;
-    default:
-      return color.neutral100;
   }
 };

--- a/packages/ui/src/badge/Badge.tsx
+++ b/packages/ui/src/badge/Badge.tsx
@@ -1,5 +1,6 @@
 import { clsx } from 'clsx';
 import { type ComponentProps, type CSSProperties, forwardRef } from 'react';
+import { color } from '../token';
 import { Typography } from '../typography';
 import styles from './Badge.module.css';
 
@@ -62,21 +63,21 @@ const getFontSize = (size: BadgeSize) => {
 const getFontColor = (variant: BadgeVariant) => {
   switch (variant) {
     case 'danger':
-      return '#FFFFFF';
+      return color.white;
     case 'success':
-      return '#007AFF';
+      return color.primary600;
     default:
-      return '#5F6A75';
+      return color.neutral600;
   }
 };
 
 const getBackgroundColor = (variant: BadgeVariant) => {
   switch (variant) {
     case 'danger':
-      return '#FC5555';
+      return color.danger600;
     case 'success':
-      return '#F2F8FF';
+      return color.primary100;
     default:
-      return '#F3F3F5';
+      return color.neutral100;
   }
 };

--- a/packages/ui/src/badge/Badge.tsx
+++ b/packages/ui/src/badge/Badge.tsx
@@ -1,3 +1,4 @@
+import { clsx } from 'clsx';
 import { type ComponentProps, type CSSProperties, forwardRef } from 'react';
 import { Typography } from '../typography';
 import styles from './Badge.module.css';
@@ -27,7 +28,7 @@ export const Badge = forwardRef<HTMLDivElement, BadgeProps>(
     const fontSize = getFontSize(size);
 
     return (
-      <div ref={ref} className={`${styles.badge} ${className}`} style={style} {...props}>
+      <div ref={ref} className={clsx(styles.badge, className)} style={style} {...props}>
         <Typography color={fontColor} size={fontSize} weight="semiBold" lineHeight="tight" asChild>
           <span>{children}</span>
         </Typography>

--- a/packages/ui/src/badge/index.ts
+++ b/packages/ui/src/badge/index.ts
@@ -1,0 +1,1 @@
+export * from './Badge';

--- a/packages/ui/src/css-modules.d.ts
+++ b/packages/ui/src/css-modules.d.ts
@@ -1,0 +1,9 @@
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.css' {
+  const classes: { readonly [key: string]: string } | string;
+  export default classes;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,3 @@
+export * from './badge';
+export * from './token';
+export * from './typography';

--- a/packages/ui/src/token/color.ts
+++ b/packages/ui/src/token/color.ts
@@ -1,0 +1,12 @@
+export const color = {
+  white: '#FFFFFF',
+  black: '#000000',
+
+  primary100: '#F2F8FF',
+  primary600: '#007AFF',
+
+  danger600: '#FC5555',
+
+  neutral100: '#F5F5F5',
+  neutral600: '#525252',
+};

--- a/packages/ui/src/token/index.ts
+++ b/packages/ui/src/token/index.ts
@@ -1,0 +1,1 @@
+export * from './typography';

--- a/packages/ui/src/token/index.ts
+++ b/packages/ui/src/token/index.ts
@@ -1,1 +1,2 @@
+export * from './color';
 export * from './typography';

--- a/packages/ui/src/token/typography.ts
+++ b/packages/ui/src/token/typography.ts
@@ -1,0 +1,31 @@
+export const fontSize = {
+  10: 10,
+  12: 12,
+  14: 14,
+  16: 16,
+  18: 18,
+  20: 20,
+  24: 24,
+  28: 28,
+  32: 32,
+  36: 36,
+  40: 40,
+} as const;
+
+export const fontWeight = {
+  regular: 400,
+  medium: 500,
+  semiBold: 600,
+  bold: 700,
+  extraBold: 800,
+  black: 900,
+} as const;
+
+export const lineHeight = {
+  none: 1,
+  tight: 1.25,
+  snug: 1.375,
+  normal: 1.5,
+  relaxed: 1.625,
+  loose: 2,
+} as const;

--- a/packages/ui/src/typography/Typography.module.css
+++ b/packages/ui/src/typography/Typography.module.css
@@ -9,3 +9,15 @@
   --hcc-typography-font-weight: inherit;
   --hcc-typography-line-height: inherit;
 }
+
+@media (min-width: 768px) {
+  .typography {
+    font-size: var(--hcc-tablet-typography-font-size, var(--hcc-typography-font-size));
+  }
+}
+
+@media (min-width: 1024px) {
+  .typography {
+    font-size: var(--hcc-desktop-typography-font-size, var(--hcc-tablet-typography-font-size, var(--hcc-typography-font-size)));
+  }
+}

--- a/packages/ui/src/typography/Typography.module.css
+++ b/packages/ui/src/typography/Typography.module.css
@@ -1,0 +1,11 @@
+.typography {
+  color: var(--hcc-typography-font-color);
+  font-size: var(--hcc-typography-font-size);
+  font-weight: var(--hcc-typography-font-weight);
+  line-height: var(--hcc-typography-line-height);
+
+  --hcc-typography-font-color: inherit;
+  --hcc-typography-font-size: inherit;
+  --hcc-typography-font-weight: inherit;
+  --hcc-typography-line-height: inherit;
+}

--- a/packages/ui/src/typography/Typography.tsx
+++ b/packages/ui/src/typography/Typography.tsx
@@ -10,13 +10,18 @@ import styles from './Typography.module.css';
 
 export type FontSize = keyof typeof fontSizeToken;
 
+export type ResponsiveFontSize =
+  | FontSize
+  | [FontSize, FontSize?, FontSize?]
+  | { base: FontSize; tablet?: FontSize; desktop?: FontSize };
+
 export type FontWeight = keyof typeof fontWeightToken;
 
 export type LineHeight = keyof typeof lineHeightToken;
 
 export interface TypographyProps extends ComponentProps<'p'> {
   asChild?: boolean;
-  size?: FontSize;
+  size?: ResponsiveFontSize;
   weight?: FontWeight;
   lineHeight?: LineHeight;
 }
@@ -36,10 +41,29 @@ export const Typography = forwardRef<HTMLParagraphElement, TypographyProps>(
     ref,
   ) => {
     const Comp = asChild ? Slot : 'p';
+
+    let base: FontSize | undefined;
+    let tablet: FontSize | undefined;
+    let desktop: FontSize | undefined;
+
+    if (Array.isArray(size)) {
+      [base, tablet, desktop] = size;
+    } else if (typeof size === 'object') {
+      ({ base, tablet, desktop } = size);
+    } else {
+      base = size;
+    }
+
     const style = {
       ..._style,
       '--hcc-typography-font-color': color,
-      '--hcc-typography-font-size': `${fontSizeToken[size]}px`,
+      '--hcc-typography-font-size': `${fontSizeToken[base]}px`,
+      ...(tablet !== undefined && {
+        '--hcc-tablet-typography-font-size': `${fontSizeToken[tablet]}px`,
+      }),
+      ...(desktop !== undefined && {
+        '--hcc-desktop-typography-font-size': `${fontSizeToken[desktop]}px`,
+      }),
       '--hcc-typography-font-weight': fontWeightToken[weight],
       '--hcc-typography-line-height': lineHeightToken[lineHeight],
     } as CSSProperties;

--- a/packages/ui/src/typography/Typography.tsx
+++ b/packages/ui/src/typography/Typography.tsx
@@ -1,0 +1,50 @@
+import { Slot } from '@radix-ui/react-slot';
+import { type ComponentProps, type CSSProperties, forwardRef } from 'react';
+import {
+  fontSize as fontSizeToken,
+  fontWeight as fontWeightToken,
+  lineHeight as lineHeightToken,
+} from '../token';
+import styles from './Typography.module.css';
+
+export type FontSize = keyof typeof fontSizeToken;
+
+export type FontWeight = keyof typeof fontWeightToken;
+
+export type LineHeight = keyof typeof lineHeightToken;
+
+export interface TypographyProps extends ComponentProps<'p'> {
+  asChild?: boolean;
+  size?: FontSize;
+  weight?: FontWeight;
+  lineHeight?: LineHeight;
+}
+
+export const Typography = forwardRef<HTMLParagraphElement, TypographyProps>(
+  (
+    {
+      asChild,
+      className,
+      color,
+      size = 16,
+      weight = 'regular',
+      lineHeight = 'normal',
+      style: _style,
+      ...props
+    },
+    ref,
+  ) => {
+    const Comp = asChild ? Slot : 'p';
+    const style = {
+      ..._style,
+      '--hcc-typography-font-color': color,
+      '--hcc-typography-font-size': `${fontSizeToken[size]}px`,
+      '--hcc-typography-font-weight': fontWeightToken[weight],
+      '--hcc-typography-line-height': lineHeightToken[lineHeight],
+    } as CSSProperties;
+
+    return (
+      <Comp className={`${styles.typography} ${className}`} ref={ref} style={style} {...props} />
+    );
+  },
+);

--- a/packages/ui/src/typography/Typography.tsx
+++ b/packages/ui/src/typography/Typography.tsx
@@ -1,4 +1,5 @@
 import { Slot } from '@radix-ui/react-slot';
+import { clsx } from 'clsx';
 import { type ComponentProps, type CSSProperties, forwardRef } from 'react';
 import {
   fontSize as fontSizeToken,
@@ -44,7 +45,7 @@ export const Typography = forwardRef<HTMLParagraphElement, TypographyProps>(
     } as CSSProperties;
 
     return (
-      <Comp className={`${styles.typography} ${className}`} ref={ref} style={style} {...props} />
+      <Comp className={clsx(styles.typography, className)} ref={ref} style={style} {...props} />
     );
   },
 );

--- a/packages/ui/src/typography/index.ts
+++ b/packages/ui/src/typography/index.ts
@@ -1,0 +1,1 @@
+export * from './Typography';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@hcc/icons':
         specifier: workspace:*
         version: link:../../packages/icons
+      '@hcc/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@lukemorales/query-key-factory':
         specifier: ^1.3.4
         version: 1.3.4(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.1(react@19.1.1))
@@ -183,6 +186,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@radix-ui/react-slot':
+        specifier: ^1.2.3
+        version: 1.2.3(@types/react@19.1.9)(react@19.1.1)
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -719,6 +725,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1982,6 +2006,19 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.4.6':
     optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.9)(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.9
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.1.9)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.9)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.9
 
   '@swc/helpers@0.5.15':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@hcc/icons':
         specifier: workspace:*
         version: link:../../packages/icons
+      '@lukemorales/query-key-factory':
+        specifier: ^1.3.4
+        version: 1.3.4(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.1(react@19.1.1))
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.5.0(next@15.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
@@ -658,6 +661,13 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
+
+  '@lukemorales/query-key-factory@1.3.4':
+    resolution: {integrity: sha512-A3frRDdkmaNNQi6mxIshsDk4chRXWoXa05US8fBo4kci/H+lVmujS6QrwQLLGIkNIRFGjMqp2uKjC4XsLdydRw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@tanstack/query-core': '>= 4.0.0'
+      '@tanstack/react-query': '>= 4.0.0'
 
   '@next/env@15.4.6':
     resolution: {integrity: sha512-yHDKVTcHrZy/8TWhj0B23ylKv5ypocuCwey9ZqPyv4rPdUdRzpGCkSi03t04KBPyU96kxVtUqx6O3nE1kpxASQ==}
@@ -1941,6 +1951,11 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
+
+  '@lukemorales/query-key-factory@1.3.4(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.1(react@19.1.1))':
+    dependencies:
+      '@tanstack/query-core': 5.83.1
+      '@tanstack/react-query': 5.84.1(react@19.1.1)
 
   '@next/env@15.4.6': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.9)(react@19.1.1)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -961,6 +964,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2194,6 +2201,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #405

## ✅ 작업 내용

- 매니저 페이지와 관객 페이지에서 공통으로 사용되는 컴포넌트를 `packages/ui` 패키지에 구현하고 있어요.
- Typography와 Badge 컴포넌트를 추가했고, 이를 사용하는 매니저 로그인 페이지를 구현했어요.

## 📝 참고 자료

- [daangn/seed-design](https://github.com/daangn/seed-design)
- [sipe-team/side](https://github.com/sipe-team/side)