### PR TITLE
feat: teamColor utils 함수 작성 및 라인업화면 팀색상 구현

### DIFF
--- a/apps/spectator/src/api/types/games.ts
+++ b/apps/spectator/src/api/types/games.ts
@@ -70,6 +70,7 @@ export type GameLineupType = {
 export type GameLineupPlayingType = {
   gameTeamId: number;
   teamName: string;
+  teamColor: string;
   gameTeamPlayers: GameTeamPlayerType[];
 };
 

--- a/apps/spectator/src/api/types/teams.ts
+++ b/apps/spectator/src/api/types/teams.ts
@@ -38,6 +38,7 @@ export type GameTeamType = {
   logoImageUrl: string;
   score: number;
   pkScore: number;
+  teamColor: string;
 };
 
 export type TeamDetailPayload = {

--- a/apps/spectator/src/app/games/[id]/_components/lineup-tab/ground/ground.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/lineup-tab/ground/ground.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ArrowBackIcon } from '@hcc/icons';
+import { getBorderColor } from '@hcc/toolkit';
 import type { ComponentProps } from 'react';
 import { twMerge } from 'tailwind-merge';
 import type { GameTeamPlayerType } from '~/api';
@@ -45,12 +46,17 @@ const GroundPlayerField = ({ className, children, ...props }: ComponentProps<'di
 
 interface PlayerProps extends ComponentProps<'span'> {
   player: GameTeamPlayerType;
+  teamColor?: string;
 }
 
-const GroundPlayer = ({ player, ...props }: PlayerProps) => {
+const GroundPlayer = ({ player, teamColor, ...props }: PlayerProps) => {
+  const borderColor = getBorderColor(teamColor);
   return (
     <span className="column-center z-above flex-1" {...props}>
-      <span className="center relative h-8 w-8 rounded-full border border-neutral-50 bg-[#50A465] font-medium text-sm text-white">
+      <span
+        style={{ backgroundColor: teamColor, borderColor: borderColor }}
+        className="center relative h-8 w-8 rounded-full border font-medium text-sm text-white"
+      >
         {player.jerseyNumber}
         {player.isReplaced && (
           <i className="center -right-0.5 -bottom-0.5 absolute h-3 w-3 rounded-full border border-[var(--color-danger-600)] bg-[var(--color-danger-200)]">

--- a/apps/spectator/src/app/games/[id]/_components/lineup-tab/ground/index.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/lineup-tab/ground/index.tsx
@@ -16,7 +16,8 @@ export const Ground = ({ gameId }: Props) => {
 
   const [homeTeam, awayTeam] = game.gameTeams;
   const [homePlayers, awayPlayers] = lineup;
-
+  const homeTeamColor = homeTeam.teamColor;
+  const awayTeamColor = awayTeam.teamColor;
   return (
     <div className="column m-5 rounded-lg border border-neutral-100 bg-white">
       <TeamBox className="order-1" team={homeTeam} />
@@ -27,7 +28,7 @@ export const Ground = ({ gameId }: Props) => {
           {groupPlayers(homePlayers.starterPlayers).map(group => (
             <div key={uuid()} className="center-y w-full max-w-[420px]">
               {group.map(player => (
-                <BaseGround.Player key={player.id} player={player} />
+                <BaseGround.Player key={player.id} player={player} teamColor={homeTeamColor} />
               ))}
             </div>
           ))}
@@ -36,7 +37,7 @@ export const Ground = ({ gameId }: Props) => {
           {groupPlayers(awayPlayers.starterPlayers).map(group => (
             <div key={uuid()} className="center-y w-full max-w-[420px]">
               {group.map(player => (
-                <BaseGround.Player key={player.id} player={player} />
+                <BaseGround.Player key={player.id} player={player} teamColor={awayTeamColor} />
               ))}
             </div>
           ))}

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -1,1 +1,2 @@
 export * from './utils/formatTime';
+export * from './utils/teamColor';

--- a/packages/toolkit/src/utils/teamColor.ts
+++ b/packages/toolkit/src/utils/teamColor.ts
@@ -1,3 +1,5 @@
+const DEFAULT_BORDER_COLOR = 'rgba(255, 255, 255, 0.5)';
+
 const TEAM_COLOR_BORDER_MAP: Record<string, string> = {
   '#FF9A9E': '#B11D23', //rose
   '#FFA788': '#BF4F28', //coral
@@ -7,14 +9,9 @@ const TEAM_COLOR_BORDER_MAP: Record<string, string> = {
   '#7EECD8': '#17957E', //mint
   '#99A8CC': '#253C73', //slate
   '#B8C0CC': '#384E6F', //gray
-
-  DEFAULT: 'rgba(255, 255, 255, 0.5)',
 };
 
 export const getBorderColor = (teamColor?: string): string => {
-  if (!teamColor) return TEAM_COLOR_BORDER_MAP.DEFAULT;
-
-  const normalizedColor = teamColor.toUpperCase().trim();
-
-  return TEAM_COLOR_BORDER_MAP[normalizedColor] || TEAM_COLOR_BORDER_MAP.DEFAULT;
+  const lookup = teamColor ? TEAM_COLOR_BORDER_MAP[teamColor.toUpperCase().trim()] : undefined;
+  return lookup || DEFAULT_BORDER_COLOR;
 };

--- a/packages/toolkit/src/utils/teamColor.ts
+++ b/packages/toolkit/src/utils/teamColor.ts
@@ -1,0 +1,20 @@
+const TEAM_COLOR_BORDER_MAP: Record<string, string> = {
+  '#FF9A9E': '#B11D23', //rose
+  '#FFA788': '#BF4F28', //coral
+  '#FFB5AA': '#D6412B', //peach
+  '#FFD479': '#C78B0C', //yellow
+  '#8CBAFF': '#1A54AA', //blue
+  '#7EECD8': '#17957E', //mint
+  '#99A8CC': '#253C73', //slate
+  '#B8C0CC': '#384E6F', //gray
+
+  DEFAULT: 'rgba(255, 255, 255, 0.5)',
+};
+
+export const getBorderColor = (teamColor?: string): string => {
+  if (!teamColor) return TEAM_COLOR_BORDER_MAP.DEFAULT;
+
+  const normalizedColor = teamColor.toUpperCase().trim();
+
+  return TEAM_COLOR_BORDER_MAP[normalizedColor] || TEAM_COLOR_BORDER_MAP.DEFAULT;
+};


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 구현한 내용
  - `packages/toolkit/src/utils/teamColor.ts` 에 팀색상 조합 설정
    - getBorderColor로 사용하면 됩니다
  - 라인업 화면에 팀색상 구현

