### PR TITLE
feat(manager): 신규대회 생성 ui개발

### DIFF
--- a/apps/manager/package.json
+++ b/apps/manager/package.json
@@ -28,12 +28,15 @@
     "@suspensive/react": "^3.9.0",
     "@vercel/analytics": "^1.5.0",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "ky": "^1.10.0",
     "next": "^15.5.3",
     "react": "^19.1.1",
+    "react-day-picker": "^9.10.0",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@hcc/typescript-config": "workspace:*",

--- a/apps/manager/package.json
+++ b/apps/manager/package.json
@@ -26,6 +26,7 @@
     "@lukemorales/query-key-factory": "^1.3.4",
     "@suspensive/react": "^3.9.0",
     "@vercel/analytics": "^1.5.0",
+    "clsx": "^2.1.1",
     "ky": "^1.10.0",
     "next": "^15.5.3",
     "react": "^19.1.1",

--- a/apps/manager/package.json
+++ b/apps/manager/package.json
@@ -24,6 +24,7 @@
     "@hcc/toolkit": "workspace:*",
     "@hcc/ui": "workspace:*",
     "@lukemorales/query-key-factory": "^1.3.4",
+    "@radix-ui/react-select": "^2.2.6",
     "@suspensive/react": "^3.9.0",
     "@vercel/analytics": "^1.5.0",
     "clsx": "^2.1.1",

