### PR TITLE
fix(spectator): 모바일 환경에서 `Conveyer` 탭이 스크롤 되지 않는 오류 해결

### DIFF
--- a/apps/spectator/src/app/(dashboard)/_components/previous-tab/year-filter.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/previous-tab/year-filter.tsx
@@ -39,19 +39,20 @@ export const YearFilter = ({ year }: Props) => {
   };
 
   return (
-    <div className="sticky top-24 z-10 bg-white py-3">
-      <div ref={containerRef} className="flex overflow-hidden">
-        <div className="flex gap-2 [&>*:first-child]:ml-5 [&>*:last-child]:mr-5">
-          {years.map(_year => {
-            return (
-              <div key={_year} className="flex shrink-0 items-center gap-2">
-                <FilterBadge isActive={year === _year} onClick={() => handleSelectYear(_year)}>
-                  {_year}
-                </FilterBadge>
-              </div>
-            );
-          })}
-        </div>
+    <div className="sticky top-24 z-header flex overflow-hidden bg-white py-3">
+      <div
+        ref={containerRef}
+        className="flex gap-2 overflow-x-scroll [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*:first-child]:pl-5 [&>*:last-child]:pr-5"
+      >
+        {years.map(_year => {
+          return (
+            <div key={_year} className="flex shrink-0 items-center gap-2">
+              <FilterBadge isActive={year === _year} onClick={() => handleSelectYear(_year)}>
+                {_year}
+              </FilterBadge>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/team-filter/index.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/team-filter/index.tsx
@@ -36,34 +36,33 @@ export const TeamFilter = () => {
   });
 
   return (
-    <div className="sticky top-24 z-10 bg-white py-3">
-      <div ref={containerRef} className="flex overflow-hidden">
-        <div className="flex gap-2 [&>*:first-child]:pl-5 [&>*:last-child]:pr-5">
-          {sortedUnits.map((unit, idx) => {
-            const isAll = unit === '전체';
-            const isActive = isAll ? isEmpty : selected.includes(unit as TeamUnitType);
+    <div className="sticky top-24 z-header flex overflow-hidden bg-white py-3">
+      <div
+        ref={containerRef}
+        className="flex gap-2 overflow-x-scroll [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*:first-child]:pl-5 [&>*:last-child]:pr-5"
+      >
+        {sortedUnits.map((unit, idx) => {
+          const isAll = unit === '전체';
+          const isActive = isAll ? isEmpty : selected.includes(unit as TeamUnitType);
 
-            const prevUnit = sortedUnits[idx - 1];
-            const wasPrevAll = prevUnit === '전체';
-            const wasPrevActive = wasPrevAll
-              ? isEmpty
-              : selected.includes(prevUnit as TeamUnitType);
+          const prevUnit = sortedUnits[idx - 1];
+          const wasPrevAll = prevUnit === '전체';
+          const wasPrevActive = wasPrevAll ? isEmpty : selected.includes(prevUnit as TeamUnitType);
 
-            const showDivider = idx > 0 && wasPrevActive && !isActive;
+          const showDivider = idx > 0 && wasPrevActive && !isActive;
 
-            return (
-              <div key={unit} className="flex shrink-0 items-center gap-2">
-                {showDivider && <div className="h-6 w-px bg-neutral-100" aria-hidden="true" />}
-                <FilterBadge
-                  isActive={isActive}
-                  onClick={() => toggle(isAll ? null : (unit as TeamUnitType))}
-                >
-                  {unit}
-                </FilterBadge>
-              </div>
-            );
-          })}
-        </div>
+          return (
+            <div key={unit} className="flex shrink-0 items-center gap-2">
+              {showDivider && <div className="h-6 w-px bg-neutral-100" aria-hidden="true" />}
+              <FilterBadge
+                isActive={isActive}
+                onClick={() => toggle(isAll ? null : (unit as TeamUnitType))}
+              >
+                {unit}
+              </FilterBadge>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/spectator/src/app/(dashboard)/page.tsx
+++ b/apps/spectator/src/app/(dashboard)/page.tsx
@@ -33,7 +33,7 @@ const Page = async ({ searchParams }: Props) => {
       <Header menu={<CalendarMenu />} />
 
       <Tabs.Root className="column w-full bg-white" defaultValue={tab}>
-        <Tabs.List className="center sticky top-12 z-10 h-12 gap-5 border-neutral-100 border-b bg-white">
+        <Tabs.List className="center sticky top-12 z-header h-12 gap-5 border-neutral-100 border-b bg-white">
           <TabTrigger value="previous">이전 대회</TabTrigger>
           <TabTrigger value="recent">최근 경기</TabTrigger>
           <TabTrigger value="team">팀별 보기</TabTrigger>

--- a/apps/spectator/src/app/leagues/[id]/_components/round-filter.tsx
+++ b/apps/spectator/src/app/leagues/[id]/_components/round-filter.tsx
@@ -14,7 +14,7 @@ export const RoundFilter = ({ league, round }: Props) => {
   );
 
   return (
-    <Tabs.Root className="sticky top-12 z-above h-12 w-full" defaultValue={round.toString()}>
+    <Tabs.Root className="sticky top-12 z-header h-12 w-full" defaultValue={round.toString()}>
       <Tabs.List className="center h-12 gap-5 border-neutral-100 border-b bg-white">
         {rounds.map(r => (
           <TabTrigger className="min-w-14" key={r} value={r.toString()} queryKey="round">

--- a/apps/spectator/src/app/leagues/[id]/_components/round-filter.tsx
+++ b/apps/spectator/src/app/leagues/[id]/_components/round-filter.tsx
@@ -14,8 +14,8 @@ export const RoundFilter = ({ league, round }: Props) => {
   );
 
   return (
-    <Tabs.Root className="column w-full" defaultValue={round.toString()}>
-      <Tabs.List className="center sticky top-12 z-10 h-12 gap-5 border-neutral-100 border-b bg-white">
+    <Tabs.Root className="sticky top-12 z-above h-12 w-full" defaultValue={round.toString()}>
+      <Tabs.List className="center h-12 gap-5 border-neutral-100 border-b bg-white">
         {rounds.map(r => (
           <TabTrigger className="min-w-14" key={r} value={r.toString()} queryKey="round">
             {r > 2 ? `${r}강` : '결승'}

--- a/apps/spectator/src/app/leagues/[id]/_components/team-filter.tsx
+++ b/apps/spectator/src/app/leagues/[id]/_components/team-filter.tsx
@@ -44,8 +44,8 @@ export const TeamFilter = ({ teams, selectedTeams }: Props) => {
   };
 
   return (
-    <div ref={containerRef} className="sticky top-24 z-10 flex h-12 overflow-hidden bg-white py-3">
-      <div className="flex gap-2 [&>*:first-child]:pl-5 [&>*:last-child]:pr-5">
+    <div ref={containerRef} className="sticky top-24 z-header flex overflow-hidden bg-white py-3">
+      <div className="flex gap-2 overflow-x-scroll [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*:first-child]:pl-5 [&>*:last-child]:pr-5">
         {teams.map(item => {
           const isActive = selectedTeams.includes(item.leagueTeamId);
 

--- a/apps/spectator/src/app/leagues/[id]/_components/team-filter.tsx
+++ b/apps/spectator/src/app/leagues/[id]/_components/team-filter.tsx
@@ -44,8 +44,11 @@ export const TeamFilter = ({ teams, selectedTeams }: Props) => {
   };
 
   return (
-    <div ref={containerRef} className="sticky top-24 z-header flex overflow-hidden bg-white py-3">
-      <div className="flex gap-2 overflow-x-scroll [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*:first-child]:pl-5 [&>*:last-child]:pr-5">
+    <div className="sticky top-24 z-header flex overflow-hidden bg-white py-3">
+      <div
+        ref={containerRef}
+        className="flex gap-2 overflow-x-scroll [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*:first-child]:pl-5 [&>*:last-child]:pr-5"
+      >
         {teams.map(item => {
           const isActive = selectedTeams.includes(item.leagueTeamId);
 

--- a/apps/spectator/src/app/leagues/[id]/page.tsx
+++ b/apps/spectator/src/app/leagues/[id]/page.tsx
@@ -36,13 +36,11 @@ const Page = async ({ searchParams, params }: Props) => {
   return (
     <HydrationBoundary state={dehydrate(qc)}>
       <Header arrow />
-      <div className="w-full">
-        {league && round && <RoundFilter league={league} round={round} />}
-        {teams && <TeamFilter teams={teams} selectedTeams={selectedTeams} />}
-        <Suspense clientOnly>
-          <GameList leagueId={id} round={round} selectedTeams={selectedTeams} />
-        </Suspense>
-      </div>
+      {league && round && <RoundFilter league={league} round={round} />}
+      {teams && <TeamFilter teams={teams} selectedTeams={selectedTeams} />}
+      <Suspense clientOnly>
+        <GameList leagueId={id} round={round} selectedTeams={selectedTeams} />
+      </Suspense>
     </HydrationBoundary>
   );
 };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #413 

## ✅ 작업 내용

- 모바일 환경에서 `@egjs/conveyer`를 사용하는 탭이 스크롤 되지 않는 문제를 해결했어요.
- 리그 페이지에서 탭이 고정되지 않는 문제를 해결했어요.
- 탭의 `z-index`를  `z-header`로 변경했어요.

## 📝 참고 자료

<table>
<tr>
<td>
<img width="678" height="1468" alt="image" src="https://github.com/user-attachments/assets/84bce46b-a897-48e5-996f-134c16c13408" />
</td>
<td>
<img width="678" height="1468" alt="image" src="https://github.com/user-attachments/assets/21ea5890-d768-402c-9946-71876ac3f12e" />
</td>
</tr>
</table>



