### PR TITLE
chore(nextjs): `Next.js` 이미지 최적화 비활성화 설정

### DIFF
--- a/apps/manager/next.config.ts
+++ b/apps/manager/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   images: {
+    unoptimized: true,
     formats: ['image/avif', 'image/webp'],
     remotePatterns: [
       {

--- a/apps/spectator/next.config.ts
+++ b/apps/spectator/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   images: {
+    unoptimized: true,
     formats: ['image/avif', 'image/webp'],
     remotePatterns: [
       {


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #413 

## ✅ 작업 내용

- `Next.js` 에서 설정하는 이미지 최적화 옵션을 비활성화 했어요.