### PR TITLE
fix(spectator): 팀별보기 페이지 API 교체 및 캘린더 버튼 제거

### DIFF
--- a/apps/spectator/src/api/queries/index.ts
+++ b/apps/spectator/src/api/queries/index.ts
@@ -13,3 +13,4 @@ export * from './useLeagueTopScorers';
 export * from './useTeam';
 export * from './useTeamGames';
 export * from './useTeams';
+export * from './useTeamsSummary';

--- a/apps/spectator/src/api/queries/useTeamsSummary.ts
+++ b/apps/spectator/src/api/queries/useTeamsSummary.ts
@@ -1,0 +1,9 @@
+import { useQuery, useSuspenseQuery } from '@hcc/api-base';
+import type { TeamListPayload } from '~/api';
+import { queryKeys } from '../queryKey';
+
+export const useTeamsSummary = (payload: TeamListPayload) =>
+  useQuery(queryKeys.teams.summary(payload));
+
+export const useSuspenseTeamsSummary = (payload: TeamListPayload) =>
+  useSuspenseQuery(queryKeys.teams.summary(payload));

--- a/apps/spectator/src/api/queryKey.ts
+++ b/apps/spectator/src/api/queryKey.ts
@@ -29,6 +29,7 @@ import type {
   TeamDetailType,
   TeamGamesPayload,
   TeamListPayload,
+  TeamSummaryType,
   TeamType,
 } from './types';
 
@@ -93,6 +94,19 @@ const teamQueryKeys = createQueryKeys('teams', {
   games: (payload: TeamGamesPayload) => ({
     queryKey: [payload],
     queryFn: () => fetcher.get<GameType[]>(`teams/${payload.id}/games`),
+  }),
+  summary: (payload: TeamListPayload) => ({
+    queryKey: [payload],
+    queryFn: () => {
+      const params = new URLSearchParams();
+
+      if (payload.units) {
+        const units = Array.isArray(payload.units) ? payload.units : [payload.units];
+        units.forEach(u => params.append('units', u));
+      }
+
+      return fetcher.get<TeamSummaryType[]>('teams/summary', { searchParams: params });
+    },
   }),
 });
 

