### PR TITLE
style(spectator): 리그별 카드 세로정렬로 수정

### DIFF
--- a/apps/spectator/src/app/(dashboard)/_components/previous-tab/index.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/previous-tab/index.tsx
@@ -30,7 +30,7 @@ export const PreviousTab = ({ year }: Props) => {
               </Suspense>
             </ErrorBoundary>
 
-            <div className="grid grid-cols-2 gap-4">
+            <div className="column w-full gap-4">
               <ErrorBoundary fallback={null}>
                 <Suspense fallback={null} clientOnly>
                   <LeagueCard.Scorers leagueId={league.leagueId} />


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 이전대회 > 대회별 폭풍응원’&‘댓글폭발 카드 ui수정
  - 세로 배치로 수정했습니다

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
