### PR TITLE
fix(spectator): 응원톡 통계가 0으로 나타나는 오류 해결

### DIFF
--- a/apps/spectator/src/api/types/leagues.ts
+++ b/apps/spectator/src/api/types/leagues.ts
@@ -39,7 +39,7 @@ export type LeagueStatisticsType = {
   firstWinnerTeam: StatisticTeamType;
   secondWinnerTeam: StatisticTeamType;
   mostCheeredTeam: StatisticTeamType & { cheerCount: number };
-  mostCheerTalksTeam: StatisticTeamType & { cheerTalkCount: number };
+  mostCheerTalksTeam: StatisticTeamType & { cheerTalksCount: number };
 };
 
 export type LeagueStatisticsPayload = {

--- a/apps/spectator/src/app/(dashboard)/_components/previous-tab/league-card.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/previous-tab/league-card.tsx
@@ -243,7 +243,7 @@ const LeagueCardStatistics = ({
               color={colors.neutral500}
               weight="medium"
             >
-              {data.mostCheerTalksTeam.cheerTalkCount ?? 0}회
+              {data.mostCheerTalksTeam.cheerTalksCount ?? 0}회
             </Typography>
           </li>
         )}


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #413 

## ✅ 작업 내용

- `cheerTalksCount` 변수를 수정하여 응원톡 통계가 0으로 나타나는 오류를 해결했어요.
- <img width="350" height="1401" alt="image" src="https://github.com/user-attachments/assets/c8260006-a2ab-4e0d-b9db-e2a89d4ba4f3" />