--- a/apps/spectator/src/api/types/teams.ts
+++ b/apps/spectator/src/api/types/teams.ts
@@ -1,3 +1,5 @@
+import type { GameType } from '~/api';
+
 export type TeamType = {
   id: number;
   name: string;
@@ -81,4 +83,9 @@ export type TeamDetailType = {
 
 export type TeamGamesPayload = {
   id: number;
+};
+
+export type TeamSummaryType = {
+  teamDetail: TeamDetailType;
+  recentGames: GameType[];
 };

--- a/apps/spectator/src/app/(dashboard)/_components/previous-tab/index.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/previous-tab/index.tsx
@@ -30,7 +30,7 @@ export const PreviousTab = ({ year }: Props) => {
               </Suspense>
             </ErrorBoundary>
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="grid grid-cols-2 gap-4">
               <ErrorBoundary fallback={null}>
                 <Suspense fallback={null} clientOnly>
                   <LeagueCard.Scorers leagueId={league.leagueId} />

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/index.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ErrorBoundary, Suspense } from '@suspensive/react';
-import { useSuspenseTeams } from '~/api';
+import { useSuspenseTeamsSummary } from '~/api';
 import { MatchHistory } from './match-history';
 import { ScoreList } from './score-list';
 import { TeamCard } from './team-card';
@@ -9,7 +9,7 @@ import { TeamFilter, useTeamUnits } from './team-filter';
 
 export const TeamTab = () => {
   const { selected } = useTeamUnits();
-  const { data } = useSuspenseTeams({ units: selected });
+  const { data } = useSuspenseTeamsSummary({ units: selected });
 
   return (
     <div className="column">
@@ -17,15 +17,15 @@ export const TeamTab = () => {
 
       <div className="column mb-5 gap-3 px-5">
         {data.map(team => (
-          <TeamCard key={team.id}>
-            <TeamCard.Header team={team} />
+          <TeamCard key={team.teamDetail.name}>
+            <TeamCard.Header team={team.teamDetail} />
             <TeamCard.Divider />
 
             <TeamCard.Content>
               <TeamCard.Section title="득점왕" icon="🙋‍♂️">
                 <ErrorBoundary fallback={null}>
                   <Suspense clientOnly>
-                    <ScoreList teamId={team.id} />
+                    <ScoreList scorers={team.teamDetail.topScorers} />
                   </Suspense>
                 </ErrorBoundary>
               </TeamCard.Section>
@@ -33,7 +33,7 @@ export const TeamTab = () => {
               <TeamCard.Section title="최근 경기" icon="💥">
                 <ErrorBoundary fallback={null}>
                   <Suspense clientOnly>
-                    <MatchHistory teamId={team.id} teamName={team.name} />
+                    <MatchHistory games={team.recentGames} teamName={team.teamDetail.name} />
                   </Suspense>
                 </ErrorBoundary>
               </TeamCard.Section>

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/match-history.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/match-history.tsx
@@ -1,21 +1,19 @@
 import { colors, Typography } from '@hcc/ui';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useSuspenseTeamGames } from '~/api';
+import type { GameType } from '~/api';
 import { routes } from '~/constants/routes';
 
 interface MatchHistoryProps {
-  teamId: number;
+  games: GameType[];
   teamName: string;
   limit?: number;
 }
 
-export const MatchHistory = ({ teamId, teamName, limit = 3 }: MatchHistoryProps) => {
-  const { data } = useSuspenseTeamGames({ id: teamId });
-
+export const MatchHistory = ({ games, teamName, limit = 3 }: MatchHistoryProps) => {
   return (
     <div className="column mt-2 gap-1.5">
-      {data.slice(0, limit).map(game => {
+      {games.slice(0, limit).map(game => {
         if (game.gameTeams.length < 2) return null;
 
         const [home, away] =
@@ -80,7 +78,7 @@ export const MatchHistory = ({ teamId, teamName, limit = 3 }: MatchHistoryProps)
         );
       })}
 
-      {data.length === 0 && (
+      {games.length === 0 && (
         <Typography color={colors.neutral500} fontSize={13} weight="medium">
           아직 경기 기록이 없어요.
         </Typography>

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/score-list.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/score-list.tsx
@@ -1,17 +1,22 @@
 import { colors, Typography } from '@hcc/ui';
-import { useSuspenseTeam } from '~/api';
+import type { TopScorerType } from '~/api';
 
 interface ScoreListProps {
-  teamId: number;
+  scorers: TopScorerType[];
   limit?: number;
 }
 
-export const ScoreList = ({ teamId, limit = 3 }: ScoreListProps) => {
-  const { data } = useSuspenseTeam({ id: teamId });
+export const ScoreList = ({ scorers, limit = 3 }: ScoreListProps) => {
+  if (!scorers) return null;
 
   return (
     <div className="column mt-2 gap-1">
-      {data.topScorers.slice(0, limit).map(player => (
+      {scorers.length === 0 && (
+        <Typography color={colors.neutral500} fontSize={13} weight="medium">
+          아직 득점 기록이 없어요.
+        </Typography>
+      )}
+      {scorers.slice(0, limit).map(player => (
         <div key={player.playerId} className="row-between">
           <Typography color={colors.neutral700} fontSize={13} weight="medium">
             {player.playerName}
@@ -21,12 +26,6 @@ export const ScoreList = ({ teamId, limit = 3 }: ScoreListProps) => {
           </Typography>
         </div>
       ))}
-
-      {data.topScorers.length === 0 && (
-        <Typography color={colors.neutral500} fontSize={13} weight="medium">
-          아직 득점 기록이 없어요.
-        </Typography>
-      )}
     </div>
   );
 };

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/team-card.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/team-card.tsx
@@ -1,11 +1,8 @@
-import { ChevronForwardIcon } from '@hcc/icons';
 import { Typography } from '@hcc/ui';
 import Image from 'next/image';
-import Link from 'next/link';
 import type { ComponentProps } from 'react';
 import { twMerge } from 'tailwind-merge';
-import type { TeamType } from '~/api';
-import { routes } from '~/constants/routes';
+import type { TeamDetailType } from '~/api';
 
 /* -------------------------------------------------------------------------------------------------
  * TeamCard
@@ -27,7 +24,7 @@ const TeamCardRoot = ({ children, className, ...props }: ComponentProps<'div'>) 
  * -----------------------------------------------------------------------------------------------*/
 
 interface TeamCardHeaderProps extends ComponentProps<'div'> {
-  team: TeamType;
+  team: TeamDetailType;
 }
 
 const TeamCardHeader = ({ team, className, ...props }: TeamCardHeaderProps) => {

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/team-card.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/team-card.tsx
@@ -48,9 +48,9 @@ const TeamCardHeader = ({ team, className, ...props }: TeamCardHeaderProps) => {
         <Typography weight="medium">{team.name}</Typography>
       </div>
 
-      <Link href={`/${routes.team(team.id)}`} className="center">
-        <ChevronForwardIcon size={24} />
-      </Link>
+      {/*<Link href={`/${routes.team(team.id)}`} className="center">*/}
+      {/*  <ChevronForwardIcon size={24} />*/}
+      {/*</Link>*/}
     </div>
   );
 };

--- a/apps/spectator/src/app/(dashboard)/page.tsx
+++ b/apps/spectator/src/app/(dashboard)/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from '@suspensive/react';
 import { redirect } from 'next/navigation';
 import { Header } from '~/components/layout';
 import { TabTrigger } from '~/components/ui';
-import { CalendarMenu } from './_components/calendar-menu';
 import { PreviousTab } from './_components/previous-tab';
 import { RecentTab } from './_components/recent-tab';
 import { TeamTab } from './_components/team-tab';
@@ -30,7 +29,9 @@ const Page = async ({ searchParams }: Props) => {
 
   return (
     <>
-      <Header menu={<CalendarMenu />} />
+      <Header
+      // menu={<CalendarMenu />}
+      />
 
       <Tabs.Root className="column w-full bg-white" defaultValue={tab}>
         <Tabs.List className="center sticky top-12 z-header h-12 gap-5 border-neutral-100 border-b bg-white">


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #413 

## ✅ 작업 내용

- 팀별보기 페이지에서 사용하는 API를 변경했어요 (`/teams/summary`)
- 메인 페이지에서 캘린더로 넘어가는 헤더 버튼을 제거했어요.
- 팀 디테일 페이지 버튼을 제거했어요.
- 모바일 환경에서도 이전 대회 카드가 두 개의 그리드로 보이도록 변경했어요.
- <img width="350" height="1401" alt="image" src="https://github.com/user-attachments/assets/47d21996-d6f5-4e79-8cfb-fd4f1e9f5a45" /> <img width="350" height="1401" alt="image" src="https://github.com/user-attachments/assets/1d87baea-3fe5-4c48-9bd7-bdac03ac5d35" />
