### PR TITLE
fix(manager): 대회 관리 버튼 라우팅 추가

### DIFF
--- a/apps/manager/src/app/(private)/leagues/_components/league-overview.tsx
+++ b/apps/manager/src/app/(private)/leagues/_components/league-overview.tsx
@@ -4,13 +4,14 @@ import { ChevronForwardIcon } from '@hcc/icons';
 import { formatTime } from '@hcc/toolkit';
 import { Badge, Button, Typography } from '@hcc/ui';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { Fragment } from 'react';
 import { useSuspenseLeaguesLeague } from '~/api';
 import { routes } from '~/constants/routes';
 
 export const LeagueOverview = () => {
   const { data } = useSuspenseLeaguesLeague();
-
+  const router = useRouter();
   return (
     <Fragment>
       {data.map(league => (
@@ -57,11 +58,29 @@ export const LeagueOverview = () => {
           </div>
 
           <div className="row-between mt-4 gap-2.5">
-            <Button className="flex-1" size="sm" color="black" variant="subtle" asChild>
-              <Link href={'/teams'}>참가 팀 관리</Link>
+            <Button
+              className="flex-1"
+              size="sm"
+              color="black"
+              variant="subtle"
+              onClick={e => {
+                e.stopPropagation();
+                router.push(`/${routes.teams}`);
+              }}
+            >
+              참가 팀 관리
             </Button>
-            <Button className="flex-1" size="sm" color="black" variant="subtle" asChild>
-              <Link href={'/cheertalks'}>응원톡 관리</Link>
+            <Button
+              className="flex-1"
+              size="sm"
+              color="black"
+              variant="subtle"
+              onClick={e => {
+                e.stopPropagation();
+                router.push(`/${routes.cheertalks}`);
+              }}
+            >
+              응원톡 관리
             </Button>
           </div>
         </Link>

--- a/apps/manager/src/app/(private)/leagues/_components/league-overview.tsx
+++ b/apps/manager/src/app/(private)/leagues/_components/league-overview.tsx
@@ -14,7 +14,7 @@ export const LeagueOverview = () => {
   return (
     <Fragment>
       {data.map(league => (
-        <div key={league.id} className="w-full bg-white p-5">
+        <Link href={`/${routes.league(league.id)}`} key={league.id} className="w-full bg-white p-5">
           <div className="row-between w-full bg-white">
             <div className="center-y gap-1.5">
               <Badge size="sm" variant={league.leagueProgress === '진행 중' ? 'danger' : 'default'}>
@@ -22,9 +22,9 @@ export const LeagueOverview = () => {
               </Badge>
               <Typography weight="semibold">{league.name}</Typography>
             </div>
-            <Link className="center" href={`/${routes.league(league.id)}`}>
+            <div className="center">
               <ChevronForwardIcon size={24} />
-            </Link>
+            </div>
           </div>
 
           <hr className="my-4 h-[1px] w-full border-none bg-neutral-100" />
@@ -58,13 +58,13 @@ export const LeagueOverview = () => {
 
           <div className="row-between mt-4 gap-2.5">
             <Button className="flex-1" size="sm" color="black" variant="subtle" asChild>
-              <Link href={''}>참가 팀 관리</Link>
+              <Link href={'/teams'}>참가 팀 관리</Link>
             </Button>
             <Button className="flex-1" size="sm" color="black" variant="subtle" asChild>
-              <Link href={''}>응원톡 관리</Link>
+              <Link href={'/cheertalks'}>응원톡 관리</Link>
             </Button>
           </div>
-        </div>
+        </Link>
       ))}
     </Fragment>
   );


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 매니저 화면에서 대회 관리 > 참가팀 관리, 응원톡 관리 라우팅 추가
- 대회 버튼 영역 확장

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