--- a/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
+++ b/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
@@ -46,8 +46,7 @@ const SelectItem = ({ name, isSelected, onClick }: SelectTeamProps) => (
 
 type TeamCreationFormProps = {
   onClose: () => void;
-  // 선택 완료 시 Affiliation과 Team 정보를 함께 전달
-  onRegister: (selection: { affiliation: Affiliation; team: Team }) => void;
+  onRegister: (selection: { affiliation: Omit<Affiliation, 'teams'>; team: Team }) => void;
 };
 
 export const SelectTeam = ({ onClose, onRegister }: TeamCreationFormProps) => {
@@ -62,9 +61,13 @@ export const SelectTeam = ({ onClose, onRegister }: TeamCreationFormProps) => {
   );
 
   const handleRegister = () => {
-    const selectedTeam = selectedAffiliation?.teams.find(team => team.id === selectedTeamId);
+    const selectedTeam = selectedAffiliation?.teams.find(t => t.id === selectedTeamId);
     if (selectedAffiliation && selectedTeam) {
-      onRegister({ affiliation: selectedAffiliation, team: selectedTeam });
+      const affiliationData = {
+        id: selectedAffiliation.id,
+        name: selectedAffiliation.name,
+      };
+      onRegister({ affiliation: affiliationData, team: selectedTeam });
     }
   };
 

--- a/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
+++ b/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { Button } from '@hcc/ui';
+import { useState, useMemo } from 'react';
+import clsx from 'clsx';
+
+type Team = { id: number; name: string };
+type Affiliation = { id: number; name: string; teams: Team[] };
+
+const AFFILIATIONS: Affiliation[] = [
+  //임시 값
+  {
+    id: 1,
+    name: '경영대학',
+    teams: [
+      { id: 101, name: '경영학과' },
+      { id: 102, name: '경영정보학과' },
+      { id: 103, name: '벤처중소기업학과' },
+      { id: 104, name: '세무학과' },
+      { id: 105, name: '글로벌경영학과' },
+      { id: 106, name: '국제통상학과' },
+      { id: 107, name: '금융학과' },
+      { id: 108, name: '회계학과' },
+    ],
+  },
+];
+
+type SelectTeamProps = {
+  name: string;
+  isSelected: boolean;
+  onClick: () => void;
+};
+
+const SelectItem = ({ name, isSelected, onClick }: SelectTeamProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={clsx('w-full p-3 text-left text-base', {
+      'bg-[#007AFF] font-medium text-[#F2F8FF]': isSelected,
+      'hover:bg-gray-100': !isSelected,
+    })}
+  >
+    {name}
+  </button>
+);
+
+type TeamCreationFormProps = {
+  onClose: () => void;
+  // 선택 완료 시 Affiliation과 Team 정보를 함께 전달
+  onRegister: (selection: { affiliation: Affiliation; team: Team }) => void;
+};
+
+export const SelectTeam = ({ onClose, onRegister }: TeamCreationFormProps) => {
+  const [selectedAffiliationId, setSelectedAffiliationId] = useState<number | null>(
+    AFFILIATIONS[0]?.id || null,
+  );
+  const [selectedTeamId, setSelectedTeamId] = useState<number | null>(null);
+
+  const selectedAffiliation = useMemo(
+    () => AFFILIATIONS.find(aff => aff.id === selectedAffiliationId),
+    [selectedAffiliationId],
+  );
+
+  const handleRegister = () => {
+    const selectedTeam = selectedAffiliation?.teams.find(team => team.id === selectedTeamId);
+    if (selectedAffiliation && selectedTeam) {
+      onRegister({ affiliation: selectedAffiliation, team: selectedTeam });
+    }
+  };
+
+  return (
+    <div className="flex h-[60vh] flex-col pt-4">
+      <div className="flex flex-grow flex-row overflow-hidden">
+        {/* 왼쪽 열: 소속 */}
+
+        <div className="flex-1 border-r">
+          <div className="w-full bg-[#EBECEE] p-3 text-left font-medium text-base">소속</div>
+          <div className="overflow-y-auto">
+            {AFFILIATIONS.map(affiliation => (
+              <SelectItem
+                key={affiliation.id}
+                name={affiliation.name}
+                isSelected={selectedAffiliationId === affiliation.id}
+                onClick={() => {
+                  setSelectedAffiliationId(affiliation.id);
+                  setSelectedTeamId(null);
+                }}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* 오른쪽 열: 팀 */}
+        <div className="flex flex-1 flex-col">
+          <div className="w-full bg-[#EBECEE] p-3 text-left font-medium text-base">팀 이름</div>
+          <div className="overflow-y-auto">
+            {selectedAffiliation?.teams.map(team => (
+              <SelectItem
+                key={team.id}
+                name={team.name}
+                isSelected={selectedTeamId === team.id}
+                onClick={() => setSelectedTeamId(team.id)}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 flex w-full flex-row gap-2">
+        <Button size="lg" color="black" variant="subtle" className="w-full" onClick={onClose}>
+          취소
+        </Button>
+        <Button
+          size="lg"
+          className="w-full"
+          color="black"
+          onClick={handleRegister}
+          disabled={!selectedTeamId}
+        >
+          등록
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/apps/manager/src/app/(private)/leagues/create/LeagueInfo.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/LeagueInfo.tsx
@@ -30,7 +30,6 @@ const LeagueInfo = ({ form, onChange, onNext, isFormValid }: LeagueInfoProps) =>
       <Suspense clientOnly>
         <div className="flex flex-col gap-4">
           <div className="font-semibold text-black text-lg">대회 정보</div>
-
           <Input
             name="name"
             size="xl"
@@ -60,20 +59,20 @@ const LeagueInfo = ({ form, onChange, onNext, isFormValid }: LeagueInfoProps) =>
             onValueChange={v => onChange({ round: v })}
           />
         </div>
-
-        <Button
-          size="lg"
-          className="w-full"
-          color="primary"
-          onClick={onNext}
-          disabled={!isFormValid}
-        >
-          다음 단계
-        </Button>
-
-        <Button size="lg" className="w-full" color="primary" disabled>
-          대회 생성
-        </Button>
+        <div className="mt-auto flex flex-col gap-2">
+          <Button
+            size="lg"
+            className="w-full"
+            color="primary"
+            onClick={onNext}
+            disabled={!isFormValid}
+          >
+            다음 단계
+          </Button>
+          <Button size="lg" className="w-full" color="primary" disabled>
+            대회 생성
+          </Button>
+        </div>
       </Suspense>
     </div>
   );

--- a/apps/manager/src/app/(private)/leagues/create/LeagueInfo.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/LeagueInfo.tsx
@@ -1,0 +1,82 @@
+'use client';
+import { Button, Input } from '@hcc/ui';
+import { Suspense } from '@suspensive/react';
+import { InputSelect } from '~/components/ui/input-select';
+import { InputDate } from '~/components/ui/input-date';
+
+export type LeagueForm = {
+  leagueName: string;
+  startDate?: Date;
+  endDate?: Date;
+  round?: string;
+};
+
+const ROUND_STRINGS = ['32강', '16강', '8강', '4강', '결승'];
+const ROUND_OPTIONS = ROUND_STRINGS.map(round => ({
+  value: round,
+  label: round,
+}));
+
+type LeagueInfoProps = {
+  form: LeagueForm;
+  onChange: (patch: Partial<LeagueForm>) => void;
+  onNext: () => void;
+  isFormValid: boolean;
+};
+
+const LeagueInfo = ({ form, onChange, onNext, isFormValid }: LeagueInfoProps) => {
+  return (
+    <div className="column h-full gap-1.5 bg-white p-5">
+      <Suspense clientOnly>
+        <div className="flex flex-col gap-4">
+          <div className="font-semibold text-black text-lg">대회 정보</div>
+
+          <Input
+            name="name"
+            size="xl"
+            type="text"
+            placeholder="대회 이름"
+            autoComplete="name"
+            value={form.leagueName}
+            onChange={e => onChange({ leagueName: e.target.value })}
+          />
+
+          <InputDate
+            label="시작 일"
+            value={form.startDate}
+            onSelect={d => onChange({ startDate: d ?? undefined })}
+          />
+
+          <InputDate
+            label="종료 일"
+            value={form.endDate}
+            onSelect={d => onChange({ endDate: d ?? undefined })}
+          />
+
+          <InputSelect
+            options={ROUND_OPTIONS}
+            label="라운드"
+            value={form.round}
+            onValueChange={v => onChange({ round: v })}
+          />
+        </div>
+
+        <Button
+          size="lg"
+          className="w-full"
+          color="primary"
+          onClick={onNext}
+          disabled={!isFormValid}
+        >
+          다음 단계
+        </Button>
+
+        <Button size="lg" className="w-full" color="primary" disabled>
+          대회 생성
+        </Button>
+      </Suspense>
+    </div>
+  );
+};
+
+export default LeagueInfo;

--- a/apps/manager/src/app/(private)/leagues/create/LeagueInfo.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/LeagueInfo.tsx
@@ -8,13 +8,13 @@ export type LeagueForm = {
   leagueName: string;
   startDate?: Date;
   endDate?: Date;
-  round?: string;
+  roundSize?: number | undefined;
 };
 
-const ROUND_STRINGS = ['32강', '16강', '8강', '4강', '결승'];
-const ROUND_OPTIONS = ROUND_STRINGS.map(round => ({
-  value: round,
-  label: round,
+const ROUND_SIZES = [32, 16, 8, 4, 2];
+const ROUND_OPTIONS = ROUND_SIZES.map(n => ({
+  value: String(n),
+  label: n === 2 ? '결승' : `${n}강`,
 }));
 
 type LeagueInfoProps = {
@@ -55,8 +55,8 @@ const LeagueInfo = ({ form, onChange, onNext, isFormValid }: LeagueInfoProps) =>
           <InputSelect
             options={ROUND_OPTIONS}
             label="라운드"
-            value={form.round}
-            onValueChange={v => onChange({ round: v })}
+            value={form.roundSize ? String(form.roundSize) : undefined}
+            onValueChange={v => onChange({ roundSize: Number(v) })}
           />
         </div>
         <div className="mt-auto flex flex-col gap-2">

--- a/apps/manager/src/app/(private)/leagues/create/LeagueRegister.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/LeagueRegister.tsx
@@ -1,26 +1,104 @@
 'use client';
-import { Button, Input } from '@hcc/ui';
-import { Suspense } from '@suspensive/react';
+
+import { AddIcon, CloseIcon, TradeHorizontalIcon } from '@hcc/icons';
+import { Button, Input, Typography } from '@hcc/ui';
+import { useState } from 'react';
+import { Drawer } from 'vaul';
+import { SelectTeam } from '../_components/select-team';
+
+type Team = { id: number; name: string };
+type Affiliation = { id: number; name: string; teams: Team[] };
+type RegisteredTeam = {
+  affiliationName: string;
+  teamName: string;
+  teamId: number;
+};
 
 type Props = {
   onPrev: () => void;
 };
+
 const LeagueRegister = ({ onPrev }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [registeredTeams, setRegisteredTeams] = useState<RegisteredTeam[]>([]);
+
+  const handleRegisterTeam = ({ affiliation, team }: { affiliation: Affiliation; team: Team }) => {
+    // 중복 등록 방지
+    if (!registeredTeams.find(rt => rt.teamId === team.id)) {
+      setRegisteredTeams(prevTeams => [
+        ...prevTeams,
+        {
+          affiliationName: affiliation.name,
+          teamName: team.name,
+          teamId: team.id,
+        },
+      ]);
+    }
+    setIsOpen(false);
+  };
+
+  const handleRemoveTeam = (teamId: number) => {
+    setRegisteredTeams(prevTeams => prevTeams.filter(team => team.teamId !== teamId));
+  };
+
   return (
-    <div className="column h-full gap-1.5 bg-white p-5">
-      <Suspense clientOnly>
-        <div className="flex flex-col gap-4">
+    <Drawer.Root open={isOpen} onOpenChange={setIsOpen}>
+      <div className="flex h-full flex-col gap-4 bg-white p-5">
+        <div className="flex flex-row items-center justify-between">
           <div className="font-semibold text-black text-lg">참가 팀</div>
+          <span className="flex flex-row font-semibold text-base">
+            <Typography color="var(--color-primary-600)" weight="semibold">
+              {registeredTeams.length}
+            </Typography>
+            /32
+          </span>
         </div>
 
-        <Button size="lg" className="w-full" color="primary" onClick={onPrev}>
-          이전 단계
-        </Button>
-        <Button size="lg" className="w-full" color="primary">
-          대회 생성
-        </Button>
-      </Suspense>
-    </div>
+        <div className="flex flex-row flex-wrap gap-3">
+          {registeredTeams.map(team => (
+            <Button
+              key={team.teamId}
+              variant="subtle"
+              onClick={() => handleRemoveTeam(team.teamId)}
+            >
+              <div className="flex flex-row items-center gap-2 p-3">
+                <span>{team.teamName}</span>
+                <CloseIcon width={16} height={16} color="var(--color-primary-600)" />
+              </div>
+            </Button>
+          ))}
+        </div>
+
+        <Drawer.Trigger asChild>
+          <Button size="lg" color="black" variant="subtle" className="w-full">
+            <AddIcon />
+            새로운 팀 추가
+          </Button>
+        </Drawer.Trigger>
+        <div className="mt-auto flex flex-col gap-2">
+          <Button size="lg" variant="subtle" className="w-full" onClick={onPrev}>
+            이전 단계
+          </Button>
+          <Button size="lg" className="w-full">
+            대회 생성
+          </Button>
+        </div>
+      </div>
+
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 bg-black/40" />
+        <Drawer.Content className="fixed right-0 bottom-0 left-0 mt-24 flex flex-col rounded-t-lg bg-white">
+          <div className="flex-1 rounded-t-lg p-4">
+            <div className="mx-auto mb-4 h-1.5 w-12 flex-shrink-0 rounded-full bg-gray-300" />
+            <Drawer.Title className="mb-4 text-start font-semibold text-2xl">팀 선택</Drawer.Title>
+            <Input size="lg" placeholder="팀 이름을 검색해주세요">
+              {/* 아이콘추가 */}
+            </Input>
+            <SelectTeam onClose={() => setIsOpen(false)} onRegister={handleRegisterTeam} />
+          </div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
   );
 };
 

--- a/apps/manager/src/app/(private)/leagues/create/LeagueRegister.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/LeagueRegister.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AddIcon, CloseIcon, TradeHorizontalIcon } from '@hcc/icons';
+import { AddIcon, CloseIcon } from '@hcc/icons';
 import { Button, Input, Typography } from '@hcc/ui';
 import { useState } from 'react';
 import { Drawer } from 'vaul';

--- a/apps/manager/src/app/(private)/leagues/create/LeagueRegister.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/LeagueRegister.tsx
@@ -2,7 +2,7 @@
 
 import { AddIcon, CloseIcon } from '@hcc/icons';
 import { Button, Input, Typography } from '@hcc/ui';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Drawer } from 'vaul';
 import { SelectTeam } from '../_components/select-team';
 
@@ -16,14 +16,18 @@ type RegisteredTeam = {
 
 type Props = {
   onPrev: () => void;
+  round: number;
 };
 
-const LeagueRegister = ({ onPrev }: Props) => {
+const LeagueRegister = ({ onPrev, round }: Props) => {
   const [isOpen, setIsOpen] = useState(false);
   const [registeredTeams, setRegisteredTeams] = useState<RegisteredTeam[]>([]);
 
+  const maxTeams = useMemo(() => round ?? 32, [round]);
+  const isFull = registeredTeams.length >= maxTeams;
   const handleRegisterTeam = ({ affiliation, team }: { affiliation: Affiliation; team: Team }) => {
     // 중복 등록 방지
+    if (isFull) return;
     if (!registeredTeams.find(rt => rt.teamId === team.id)) {
       setRegisteredTeams(prevTeams => [
         ...prevTeams,
@@ -50,7 +54,7 @@ const LeagueRegister = ({ onPrev }: Props) => {
             <Typography color="var(--color-primary-600)" weight="semibold">
               {registeredTeams.length}
             </Typography>
-            /32
+            /{round}
           </span>
         </div>
 

--- a/apps/manager/src/app/(private)/leagues/create/LeagueRegister.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/LeagueRegister.tsx
@@ -7,7 +7,7 @@ import { Drawer } from 'vaul';
 import { SelectTeam } from '../_components/select-team';
 
 type Team = { id: number; name: string };
-type Affiliation = { id: number; name: string; teams: Team[] };
+type Affiliation = { id: number; name: string };
 type RegisteredTeam = {
   affiliationName: string;
   teamName: string;

--- a/apps/manager/src/app/(private)/leagues/create/LeagueRegister.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/LeagueRegister.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { Button, Input } from '@hcc/ui';
+import { Suspense } from '@suspensive/react';
+
+type Props = {
+  onPrev: () => void;
+};
+const LeagueRegister = ({ onPrev }: Props) => {
+  return (
+    <div className="column h-full gap-1.5 bg-white p-5">
+      <Suspense clientOnly>
+        <div className="flex flex-col gap-4">
+          <div className="font-semibold text-black text-lg">참가 팀</div>
+        </div>
+
+        <Button size="lg" className="w-full" color="primary" onClick={onPrev}>
+          이전 단계
+        </Button>
+        <Button size="lg" className="w-full" color="primary">
+          대회 생성
+        </Button>
+      </Suspense>
+    </div>
+  );
+};
+
+export default LeagueRegister;

--- a/apps/manager/src/app/(private)/leagues/create/page.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/page.tsx
@@ -13,11 +13,11 @@ const Page = () => {
     leagueName: '',
     startDate: undefined,
     endDate: undefined,
-    round: undefined,
+    roundSize: undefined,
   });
 
   const isFormValid = useMemo(() => {
-    return form.leagueName.trim() !== '' && !!form.startDate && !!form.endDate && !!form.round;
+    return form.leagueName.trim() !== '' && !!form.startDate && !!form.endDate && !!form.roundSize;
   }, [form]);
 
   const handleFormChange = (patch: Partial<LeagueForm>) => {
@@ -49,7 +49,9 @@ const Page = () => {
               />
             )}
 
-            {currentStep === 2 && <LeagueRegister onPrev={() => setCurrentStep(1)} />}
+            {currentStep === 2 && (
+              <LeagueRegister onPrev={() => setCurrentStep(1)} round={form.roundSize ?? 0} />
+            )}
           </div>
         </Suspense>
       </div>

--- a/apps/manager/src/app/(private)/leagues/create/page.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/page.tsx
@@ -1,24 +1,34 @@
 'use client';
-import { Button, Input, Typography } from '@hcc/ui';
 import { Suspense } from '@suspensive/react';
-import Link from 'next/link';
 import { Header } from '~/components/layout';
-import { routes } from '~/constants/routes';
 import { StepProgress } from '~/components/ui';
-import { InputSelect } from '~/components/ui/input-select';
-import { InputDate } from '~/components/ui/input-date';
+import { useMemo, useState } from 'react';
+import LeagueInfo, { type LeagueForm } from './LeagueInfo';
+import LeagueRegister from './LeagueRegister';
 
-const ROUND_STRINGS = ['32강', '16강', '8강', '4강', '결승'];
-const ROUND_OPTIONS = ROUND_STRINGS.map(round => ({
-  value: round,
-  label: round,
-}));
 const Page = () => {
-  const handleNextStep = () => (
-    <Typography color="var(--color-neutral-500)" weight="semibold" asChild>
-      <Link href={`/${routes.league}`}>대회 생성</Link>
-    </Typography>
-  );
+  const [currentStep, setCurrentStep] = useState<1 | 2>(1);
+
+  const [form, setForm] = useState<LeagueForm>({
+    leagueName: '',
+    startDate: undefined,
+    endDate: undefined,
+    round: undefined,
+  });
+
+  const isFormValid = useMemo(() => {
+    return form.leagueName.trim() !== '' && !!form.startDate && !!form.endDate && !!form.round;
+  }, [form]);
+
+  const handleFormChange = (patch: Partial<LeagueForm>) => {
+    setForm(prev => ({ ...prev, ...patch }));
+  };
+
+  const goNext = () => {
+    if (!isFormValid) return;
+    setCurrentStep(2);
+  };
+
   return (
     <>
       <Header title="신규 대회 만들기" arrow />
@@ -26,21 +36,21 @@ const Page = () => {
       <div className="column h-full gap-1.5 bg-white p-5">
         <Suspense clientOnly>
           <div className="w-auto px-10">
-            <StepProgress steps={['기본 정보', '참가 팀등록']} currentStep={1} />
+            <StepProgress steps={['기본 정보', '참가 팀등록']} currentStep={currentStep} />
           </div>
-          <div className="flex flex-col gap-4">
-            <div className="font-semibold text-black text-lg">대회 정보</div>
-            <Input name="name" size="xl" type="name" placeholder="대회 이름" autoComplete="name" />
-            <InputDate label="시작 일" />
-            <InputDate label="종료 일" />
-            <InputSelect options={ROUND_OPTIONS} label="라운드" placeholder="32강" />
+
+          <div className="flex-grow">
+            {currentStep === 1 && (
+              <LeagueInfo
+                form={form}
+                onChange={handleFormChange}
+                onNext={goNext}
+                isFormValid={isFormValid}
+              />
+            )}
+
+            {currentStep === 2 && <LeagueRegister onPrev={() => setCurrentStep(1)} />}
           </div>
-          <Button size="lg" className="w-full" color="primary" onClick={handleNextStep}>
-            다음 단계
-          </Button>
-          <Button size="lg" className="w-full" color="primary">
-            대회 생성
-          </Button>
         </Suspense>
       </div>
     </>

--- a/apps/manager/src/app/(private)/leagues/create/page.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/page.tsx
@@ -1,0 +1,41 @@
+import { Badge, Button, Input, Typography } from '@hcc/ui';
+import { Suspense } from '@suspensive/react';
+import Link from 'next/link';
+import { Header } from '~/components/layout';
+import { routes } from '~/constants/routes';
+import { LeagueOverview } from '../_components/league-overview';
+import { SwitchCase } from '~/components/feature';
+import { StepProgress } from '~/components/ui';
+
+// const LeagueCreateMenu = () => (
+//   <Typography color="var(--color-neutral-500)" weight="semibold" asChild>
+//     <Link href={`/${routes.league}`}>대회 생성</Link>
+//   </Typography>
+// );
+
+const Page = () => {
+  return (
+    <>
+      <Header title="신규 대회 만들기" arrow />
+
+      <div className="column h-full gap-1.5 bg-white p-5">
+        <Suspense clientOnly>
+          <div className="w-auto px-10">
+            <StepProgress steps={['기본 정보', '참가 팀등록']} currentStep={1} />
+          </div>
+          <div>
+            <div className="font-semibold text-black text-lg">대회 정보</div>
+          </div>
+          <Button size="lg" className="w-full" color="primary">
+            다음 단계
+          </Button>
+          <Button size="lg" className="w-full" color="primary">
+            대회 생성
+          </Button>
+        </Suspense>
+      </div>
+    </>
+  );
+};
+
+export default Page;

--- a/apps/manager/src/app/(private)/leagues/create/page.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/page.tsx
@@ -1,19 +1,23 @@
-import { Badge, Button, Input, Typography } from '@hcc/ui';
+'use client';
+import { Button, Input, Typography } from '@hcc/ui';
 import { Suspense } from '@suspensive/react';
 import Link from 'next/link';
 import { Header } from '~/components/layout';
 import { routes } from '~/constants/routes';
-import { LeagueOverview } from '../_components/league-overview';
-import { SwitchCase } from '~/components/feature';
 import { StepProgress } from '~/components/ui';
+import { InputSelect } from '~/components/ui/input-select';
 
-// const LeagueCreateMenu = () => (
-//   <Typography color="var(--color-neutral-500)" weight="semibold" asChild>
-//     <Link href={`/${routes.league}`}>대회 생성</Link>
-//   </Typography>
-// );
-
+const ROUND_STRINGS = ['32강', '16강', '8강', '4강', '결승'];
+const ROUND_OPTIONS = ROUND_STRINGS.map(round => ({
+  value: round,
+  label: round,
+}));
 const Page = () => {
+  const handleNextStep = () => (
+    <Typography color="var(--color-neutral-500)" weight="semibold" asChild>
+      <Link href={`/${routes.league}`}>대회 생성</Link>
+    </Typography>
+  );
   return (
     <>
       <Header title="신규 대회 만들기" arrow />
@@ -23,10 +27,26 @@ const Page = () => {
           <div className="w-auto px-10">
             <StepProgress steps={['기본 정보', '참가 팀등록']} currentStep={1} />
           </div>
-          <div>
+          <div className="flex flex-col gap-4">
             <div className="font-semibold text-black text-lg">대회 정보</div>
+            <Input name="name" size="xl" type="name" placeholder="대회 이름" autoComplete="name" />
+            <Input
+              name="start-date"
+              size="xl"
+              type="date"
+              placeholder="시작 일"
+              autoComplete="start-date"
+            />
+            <Input
+              name="end-date"
+              size="xl"
+              type="date"
+              placeholder="종료 일"
+              autoComplete="end-date"
+            />
+            <InputSelect options={ROUND_OPTIONS} label="라운드" placeholder="32강" />
           </div>
-          <Button size="lg" className="w-full" color="primary">
+          <Button size="lg" className="w-full" color="primary" onClick={handleNextStep}>
             다음 단계
           </Button>
           <Button size="lg" className="w-full" color="primary">

--- a/apps/manager/src/app/(private)/leagues/create/page.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/page.tsx
@@ -6,6 +6,7 @@ import { Header } from '~/components/layout';
 import { routes } from '~/constants/routes';
 import { StepProgress } from '~/components/ui';
 import { InputSelect } from '~/components/ui/input-select';
+import { InputDate } from '~/components/ui/input-date';
 
 const ROUND_STRINGS = ['32강', '16강', '8강', '4강', '결승'];
 const ROUND_OPTIONS = ROUND_STRINGS.map(round => ({
@@ -30,20 +31,8 @@ const Page = () => {
           <div className="flex flex-col gap-4">
             <div className="font-semibold text-black text-lg">대회 정보</div>
             <Input name="name" size="xl" type="name" placeholder="대회 이름" autoComplete="name" />
-            <Input
-              name="start-date"
-              size="xl"
-              type="date"
-              placeholder="시작 일"
-              autoComplete="start-date"
-            />
-            <Input
-              name="end-date"
-              size="xl"
-              type="date"
-              placeholder="종료 일"
-              autoComplete="end-date"
-            />
+            <InputDate label="시작 일" />
+            <InputDate label="종료 일" />
             <InputSelect options={ROUND_OPTIONS} label="라운드" placeholder="32강" />
           </div>
           <Button size="lg" className="w-full" color="primary" onClick={handleNextStep}>

--- a/apps/manager/src/app/(private)/leagues/page.tsx
+++ b/apps/manager/src/app/(private)/leagues/page.tsx
@@ -7,7 +7,7 @@ import { LeagueOverview } from './_components/league-overview';
 
 const LeagueCreateMenu = () => (
   <Typography color="var(--color-neutral-500)" weight="semibold" asChild>
-    <Link href={`/${routes.league}`}>대회 생성</Link>
+    <Link href={`/${routes.league_create}`}>대회 생성</Link>
   </Typography>
 );
 

--- a/apps/manager/src/components/ui/alert-dialog.tsx
+++ b/apps/manager/src/components/ui/alert-dialog.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { Button, Modal, Typography } from '@hcc/ui';
 import { type ReactNode, useState } from 'react';
 

--- a/apps/manager/src/components/ui/bottom-sheet.tsx
+++ b/apps/manager/src/components/ui/bottom-sheet.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Drawer } from 'vaul';
+import React, { type ComponentProps } from 'react';
+
+type BottomSheetProps = ComponentProps<typeof Drawer.Root> & {
+  title: string;
+};
+
+export const BottomSheet = ({ children, title, ...props }: BottomSheetProps) => {
+  const childrenArray = React.Children.toArray(children);
+
+  const trigger = childrenArray[0];
+  const content = childrenArray[1];
+
+  return (
+    <Drawer.Root {...props}>
+      {trigger}
+
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 bg-black/40" />
+        <Drawer.Content className="fixed right-0 bottom-0 left-0 mt-24 flex flex-col rounded-t-[10px] bg-white">
+          <div className="flex-1 rounded-t-[10px] p-4">
+            <div className="mx-auto mb-4 h-1.5 w-12 flex-shrink-0 rounded-full bg-gray-300" />
+            <Drawer.Title className="mb-4 text-center font-semibold text-lg">{title}</Drawer.Title>
+            {content}
+          </div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
+  );
+};

--- a/apps/manager/src/components/ui/index.ts
+++ b/apps/manager/src/components/ui/index.ts
@@ -1,2 +1,3 @@
 export * from './alert-dialog';
 export * from './image-uploader';
+export * from './step-progress';

--- a/apps/manager/src/components/ui/input-date.tsx
+++ b/apps/manager/src/components/ui/input-date.tsx
@@ -16,7 +16,6 @@ type InputDateProps = {
 };
 
 export const InputDate = ({ label, value, onSelect }: InputDateProps) => {
-  //const [date, setDate] = useState<Date | undefined>();
   const formattedDate = value ? format(value, 'yyyy년 MM월 dd일') : null;
 
   return (

--- a/apps/manager/src/components/ui/input-date.tsx
+++ b/apps/manager/src/components/ui/input-date.tsx
@@ -30,7 +30,7 @@ export const InputDate = ({ label, value, onSelect }: InputDateProps) => {
             <p
               className={`pointer-events-none absolute font-medium text-neutral-400 transition-all ${
                 value ? 'top-2 text-xs' : '-translate-y-1/2 top-1/2 text-base'
-              } group-data-[state=open]:-translate-y-0 group-data-[state=open]:top-1.5 group-data-[state=open]:text-xs`}
+              } group-data-[state=open]:-translate-y-0 group-data-[state=open]:top-2 group-data-[state=open]:text-xs`}
             >
               {label}
             </p>

--- a/apps/manager/src/components/ui/input-date.tsx
+++ b/apps/manager/src/components/ui/input-date.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+import { DayPicker } from 'react-day-picker';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { CalendarMonthIcon } from '@hcc/icons';
+import { Drawer } from 'vaul';
+import { Button } from '@hcc/ui';
+import 'react-day-picker/dist/style.css';
+
+type InputDateProps = {
+  label: string;
+};
+
+export const InputDate = ({ label }: InputDateProps) => {
+  const [date, setDate] = useState<Date | undefined>();
+  const formattedDate = date ? format(date, 'yyyy년 MM월 dd일') : null;
+
+  return (
+    <Drawer.Root>
+      <Drawer.Trigger asChild>
+        <button
+          type="button"
+          className="group relative flex h-15 w-full cursor-pointer items-center rounded-lg border border-neutral-100 bg-white px-4 text-left"
+        >
+          <div className="w-full">
+            <p
+              className={`pointer-events-none absolute font-medium text-neutral-400 transition-all ${
+                date ? 'top-2 text-xs' : '-translate-y-1/2 top-1/2 text-base'
+              } group-data-[state=open]:-translate-y-0 group-data-[state=open]:top-1.5 group-data-[state=open]:text-xs`}
+            >
+              {label}
+            </p>
+            {date && <p className="pt-4 font-medium text-base text-black">{formattedDate}</p>}
+          </div>
+          <CalendarMonthIcon className={date ? 'text-black' : 'text-gray-500'} />
+        </button>
+      </Drawer.Trigger>
+
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 bg-black/40" />
+        <Drawer.Content className="fixed right-0 bottom-0 left-0 mt-24 flex flex-col rounded-t-lg bg-white">
+          <div className="flex-1 rounded-t-lg p-4">
+            <div className="mx-auto mb-4 h-1.5 w-12 flex-shrink-0 rounded-full bg-gray-300" />
+            <Drawer.Title className="mb-4 text-center font-semibold text-lg">{label}</Drawer.Title>
+            <div className="flex justify-center">
+              <DayPicker locale={ko} mode="single" selected={date} onSelect={setDate} />
+            </div>
+            <Drawer.Close asChild>
+              <Button size="lg" className="mt-4 w-full">
+                확인
+              </Button>
+            </Drawer.Close>
+          </div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
+  );
+};

--- a/apps/manager/src/components/ui/input-date.tsx
+++ b/apps/manager/src/components/ui/input-date.tsx
@@ -11,11 +11,13 @@ import 'react-day-picker/dist/style.css';
 
 type InputDateProps = {
   label: string;
+  value?: Date;
+  onSelect?: (date?: Date) => void;
 };
 
-export const InputDate = ({ label }: InputDateProps) => {
-  const [date, setDate] = useState<Date | undefined>();
-  const formattedDate = date ? format(date, 'yyyy년 MM월 dd일') : null;
+export const InputDate = ({ label, value, onSelect }: InputDateProps) => {
+  //const [date, setDate] = useState<Date | undefined>();
+  const formattedDate = value ? format(value, 'yyyy년 MM월 dd일') : null;
 
   return (
     <Drawer.Root>
@@ -27,14 +29,14 @@ export const InputDate = ({ label }: InputDateProps) => {
           <div className="w-full">
             <p
               className={`pointer-events-none absolute font-medium text-neutral-400 transition-all ${
-                date ? 'top-2 text-xs' : '-translate-y-1/2 top-1/2 text-base'
+                value ? 'top-2 text-xs' : '-translate-y-1/2 top-1/2 text-base'
               } group-data-[state=open]:-translate-y-0 group-data-[state=open]:top-1.5 group-data-[state=open]:text-xs`}
             >
               {label}
             </p>
-            {date && <p className="pt-4 font-medium text-base text-black">{formattedDate}</p>}
+            {value && <p className="pt-4 font-medium text-base text-black">{formattedDate}</p>}
           </div>
-          <CalendarMonthIcon className={date ? 'text-black' : 'text-gray-500'} />
+          <CalendarMonthIcon className={value ? 'text-black' : 'text-gray-500'} />
         </button>
       </Drawer.Trigger>
 
@@ -45,7 +47,7 @@ export const InputDate = ({ label }: InputDateProps) => {
             <div className="mx-auto mb-4 h-1.5 w-12 flex-shrink-0 rounded-full bg-gray-300" />
             <Drawer.Title className="mb-4 text-center font-semibold text-lg">{label}</Drawer.Title>
             <div className="flex justify-center">
-              <DayPicker locale={ko} mode="single" selected={date} onSelect={setDate} />
+              <DayPicker locale={ko} mode="single" selected={value} onSelect={onSelect} />
             </div>
             <Drawer.Close asChild>
               <Button size="lg" className="mt-4 w-full">

--- a/apps/manager/src/components/ui/input-select.tsx
+++ b/apps/manager/src/components/ui/input-select.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import * as Select from '@radix-ui/react-select';
+import { CheckSmallIcon, KeyboardArrowDownIcon } from '@hcc/icons';
+
+type SelectOption = { value: string; label: string };
+type BoxSelectProps = Select.SelectProps & {
+  options: SelectOption[];
+  label?: string;
+  placeholder?: string;
+};
+
+export const InputSelect = ({ options, placeholder, label, ...props }: BoxSelectProps) => {
+  return (
+    <Select.Root {...props}>
+      <Select.Trigger className="group relative flex h-15 w-full items-center justify-between rounded-lg border border-neutral-100 bg-white px-4 font-medium text-base focus:outline-none">
+        <div className="flex flex-col">
+          <span className="top-2 font-medium text-neutral-400 text-xs">{label}</span>
+          <Select.Value
+            placeholder={placeholder}
+            className="group-data-[placeholder]:text-gray-400"
+          />
+        </div>
+        <Select.Icon className="text-[#141B21]">
+          <KeyboardArrowDownIcon />
+        </Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Content
+          position="popper"
+          sideOffset={5}
+          className="w-[var(--radix-select-trigger-width)] overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg"
+        >
+          <Select.Viewport className="max-h-60 overflow-y-auto p-1">
+            {options.map(option => (
+              <Select.Item
+                key={option.value}
+                value={option.value}
+                className="relative flex cursor-pointer select-none items-center rounded-md py-2 pr-4 pl-8 text-base outline-none data-[highlighted]:bg-gray-100"
+              >
+                <Select.ItemIndicator className="absolute left-2">
+                  <CheckSmallIcon />
+                </Select.ItemIndicator>
+                <Select.ItemText>{option.label}</Select.ItemText>
+              </Select.Item>
+            ))}
+          </Select.Viewport>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  );
+};

--- a/apps/manager/src/components/ui/input-select.tsx
+++ b/apps/manager/src/components/ui/input-select.tsx
@@ -2,7 +2,6 @@
 
 import * as Select from '@radix-ui/react-select';
 import { CheckSmallIcon, KeyboardArrowDownIcon } from '@hcc/icons';
-import { useState } from 'react';
 
 type SelectOption = { value: string; label: string };
 type BoxSelectProps = Select.SelectProps & {

--- a/apps/manager/src/components/ui/input-select.tsx
+++ b/apps/manager/src/components/ui/input-select.tsx
@@ -2,6 +2,7 @@
 
 import * as Select from '@radix-ui/react-select';
 import { CheckSmallIcon, KeyboardArrowDownIcon } from '@hcc/icons';
+import { useState } from 'react';
 
 type SelectOption = { value: string; label: string };
 type BoxSelectProps = Select.SelectProps & {
@@ -10,12 +11,19 @@ type BoxSelectProps = Select.SelectProps & {
   placeholder?: string;
 };
 
-export const InputSelect = ({ options, placeholder, label, ...props }: BoxSelectProps) => {
+export const InputSelect = ({ options, placeholder, label }: BoxSelectProps) => {
+  const [value, setValue] = useState<string | undefined>(undefined);
   return (
-    <Select.Root {...props}>
+    <Select.Root value={value} onValueChange={setValue}>
       <Select.Trigger className="group relative flex h-15 w-full items-center justify-between rounded-lg border border-neutral-100 bg-white px-4 font-medium text-base focus:outline-none">
         <div className="flex flex-col">
-          <span className="top-2 font-medium text-neutral-400 text-xs">{label}</span>
+          <span
+            className={`font-medium text-neutral-400 transition-all ${
+              value ? 'text-xs' : 'text-base'
+            }`}
+          >
+            {label}
+          </span>
           <Select.Value
             placeholder={placeholder}
             className="group-data-[placeholder]:text-gray-400"

--- a/apps/manager/src/components/ui/input-select.tsx
+++ b/apps/manager/src/components/ui/input-select.tsx
@@ -11,23 +11,31 @@ type BoxSelectProps = Select.SelectProps & {
   placeholder?: string;
 };
 
-export const InputSelect = ({ options, placeholder, label }: BoxSelectProps) => {
-  const [value, setValue] = useState<string | undefined>(undefined);
+export const InputSelect = ({ options, placeholder, label, ...props }: BoxSelectProps) => {
+  const hasValue =
+    typeof props.value === 'string'
+      ? props.value.length > 0
+      : typeof props.defaultValue === 'string'
+        ? props.defaultValue.length > 0
+        : false;
   return (
-    <Select.Root value={value} onValueChange={setValue}>
+    <Select.Root {...props}>
       <Select.Trigger className="group relative flex h-15 w-full items-center justify-between rounded-lg border border-neutral-100 bg-white px-4 font-medium text-base focus:outline-none">
         <div className="flex flex-col">
           <span
-            className={`font-medium text-neutral-400 transition-all ${
-              value ? 'text-xs' : 'text-base'
-            }`}
+            className={`pointer-events-none absolute font-medium text-neutral-400 transition-all ${
+              hasValue ? 'top-2 text-xs' : '-translate-y-1/2 top-1/2 text-base'
+            } group-data-[state=open]:-translate-y-0 group-data-[state=open]:top-2 group-data-[state=open]:text-xs`}
           >
             {label}
           </span>
-          <Select.Value
-            placeholder={placeholder}
-            className="group-data-[placeholder]:text-gray-400"
-          />
+          {hasValue ? (
+            <p className="pt-4 font-medium text-base text-black">
+              <Select.Value />
+            </p>
+          ) : (
+            <Select.Value placeholder={placeholder} className="text-gray-400" />
+          )}
         </div>
         <Select.Icon className="text-[#141B21]">
           <KeyboardArrowDownIcon />

--- a/apps/manager/src/components/ui/step-progress.tsx
+++ b/apps/manager/src/components/ui/step-progress.tsx
@@ -24,12 +24,10 @@ export const StepProgress = ({ steps, currentStep }: StepProgressProps) => {
                 className={clsx(
                   'flex h-6 w-6 items-center justify-center rounded-full border font-semibold text-sm transition-all',
                   {
-                    // 완료된 단계 (체크 아이콘)
-                    'bg-white text-blue-600': isCompleted,
+                    // 완료된 단계 (체크 아이콘) or 비활성 단계
+                    'bg-gray-400 text-white': isCompleted || (!isCompleted && !isActive),
                     // 현재 활성 단계
                     'bg-blue-500 text-white': isActive,
-                    // 비활성 단계
-                    'border-gray-300 bg-gray-400 text-white': !isCompleted && !isActive,
                   },
                 )}
               >

--- a/apps/manager/src/components/ui/step-progress.tsx
+++ b/apps/manager/src/components/ui/step-progress.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Fragment } from 'react';
+import { CheckSmallIcon } from '@hcc/icons';
+import clsx from 'clsx';
+
+type StepProgressProps = {
+  steps: string[];
+  currentStep: number;
+};
+
+export const StepProgress = ({ steps, currentStep }: StepProgressProps) => {
+  return (
+    <div className="flex w-full items-center justify-center gap-2">
+      {steps.map((step, index) => {
+        const stepNumber = index + 1;
+        const isCompleted = stepNumber < currentStep;
+        const isActive = stepNumber === currentStep;
+
+        return (
+          <Fragment key={step}>
+            <div className="flex flex-row items-center gap-2">
+              <div
+                className={clsx(
+                  'flex h-6 w-6 items-center justify-center rounded-full border font-semibold text-sm transition-all',
+                  {
+                    // 완료된 단계 (체크 아이콘)
+                    'bg-white text-blue-600': isCompleted,
+                    // 현재 활성 단계
+                    'bg-blue-500 text-white': isActive,
+                    // 비활성 단계
+                    'border-gray-300 bg-gray-400 text-white': !isCompleted && !isActive,
+                  },
+                )}
+              >
+                {isCompleted ? <CheckSmallIcon width={20} height={20} /> : stepNumber}
+              </div>
+              <span className={'whitespace-nowrap text-black text-sm'}>{step}</span>
+            </div>
+
+            {stepNumber < steps.length && <div className="h-px flex-grow bg-gray-300" />}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/manager/src/components/ui/step-progress.tsx
+++ b/apps/manager/src/components/ui/step-progress.tsx
@@ -25,7 +25,7 @@ export const StepProgress = ({ steps, currentStep }: StepProgressProps) => {
                   'flex h-6 w-6 items-center justify-center rounded-full border font-semibold text-sm transition-all',
                   {
                     // 완료된 단계 (체크 아이콘) or 비활성 단계
-                    'bg-gray-400 text-white': isCompleted || (!isCompleted && !isActive),
+                    'bg-gray-400 text-white': !isActive,
                     // 현재 활성 단계
                     'bg-blue-500 text-white': isActive,
                   },

--- a/apps/manager/src/constants/routes.ts
+++ b/apps/manager/src/constants/routes.ts
@@ -3,6 +3,7 @@ export const routes = {
   login: 'auth/login',
 
   league: 'leagues',
+  league_create: 'leagues/create',
   player: 'players',
   player_create: 'players/create',
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       ky:
         specifier: ^1.10.0
         version: 1.10.0
@@ -71,6 +74,9 @@ importers:
       react:
         specifier: ^19.1.1
         version: 19.1.1
+      react-day-picker:
+        specifier: ^9.10.0
+        version: 9.10.0(react@19.1.1)
       react-dom:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
@@ -80,6 +86,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     devDependencies:
       '@hcc/typescript-config':
         specifier: workspace:*
@@ -666,6 +675,9 @@ packages:
   '@commitlint/types@19.8.1':
     resolution: {integrity: sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==}
     engines: {node: '>=v18'}
+
+  '@date-fns/tz@1.4.1':
+    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
   '@egjs/agent@2.4.4':
     resolution: {integrity: sha512-cvAPSlUILhBBOakn2krdPnOGv5hAZq92f1YHxYcfu0p7uarix2C6Ia3AVizpS1SGRZGiEkIS5E+IVTLg1I2Iog==}
@@ -1972,6 +1984,12 @@ packages:
     resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
     engines: {node: '>=12'}
 
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
   dayjs@1.11.18:
     resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
 
@@ -2776,6 +2794,12 @@ packages:
     resolution: {integrity: sha512-VWQJyU2bcDTgZw8kpfBpB/ejZASlCrzwz5f2hjb/zlujOEB4oeiAhHygAWq8ubsX2GVkD4kCU5V2dwOTaCY5EQ==}
     engines: {node: '>=0.12'}
 
+  react-day-picker@9.10.0:
+    resolution: {integrity: sha512-tedecLSd+fpSN+J08601MaMsf122nxtqZXxB6lwX37qFoLtuPNuRJN8ylxFjLhyJS1kaLfAqL1GUkSLd2BMrpQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
+
   react-dom@19.1.1:
     resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
     peerDependencies:
@@ -3137,6 +3161,12 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -3651,6 +3681,8 @@ snapshots:
     dependencies:
       '@types/conventional-commits-parser': 5.0.1
       chalk: 5.6.2
+
+  '@date-fns/tz@1.4.1': {}
 
   '@egjs/agent@2.4.4': {}
 
@@ -4734,6 +4766,10 @@ snapshots:
 
   dargs@8.1.0: {}
 
+  date-fns-jalali@4.1.0-0: {}
+
+  date-fns@4.1.0: {}
+
   dayjs@1.11.18: {}
 
   debug@4.4.3:
@@ -5419,6 +5455,13 @@ snapshots:
 
   promise.series@0.2.0: {}
 
+  react-day-picker@9.10.0(react@19.1.1):
+    dependencies:
+      '@date-fns/tz': 1.4.1
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
+      react: 19.1.1
+
   react-dom@19.1.1(react@19.1.1):
     dependencies:
       react: 19.1.1
@@ -5776,6 +5819,15 @@ snapshots:
       '@types/react': 19.1.13
 
   util-deprecate@1.0.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vite-node@3.2.4(@types/node@24.4.0)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@lukemorales/query-key-factory':
         specifier: ^1.3.4
         version: 1.3.4(@tanstack/query-core@5.87.4)(@tanstack/react-query@5.87.4(react@19.1.1))
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@suspensive/react':
         specifier: ^3.9.0
         version: 3.9.0(react@19.1.1)
@@ -841,6 +844,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+
+  '@floating-ui/dom@1.7.4':
+    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
+  '@floating-ui/react-dom@2.1.6':
+    resolution: {integrity: sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
   '@img/sharp-darwin-arm64@0.34.3':
     resolution: {integrity: sha512-ryFMfvxxpQRsgZJqBd4wsttYQbCxsJksrv9Lw/v798JcQ8+w84mBWuXwl+TT0WJ/WrYOLaYpwQXi3sA9nTIaIg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -1047,8 +1065,24 @@ packages:
       next: ^13.0.0 || ^14.0.0 || ^15.0.0
       react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
@@ -1147,6 +1181,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
@@ -1188,6 +1235,19 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1265,6 +1325,49 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rollup/plugin-babel@6.0.4':
     resolution: {integrity: sha512-YF7Y52kFdFT/xVSuVdjkV5ZdX/3YtmX0QulG+x0taQOtJdHYzVU61aSSkAgVJ7NOv6qPkIYiJSgSWWN/DM5sGw==}
@@ -3655,6 +3758,23 @@ snapshots:
   '@esbuild/win32-x64@0.25.9':
     optional: true
 
+  '@floating-ui/core@1.7.3':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.4':
+    dependencies:
+      '@floating-ui/core': 1.7.3
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/react-dom@2.1.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+
+  '@floating-ui/utils@0.2.10': {}
+
   '@img/sharp-darwin-arm64@0.34.3':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.0
@@ -3801,7 +3921,18 @@ snapshots:
       react: 19.1.1
       third-party-capital: 1.0.20
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
 
   '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
@@ -3892,6 +4023,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.13
 
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -3934,6 +4083,35 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.13)(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      aria-hidden: 1.2.6
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      react-remove-scroll: 2.7.1(@types/react@19.1.13)(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.13
       '@types/react-dom': 19.1.9(@types/react@19.1.13)
@@ -3994,6 +4172,37 @@ snapshots:
       react: 19.1.1
     optionalDependencies:
       '@types/react': 19.1.13
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rollup/plugin-babel@6.0.4(@babel/core@7.28.4)(rollup@4.50.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.5.0(next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       ky:
         specifier: ^1.10.0
         version: 1.10.0


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 신규대회 만들기 `leagues/create`  페이지 ui개발

<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/88bdd842-7c9d-4c21-995d-8485b7d22cb3" />
<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/be905e35-58e1-4499-9efd-4f406e34e150" />
<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/3b2a0ebf-bda4-4e8f-a8e9-f6f92e2e0b77" />

- manager화면에서 사용할 컴포넌트 제작
  - `StepProgress` , `InputSelect` , `InputDate`


## ♾️ 기타

- 팀 이름 선택 버튼에 필요한 돋보기 icon 파일 만들어야합니다.
- 달력을 휠 선택방식이 아니라 라이브러리설치해서 임의로 구현해뒀는데 괜찮을까요?
