### PR TITLE
fix(spectaor): 이전 대회> 게임 페이지 랜딩 일원화

### DIFF
--- a/apps/spectator/src/app/leagues/[id]/_components/round-filter.tsx
+++ b/apps/spectator/src/app/leagues/[id]/_components/round-filter.tsx
@@ -14,7 +14,7 @@ export const RoundFilter = ({ league, round }: Props) => {
   );
 
   return (
-    <Tabs.Root className="sticky top-12 z-header h-12 w-full" defaultValue={rounds[0].toString()}>
+    <Tabs.Root className="sticky top-12 z-header h-12 w-full" defaultValue={round.toString()}>
       <Tabs.List className="center h-12 gap-5 border-neutral-100 border-b bg-white">
         {rounds.map(r => (
           <TabTrigger className="min-w-14" key={r} value={r.toString()} queryKey="round">

--- a/apps/spectator/src/app/leagues/[id]/_components/round-filter.tsx
+++ b/apps/spectator/src/app/leagues/[id]/_components/round-filter.tsx
@@ -14,7 +14,7 @@ export const RoundFilter = ({ league, round }: Props) => {
   );
 
   return (
-    <Tabs.Root className="sticky top-12 z-header h-12 w-full" defaultValue={round.toString()}>
+    <Tabs.Root className="sticky top-12 z-header h-12 w-full" defaultValue={rounds[0].toString()}>
       <Tabs.List className="center h-12 gap-5 border-neutral-100 border-b bg-white">
         {rounds.map(r => (
           <TabTrigger className="min-w-14" key={r} value={r.toString()} queryKey="round">

--- a/apps/spectator/src/app/leagues/[id]/page.tsx
+++ b/apps/spectator/src/app/leagues/[id]/page.tsx
@@ -28,9 +28,12 @@ const Page = async ({ searchParams, params }: Props) => {
   const league: LeagueDetailType = await fetchLeague({ leagueId: id });
 
   const { round: _round, teams: _teams } = await searchParams;
-  const round = Number(_round) || league.inProgressRound;
-
-  const teams: LeagueTeamType[] = await fetchLeagueTeams({ leagueId: id, round });
+  // const round = Number(_round) || league.inProgressRound;
+  const round = Number(_round) || league.maxRound;
+  const teams: LeagueTeamType[] = await fetchLeagueTeams({
+    leagueId: id,
+    round,
+  });
   const selectedTeams = _teams ? _teams.split(',').map(Number).filter(Boolean) : [];
 
   return (


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 페이지 랜딩 일원화 작업 
  - 대회/경기 페이지 진입 시 가장 낮은 라운드 탭부터 보이도록 수정함

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
