### PR TITLE
fix(spectator): 탭 컴포넌트에 `ErrorBoundary` 추가

### DIFF
--- a/apps/spectator/src/app/(dashboard)/page.tsx
+++ b/apps/spectator/src/app/(dashboard)/page.tsx
@@ -1,5 +1,6 @@
+import { colors, Typography } from '@hcc/ui';
 import * as Tabs from '@radix-ui/react-tabs';
-import { Suspense } from '@suspensive/react';
+import { ErrorBoundary, Suspense } from '@suspensive/react';
 import { redirect } from 'next/navigation';
 import { Header } from '~/components/layout';
 import { TabTrigger } from '~/components/ui';
@@ -41,19 +42,25 @@ const Page = async ({ searchParams }: Props) => {
         </Tabs.List>
 
         <Tabs.Content value="previous">
-          <Suspense clientOnly>
-            <PreviousTab year={year} />
-          </Suspense>
+          <ErrorBoundary fallback={<ErrorMessage />}>
+            <Suspense clientOnly>
+              <PreviousTab year={year} />
+            </Suspense>
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="recent">
-          <Suspense clientOnly>
-            <RecentTab />
-          </Suspense>
+          <ErrorBoundary fallback={<ErrorMessage />}>
+            <Suspense clientOnly>
+              <RecentTab />
+            </Suspense>
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="team">
-          <Suspense clientOnly>
-            <TeamTab />
-          </Suspense>
+          <ErrorBoundary fallback={<ErrorMessage />}>
+            <Suspense clientOnly>
+              <TeamTab />
+            </Suspense>
+          </ErrorBoundary>
         </Tabs.Content>
       </Tabs.Root>
     </>
@@ -61,3 +68,11 @@ const Page = async ({ searchParams }: Props) => {
 };
 
 export default Page;
+
+const ErrorMessage = () => {
+  return (
+    <Typography className="p-5 text-center" color={colors.neutral500} fontSize={14} weight="medium">
+      알 수 없는 오류가 발생했어요. 잠시 후 다시 시도해 주세요.
+    </Typography>
+  );
+};


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #413 

## ✅ 작업 내용

- 메인 페이지 탭에 `ErrorBoundary`를 추가해서, 서버 오류가 발생하는 경우 텍스트가 나타나게 했어요.
- <img width="350" height="1401" alt="image" src="https://github.com/user-attachments/assets/6824fd7a-c450-4a55-98b1-10e8f36ca10d" />
