### PR TITLE
feat(spectator): 등번호 추가 및 FINISHED 필터링 제거

### DIFF
--- a/apps/spectator/src/api/types/games.ts
+++ b/apps/spectator/src/api/types/games.ts
@@ -53,10 +53,10 @@ export type GameTeamPlayerType = {
   id: number;
   playerName: string;
   description?: string;
-  number: number;
+  jerseyNumber: number;
   isCaptain: boolean;
   isReplaced: boolean;
-  replacedPlayer: Pick<GameTeamPlayerType, 'id' | 'number' | 'playerName'> | null;
+  replacedPlayer: Pick<GameTeamPlayerType, 'id' | 'jerseyNumber' | 'playerName'> | null;
   state: 'STARTER' | 'CANDIDATE';
 };
 

--- a/apps/spectator/src/api/types/leagues.ts
+++ b/apps/spectator/src/api/types/leagues.ts
@@ -8,7 +8,7 @@ export type LeagueType = {
 
 export type LeagueListPayload = {
   year: number;
-  leagueProgress: 'BEFORE_START' | 'IN_PROGRESS' | 'FINISHED';
+  leagueProgress?: 'BEFORE_START' | 'IN_PROGRESS' | 'FINISHED';
   cursor?: number;
   size: number;
 };

--- a/apps/spectator/src/app/(dashboard)/_components/previous-tab/index.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/previous-tab/index.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export const PreviousTab = ({ year }: Props) => {
-  const { data } = useSuspenseLeagues({ year, leagueProgress: 'FINISHED', size: 50 });
+  const { data } = useSuspenseLeagues({ year, size: 50 });
 
   return (
     <div className="column">

--- a/apps/spectator/src/app/games/[id]/_components/lineup-tab/candidate-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/lineup-tab/candidate-list.tsx
@@ -38,7 +38,7 @@ export const CandidateList = ({ gameId }: Props) => {
                   .map(player => (
                     <div key={player.id} className="center-y w-full gap-2">
                       <span className="center h-7 w-7 rounded-lg bg-neutral-100 font-medium text-neutral-500 text-sm">
-                        {player.number}
+                        {player.jerseyNumber}
                       </span>
                       <Typography fontSize={14} weight="medium" lineHeight="none" asChild>
                         <span>{player.playerName}</span>

--- a/apps/spectator/src/app/games/[id]/_components/lineup-tab/ground/ground.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/lineup-tab/ground/ground.tsx
@@ -51,7 +51,7 @@ const GroundPlayer = ({ player, ...props }: PlayerProps) => {
   return (
     <span className="column-center z-above flex-1" {...props}>
       <span className="center relative h-8 w-8 rounded-full border border-neutral-50 bg-[#50A465] font-medium text-sm text-white">
-        {player.number}
+        {player.jerseyNumber}
         {player.isReplaced && (
           <i className="center -right-0.5 -bottom-0.5 absolute h-3 w-3 rounded-full border border-[var(--color-danger-600)] bg-[var(--color-danger-200)]">
             <ArrowBackIcon className="text-[var(--color-danger-600)]" size={8} />

--- a/apps/spectator/src/app/games/[id]/_components/lineup-tab/player-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/lineup-tab/player-list.tsx
@@ -47,7 +47,7 @@ export const PlayerList = ({ gameId }: Props) => {
             .map(player => (
               <div key={player.id} className="center-y w-full gap-2">
                 <span className="center h-7 w-7 rounded-lg bg-neutral-100 font-medium text-neutral-500 text-sm">
-                  {player.number}
+                  {player.jerseyNumber}
                 </span>
                 <div className="column gap-1">
                   <Typography fontSize={14} weight="medium" lineHeight="none">


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 라인업 화면에서 등번호 추가
- 이전 대회(2025)에 FINISHED 필터링 제거

