### PR TITLE
feat(spectator): 팀 상세 페이지 개발

### DIFF
--- a/apps/spectator/src/api/queries/useTeamPlayers.ts
+++ b/apps/spectator/src/api/queries/useTeamPlayers.ts
@@ -1,0 +1,9 @@
+import { useQuery, useSuspenseQuery } from '@hcc/api-base';
+import type { TeamDetailPayload } from '~/api';
+import { queryKeys } from '../queryKey';
+
+export const useTeamsPlayers = (payload: TeamDetailPayload) =>
+  useQuery(queryKeys.teams.players(payload));
+
+export const useSuspenseTeamsPlayers = (payload: TeamDetailPayload) =>
+  useSuspenseQuery(queryKeys.teams.players(payload));

--- a/apps/spectator/src/api/queryKey.ts
+++ b/apps/spectator/src/api/queryKey.ts
@@ -30,6 +30,7 @@ import type {
   TeamDetailType,
   TeamGamesPayload,
   TeamListPayload,
+  TeamPlayerType,
   TeamSummaryType,
   TeamType,
 } from './types';
@@ -102,6 +103,10 @@ const teamQueryKeys = createQueryKeys('teams', {
   games: (payload: TeamGamesPayload) => ({
     queryKey: [payload],
     queryFn: () => fetcher.get<GameType[]>(`teams/${payload.id}/games`),
+  }),
+  players: (payload: TeamDetailPayload) => ({
+    queryKey: [payload],
+    queryFn: () => fetcher.get<TeamPlayerType[]>(`teams/${payload.id}/players`),
   }),
   summary: (payload: TeamListPayload) => ({
     queryKey: [payload],

--- a/apps/spectator/src/api/types/teams.ts
+++ b/apps/spectator/src/api/types/teams.ts
@@ -70,7 +70,7 @@ export type TrophyType = {
 };
 
 export type TeamDetailType = {
-  // teamId: number;
+  teamId: number;
   name: string;
   logoImageUrl: string;
   unit: string;

--- a/apps/spectator/src/api/types/teams.ts
+++ b/apps/spectator/src/api/types/teams.ts
@@ -70,6 +70,7 @@ export type TrophyType = {
 };
 
 export type TeamDetailType = {
+  // teamId: number;
   name: string;
   logoImageUrl: string;
   unit: string;

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/index.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/index.tsx
@@ -6,41 +6,70 @@ import { MatchHistory } from './match-history';
 import { ScoreList } from './score-list';
 import { TeamCard } from './team-card';
 import { TeamFilter, useTeamUnits } from './team-filter';
+import { useState } from 'react';
+import { ScorersModal } from './score-modal';
 
+type ModalPayload = {
+  teamName: string;
+  scorers: any[]; // 아래에서 실제 타입으로 바꿔도 됨
+} | null;
 export const TeamTab = () => {
   const { selected } = useTeamUnits();
   const { data } = useSuspenseTeamsSummary({ units: selected });
 
+  const [modal, setModal] = useState<ModalPayload>(null);
+  const open = modal !== null;
   return (
-    <div className="column">
-      <TeamFilter />
+    <>
+      <div className="column">
+        <TeamFilter />
 
-      <div className="column mb-5 gap-3 px-5">
-        {data.map(team => (
-          <TeamCard key={team.teamDetail.name}>
-            <TeamCard.Header team={team.teamDetail} />
-            <TeamCard.Divider />
+        <div className="column mb-5 gap-3 px-5">
+          {data.map(team => (
+            <TeamCard key={team.teamDetail.name}>
+              <TeamCard.Header team={team.teamDetail} />
+              <TeamCard.Divider />
 
-            <TeamCard.Content>
-              <TeamCard.Section title="득점왕" icon="🙋‍♂️">
-                <ErrorBoundary fallback={null}>
-                  <Suspense clientOnly>
-                    <ScoreList scorers={team.teamDetail.topScorers} />
-                  </Suspense>
-                </ErrorBoundary>
-              </TeamCard.Section>
-
-              <TeamCard.Section title="최근 경기" icon="💥">
-                <ErrorBoundary fallback={null}>
-                  <Suspense clientOnly>
-                    <MatchHistory games={team.recentGames} teamName={team.teamDetail.name} />
-                  </Suspense>
-                </ErrorBoundary>
-              </TeamCard.Section>
-            </TeamCard.Content>
-          </TeamCard>
-        ))}
+              <TeamCard.Content>
+                <button
+                  type="button"
+                  className="w-full text-left"
+                  onClick={() =>
+                    setModal({
+                      teamName: team.teamDetail.name,
+                      scorers: team.teamDetail.topScorers,
+                    })
+                  }
+                >
+                  <TeamCard.Section title="득점왕" icon="🙋‍♂️">
+                    <ErrorBoundary fallback={null}>
+                      <Suspense clientOnly>
+                        <ScoreList scorers={team.teamDetail.topScorers} />
+                      </Suspense>
+                    </ErrorBoundary>
+                  </TeamCard.Section>
+                </button>
+                <TeamCard.Section title="최근 경기" icon="💥">
+                  <ErrorBoundary fallback={null}>
+                    <Suspense clientOnly>
+                      <MatchHistory games={team.recentGames} teamName={team.teamDetail.name} />
+                    </Suspense>
+                  </ErrorBoundary>
+                </TeamCard.Section>
+              </TeamCard.Content>
+            </TeamCard>
+          ))}
+        </div>
       </div>
-    </div>
+
+      <ScorersModal
+        open={open}
+        onOpenChange={next => {
+          if (!next) setModal(null);
+        }}
+        teamName={modal?.teamName ?? ''}
+        scorers={modal?.scorers ?? []}
+      />
+    </>
   );
 };

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/index.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/index.tsx
@@ -27,7 +27,7 @@ export const TeamTab = () => {
 
         <div className="column mb-5 gap-3 px-5">
           {data.map(team => (
-            <TeamCard key={team.teamDetail.name}>
+            <TeamCard key={team.teamDetail.teamId}>
               <TeamCard.Header team={team.teamDetail} />
               <TeamCard.Divider />
 

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/index.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/index.tsx
@@ -11,8 +11,9 @@ import { ScorersModal } from './score-modal';
 
 type ModalPayload = {
   teamName: string;
-  scorers: any[]; // 아래에서 실제 타입으로 바꿔도 됨
+  teamId: number;
 } | null;
+
 export const TeamTab = () => {
   const { selected } = useTeamUnits();
   const { data } = useSuspenseTeamsSummary({ units: selected });
@@ -36,8 +37,8 @@ export const TeamTab = () => {
                   className="w-full text-left"
                   onClick={() =>
                     setModal({
+                      teamId: team.teamDetail.teamId,
                       teamName: team.teamDetail.name,
-                      scorers: team.teamDetail.topScorers,
                     })
                   }
                 >
@@ -62,14 +63,20 @@ export const TeamTab = () => {
         </div>
       </div>
 
-      <ScorersModal
-        open={open}
-        onOpenChange={next => {
-          if (!next) setModal(null);
-        }}
-        teamName={modal?.teamName ?? ''}
-        scorers={modal?.scorers ?? []}
-      />
+      {modal && (
+        <ErrorBoundary fallback={null}>
+          <Suspense fallback={null}>
+            <ScorersModal
+              open={open}
+              onOpenChange={next => {
+                if (!next) setModal(null);
+              }}
+              teamId={modal.teamId}
+              teamName={modal.teamName}
+            />
+          </Suspense>
+        </ErrorBoundary>
+      )}
     </>
   );
 };

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/score-badge.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/score-badge.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { Typography } from '@hcc/ui';
+import type { FC } from 'react';
+import type { TeamDetailType } from '~/api';
+
+type Props = {
+  team: TeamDetailType;
+};
+
+const ScoreBadge: FC<Props> = ({ team }) => {
+  const trophies = team.trophies ?? [];
+
+  if (trophies.length > 0) {
+    const winCount = trophies.filter(t => t.trophyType === '우승').length;
+    const runnerUpCount = trophies.filter(t => t.trophyType === '준우승').length;
+
+    return (
+      <div className="flex items-center gap-2 whitespace-nowrap">
+        <div className="flex items-center gap-1 rounded-2xl bg-yellow-300 px-2 py-0.5">
+          <Typography fontSize={14} color="neutral-700">
+            🏆
+          </Typography>
+          <div className="rounded-2xl bg-white px-2">
+            <Typography fontSize={14} color="neutral-700">
+              x{winCount}
+            </Typography>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 rounded-2xl bg-neutral-200 px-2 py-0.5">
+          <Typography fontSize={14} color="neutral-700">
+            🥈
+          </Typography>
+          <div className="rounded-2xl bg-white px-2">
+            <Typography fontSize={14} color="neutral-700">
+              x{runnerUpCount}
+            </Typography>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 whitespace-nowrap">
+      <Typography fontSize={14} color="neutral-500">
+        🟢{team.winCount}W
+      </Typography>
+      <Typography fontSize={14} color="neutral-500">
+        🟡{team.drawCount}D
+      </Typography>
+      <Typography fontSize={14} color="neutral-500">
+        🔴{team.loseCount}L
+      </Typography>
+    </div>
+  );
+};
+
+export default ScoreBadge;

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/score-modal.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/score-modal.tsx
@@ -80,15 +80,12 @@ export function ScorersModal({ open, onOpenChange, teamName, teamId }: TopScorer
               </thead>
 
               <tbody>
-                {rows.map((r, idx) => {
+                {rows.map(r => {
                   const isTopThree = r.rank <= 3;
                   const fontWeightClass = isTopThree ? 'font-semibold bg-gray-100' : 'font-medium';
 
                   return (
-                    <tr
-                      key={`${r.studentNumber ?? 'na'}-${r.name}-${idx}`}
-                      className="border-neutral-100 border-b"
-                    >
+                    <tr key={r.playerId} className="border-neutral-100 border-b">
                       <td className={`px-3 py-2 text-center text-neutral-900 ${fontWeightClass}`}>
                         {r.rank}
                       </td>

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/score-modal.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/score-modal.tsx
@@ -1,0 +1,137 @@
+import { Modal } from '@hcc/ui';
+
+type TopScorer = {
+  studentNo?: string | number;
+  name: string;
+  goals: number;
+};
+
+type Row = TopScorer & {
+  rank: number;
+};
+
+export type TopScorersModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  teamName: string;
+  scorers: TopScorer[];
+};
+
+export function ScorersModal({ open, onOpenChange, teamName, scorers }: TopScorersModalProps) {
+  // ✅ 공동 순위 포함해서 rank 계산 + 최대 20명
+  const rows: Row[] = (() => {
+    const sorted = [...(scorers ?? [])].sort((a, b) => b.goals - a.goals);
+
+    let prevGoals: number | null = null;
+    let rank = 0;
+
+    return sorted.slice(0, 20).map((s, idx) => {
+      if (prevGoals === null || s.goals !== prevGoals) {
+        rank = idx + 1;
+        prevGoals = s.goals;
+      }
+      return { ...s, rank };
+    });
+  })();
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      {/* Close 버튼 */}
+
+      <Modal.Content className="relative max-h-[min(640px,calc(100vh-64px))] w-[min(560px,calc(100vw-32px))] overflow-hidden rounded-2xl bg-white px-4 pt-12 pb-4 shadow-xl">
+        <Modal.Close asChild>
+          <button
+            type="button"
+            className="absolute top-2 right-3 h-9 w-9 rounded-full text-2xl text-neutral-500 hover:bg-neutral-100 hover:text-neutral-800"
+          >
+            ×
+          </button>
+        </Modal.Close>
+        <VisuallyHidden>
+          <Modal.Title>{teamName} 득점왕</Modal.Title>
+        </VisuallyHidden>
+        <VisuallyHidden>
+          <Modal.Description>
+            {teamName} 팀의 득점왕 순위 목록입니다. 최대 20명까지 표시됩니다.
+          </Modal.Description>
+        </VisuallyHidden>
+
+        <div className="mb-3 rounded-xl bg-neutral-100 px-4 py-3">
+          <h2 className="text-center font-medium text-base text-neutral-900">
+            {teamName} <span className="font-semibold">득점왕</span> ⚽
+          </h2>
+        </div>
+
+        {/* Table */}
+        <div className="overflow-hidden rounded-xl border border-neutral-200">
+          <div className="max-h-[360px] overflow-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead className="sticky top-0 z-10 bg-white">
+                <tr className="border-neutral-200 border-b">
+                  <th className="px-3 py-2 text-center font-bold text-[13px] text-blue-600">
+                    순위
+                  </th>
+                  <th className="px-3 py-2 text-center text-[13px] text-blue-600">학번</th>
+                  <th className="px-3 py-2 text-center font-bold text-[13px] text-blue-600">
+                    이름
+                  </th>
+                  <th className="px-3 py-2 text-center font-bold text-[13px] text-blue-600">
+                    득점
+                  </th>
+                </tr>
+              </thead>
+
+              <tbody>
+                {rows.map((r, idx) => (
+                  <tr
+                    key={`${r.studentNo ?? 'na'}-${r.name}-${idx}`}
+                    className="border-neutral-100 border-b"
+                  >
+                    <td className="px-3 py-2 text-center text-neutral-900">{r.rank}</td>
+                    <td className="px-3 py-2 text-center text-neutral-900">{r.studentNo ?? '-'}</td>
+                    <td className="px-3 py-2 font-semibold text-neutral-900">{r.name}</td>
+                    <td className="px-3 py-2 text-right font-bold text-neutral-900">{r.goals}</td>
+                  </tr>
+                ))}
+
+                {rows.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="px-3 py-10 text-center text-neutral-500">
+                      표시할 데이터가 없습니다.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Footer note */}
+        <div className="py-3 text-center text-neutral-500 text-xs">
+          <p>* 득점왕 순위는 최대 20명까지 표시합니다.</p>
+          <p>** 모든 통계 기록은 리그가 종료된 이후 업데이트 됩니다.</p>
+        </div>
+      </Modal.Content>
+    </Modal>
+  );
+}
+
+export const VisuallyHidden = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <span
+      style={{
+        position: 'absolute',
+        width: '1px',
+        height: '1px',
+        padding: '0',
+        margin: '-1px',
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        borderWidth: '0',
+      }}
+    >
+      {children}
+    </span>
+  );
+};

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/score-modal.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/score-modal.tsx
@@ -1,43 +1,41 @@
 import { Modal } from '@hcc/ui';
+import type { TeamPlayerType } from '~/api';
+import { useSuspenseTeamsPlayers } from '~/api/queries/useTeamPlayers';
 
-type TopScorer = {
-  studentNo?: string | number;
-  name: string;
-  goals: number;
-};
-
-type Row = TopScorer & {
+type Row = TeamPlayerType & {
   rank: number;
 };
 
 export type TopScorersModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  teamId: number;
   teamName: string;
-  scorers: TopScorer[];
 };
 
-export function ScorersModal({ open, onOpenChange, teamName, scorers }: TopScorersModalProps) {
-  // ✅ 공동 순위 포함해서 rank 계산 + 최대 20명
+export function ScorersModal({ open, onOpenChange, teamName, teamId }: TopScorersModalProps) {
+  const { data: players } = useSuspenseTeamsPlayers({ id: teamId });
   const rows: Row[] = (() => {
-    const sorted = [...(scorers ?? [])].sort((a, b) => b.goals - a.goals);
+    const sorted = [...(players ?? [])].sort((a, b) => b.totalGoalCount - a.totalGoalCount);
 
     let prevGoals: number | null = null;
     let rank = 0;
 
     return sorted.slice(0, 20).map((s, idx) => {
-      if (prevGoals === null || s.goals !== prevGoals) {
+      if (prevGoals === null || s.totalGoalCount !== prevGoals) {
         rank = idx + 1;
-        prevGoals = s.goals;
+        prevGoals = s.totalGoalCount;
       }
       return { ...s, rank };
     });
   })();
 
+  const formatStudentNumber = (num: string | null | undefined) => {
+    if (!num || num.length < 4) return '-';
+    return num.substring(2, 4);
+  };
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
-      {/* Close 버튼 */}
-
       <Modal.Content className="relative max-h-[min(640px,calc(100vh-64px))] w-[min(560px,calc(100vw-32px))] overflow-hidden rounded-2xl bg-white px-4 pt-12 pb-4 shadow-xl">
         <Modal.Close asChild>
           <button
@@ -82,17 +80,30 @@ export function ScorersModal({ open, onOpenChange, teamName, scorers }: TopScore
               </thead>
 
               <tbody>
-                {rows.map((r, idx) => (
-                  <tr
-                    key={`${r.studentNo ?? 'na'}-${r.name}-${idx}`}
-                    className="border-neutral-100 border-b"
-                  >
-                    <td className="px-3 py-2 text-center text-neutral-900">{r.rank}</td>
-                    <td className="px-3 py-2 text-center text-neutral-900">{r.studentNo ?? '-'}</td>
-                    <td className="px-3 py-2 font-semibold text-neutral-900">{r.name}</td>
-                    <td className="px-3 py-2 text-right font-bold text-neutral-900">{r.goals}</td>
-                  </tr>
-                ))}
+                {rows.map((r, idx) => {
+                  const isTopThree = r.rank <= 3;
+                  const fontWeightClass = isTopThree ? 'font-semibold bg-gray-100' : 'font-medium';
+
+                  return (
+                    <tr
+                      key={`${r.studentNumber ?? 'na'}-${r.name}-${idx}`}
+                      className="border-neutral-100 border-b"
+                    >
+                      <td className={`px-3 py-2 text-center text-neutral-900 ${fontWeightClass}`}>
+                        {r.rank}
+                      </td>
+                      <td className={`px-3 py-2 text-center text-neutral-900 ${fontWeightClass}`}>
+                        {formatStudentNumber(r.studentNumber)}
+                      </td>
+                      <td className={`px-3 py-2 text-center text-neutral-900 ${fontWeightClass}`}>
+                        {r.name}
+                      </td>
+                      <td className={`px-3 py-2 text-center text-neutral-900 ${fontWeightClass}`}>
+                        {r.totalGoalCount}
+                      </td>
+                    </tr>
+                  );
+                })}
 
                 {rows.length === 0 && (
                   <tr>

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/team-card.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/team-card.tsx
@@ -4,6 +4,9 @@ import type { ComponentProps } from 'react';
 import { twMerge } from 'tailwind-merge';
 import type { TeamDetailType } from '~/api';
 import ScoreBadge from './score-badge';
+import Link from 'next/link';
+import { routes } from '~/constants/routes';
+import { ChevronForwardIcon } from '@hcc/icons';
 
 /* -------------------------------------------------------------------------------------------------
  * TeamCard
@@ -50,9 +53,9 @@ const TeamCardHeader = ({ team, className, ...props }: TeamCardHeaderProps) => {
 
       <div className="flex flex-shrink-0 flex-row items-center gap-2 whitespace-nowrap">
         <ScoreBadge team={team} />
-        {/* <Link href={`/${routes.team(team.teamId)}`} className="center">
+        <Link href={`/${routes.team(team.teamId)}`} className="center">
           <ChevronForwardIcon size={24} />
-        </Link> */}
+        </Link>
       </div>
     </div>
   );

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/team-card.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/team-card.tsx
@@ -27,13 +27,17 @@ const TeamCardRoot = ({ children, className, ...props }: ComponentProps<'div'>) 
  * TeamCard.Header
  * -----------------------------------------------------------------------------------------------*/
 
-interface TeamCardHeaderProps extends ComponentProps<'div'> {
+interface TeamCardHeaderProps extends ComponentProps<'a'> {
   team: TeamDetailType;
 }
 
 const TeamCardHeader = ({ team, className, ...props }: TeamCardHeaderProps) => {
   return (
-    <div className={twMerge('row-between gap-3', className)} {...props}>
+    <Link
+      href={`/${routes.team(team.teamId)}`}
+      className={twMerge('row-between gap-3', className)}
+      {...props}
+    >
       <div className="center-y min-w-0 flex-1 gap-3">
         {team.logoImageUrl && (
           <div className="center relative h-8 w-8 overflow-hidden rounded-full bg-neutral-200">
@@ -53,11 +57,11 @@ const TeamCardHeader = ({ team, className, ...props }: TeamCardHeaderProps) => {
 
       <div className="flex flex-shrink-0 flex-row items-center gap-2 whitespace-nowrap">
         <ScoreBadge team={team} />
-        <Link href={`/${routes.team(team.teamId)}`} className="center">
+        <div className="center">
           <ChevronForwardIcon size={24} />
-        </Link>
+        </div>
       </div>
-    </div>
+    </Link>
   );
 };
 

--- a/apps/spectator/src/app/(dashboard)/_components/team-tab/team-card.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/team-tab/team-card.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import type { ComponentProps } from 'react';
 import { twMerge } from 'tailwind-merge';
 import type { TeamDetailType } from '~/api';
+import ScoreBadge from './score-badge';
 
 /* -------------------------------------------------------------------------------------------------
  * TeamCard
@@ -30,7 +31,7 @@ interface TeamCardHeaderProps extends ComponentProps<'div'> {
 const TeamCardHeader = ({ team, className, ...props }: TeamCardHeaderProps) => {
   return (
     <div className={twMerge('row-between gap-3', className)} {...props}>
-      <div className="center-y gap-3">
+      <div className="center-y min-w-0 flex-1 gap-3">
         {team.logoImageUrl && (
           <div className="center relative h-8 w-8 overflow-hidden rounded-full bg-neutral-200">
             <Image
@@ -42,12 +43,17 @@ const TeamCardHeader = ({ team, className, ...props }: TeamCardHeaderProps) => {
             />
           </div>
         )}
-        <Typography weight="medium">{team.name}</Typography>
+        <Typography className="whitespace-normal break-words" weight="medium">
+          {team.name}
+        </Typography>
       </div>
 
-      {/*<Link href={`/${routes.team(team.id)}`} className="center">*/}
-      {/*  <ChevronForwardIcon size={24} />*/}
-      {/*</Link>*/}
+      <div className="flex flex-shrink-0 flex-row items-center gap-2 whitespace-nowrap">
+        <ScoreBadge team={team} />
+        {/* <Link href={`/${routes.team(team.teamId)}`} className="center">
+          <ChevronForwardIcon size={24} />
+        </Link> */}
+      </div>
     </div>
   );
 };

--- a/apps/spectator/src/app/teams/[id]/_components/team-card.tsx
+++ b/apps/spectator/src/app/teams/[id]/_components/team-card.tsx
@@ -1,0 +1,156 @@
+import { formatTime } from '@hcc/toolkit';
+import { Badge, Button, colors, Typography } from '@hcc/ui';
+import Image from 'next/image';
+import type { ComponentProps } from 'react';
+import { twMerge } from 'tailwind-merge';
+import type { GameListType, TeamDetailType } from '~/api';
+
+/* -------------------------------------------------------------------------------------------------
+ * TeamCard
+ * -----------------------------------------------------------------------------------------------*/
+
+const TeamCardRoot = ({ children, className, ...props }: ComponentProps<'div'>) => {
+  return (
+    <div
+      className={twMerge('column gap-3 rounded-lg border border-gray-100 p-4', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * TeamCard.Header
+ * -----------------------------------------------------------------------------------------------*/
+
+interface TeamCardHeaderProps extends ComponentProps<'div'> {
+  team: TeamDetailType;
+}
+
+const TeamCardHeader = ({ team, className, ...props }: TeamCardHeaderProps) => {
+  return (
+    <div className={twMerge('row-between gap-3', className)} {...props}>
+      <div className="center-y min-w-0 flex-1 gap-3">
+        {team.logoImageUrl && (
+          <div className="center relative h-8 w-8 overflow-hidden rounded-full bg-neutral-200">
+            <Image
+              className="rounded-full object-cover"
+              src={team.logoImageUrl}
+              alt={`${team.name} 팀 로고`}
+              width={28}
+              height={28}
+            />
+          </div>
+        )}
+        <Typography className="whitespace-normal break-words" weight="medium">
+          {team.name}
+        </Typography>
+      </div>
+    </div>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * TeamCard.Content
+ * -----------------------------------------------------------------------------------------------*/
+
+const TeamCardContent = ({ children, className, ...props }: ComponentProps<'div'>) => {
+  return (
+    <div className={twMerge('flex flex-col gap-5', className)} {...props}>
+      {children}
+    </div>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * GameCard.Header
+ * -----------------------------------------------------------------------------------------------*/
+
+interface GameCardHeaderProps extends ComponentProps<'div'> {
+  game: GameListType;
+}
+
+const GameCardHeader = ({ game, className, ...props }: GameCardHeaderProps) => {
+  return (
+    <div className={twMerge('row-between', className)} {...props}>
+      <Typography color={colors.neutral500} fontSize={13} weight="medium">
+        {game.leagueName}
+        {' ‧ '}
+        {game.round === 2 ? '결승' : `${game.round}강`}
+        {' ‧ '}
+        {formatTime(game.startTime, { format: 'MM.DD. HH:mm' })}
+      </Typography>
+      <Badge size="sm">{game.gameQuarter}</Badge>
+    </div>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * GameCard.Actions
+ * -----------------------------------------------------------------------------------------------*/
+
+interface GameCardActionsProps extends ComponentProps<'div'> {
+  // onBroadcastClick?: () => void;
+  // onCheerClick?: () => void;
+  onStatsClick?: () => void;
+}
+
+const GameCardActions = ({ onStatsClick, className, ...props }: GameCardActionsProps) => {
+  return (
+    <div className={twMerge('center-y gap-2 self-center pt-2', className)} {...props}>
+      <Button
+        className="!border !border-neutral-100 min-w-12"
+        variant="ghost"
+        color="black"
+        size="xs"
+        onClick={e => {
+          e.stopPropagation();
+          onStatsClick?.();
+        }}
+      >
+        기록
+      </Button>
+    </div>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * TeamCard.Section
+ * -----------------------------------------------------------------------------------------------*/
+
+interface TeamCardSectionProps extends ComponentProps<'div'> {
+  title: string;
+  icon?: string;
+}
+
+const TeamCardSection = ({ title, icon, children, className, ...props }: TeamCardSectionProps) => {
+  return (
+    <div className={twMerge('column', className)} {...props}>
+      <Typography fontSize={14} weight="medium">
+        {icon && `${icon} `}
+        {title}
+      </Typography>
+      {children}
+    </div>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * TeamCard.Divider
+ * -----------------------------------------------------------------------------------------------*/
+
+const TeamCardDivider = ({ className, ...props }: ComponentProps<'hr'>) => {
+  return <hr className={twMerge('h-px w-full border-none bg-neutral-100', className)} {...props} />;
+};
+
+/* -----------------------------------------------------------------------------------------------*/
+
+export const TeamCard = Object.assign(TeamCardRoot, {
+  Header: TeamCardHeader,
+  Content: TeamCardContent,
+  GameHeader: GameCardHeader,
+  Actions: GameCardActions,
+  Section: TeamCardSection,
+  Divider: TeamCardDivider,
+});

--- a/apps/spectator/src/app/teams/[id]/_components/team-card.tsx
+++ b/apps/spectator/src/app/teams/[id]/_components/team-card.tsx
@@ -1,9 +1,8 @@
-import { formatTime } from '@hcc/toolkit';
-import { Badge, Button, colors, Typography } from '@hcc/ui';
+import { Typography } from '@hcc/ui';
 import Image from 'next/image';
 import type { ComponentProps } from 'react';
 import { twMerge } from 'tailwind-merge';
-import type { GameListType, TeamDetailType } from '~/api';
+import type { TeamDetailType } from '~/api';
 
 /* -------------------------------------------------------------------------------------------------
  * TeamCard
@@ -64,58 +63,6 @@ const TeamCardContent = ({ children, className, ...props }: ComponentProps<'div'
 };
 
 /* -------------------------------------------------------------------------------------------------
- * GameCard.Header
- * -----------------------------------------------------------------------------------------------*/
-
-interface GameCardHeaderProps extends ComponentProps<'div'> {
-  game: GameListType;
-}
-
-const GameCardHeader = ({ game, className, ...props }: GameCardHeaderProps) => {
-  return (
-    <div className={twMerge('row-between', className)} {...props}>
-      <Typography color={colors.neutral500} fontSize={13} weight="medium">
-        {game.leagueName}
-        {' ‧ '}
-        {game.round === 2 ? '결승' : `${game.round}강`}
-        {' ‧ '}
-        {formatTime(game.startTime, { format: 'MM.DD. HH:mm' })}
-      </Typography>
-      <Badge size="sm">{game.gameQuarter}</Badge>
-    </div>
-  );
-};
-
-/* -------------------------------------------------------------------------------------------------
- * GameCard.Actions
- * -----------------------------------------------------------------------------------------------*/
-
-interface GameCardActionsProps extends ComponentProps<'div'> {
-  // onBroadcastClick?: () => void;
-  // onCheerClick?: () => void;
-  onStatsClick?: () => void;
-}
-
-const GameCardActions = ({ onStatsClick, className, ...props }: GameCardActionsProps) => {
-  return (
-    <div className={twMerge('center-y gap-2 self-center pt-2', className)} {...props}>
-      <Button
-        className="!border !border-neutral-100 min-w-12"
-        variant="ghost"
-        color="black"
-        size="xs"
-        onClick={e => {
-          e.stopPropagation();
-          onStatsClick?.();
-        }}
-      >
-        기록
-      </Button>
-    </div>
-  );
-};
-
-/* -------------------------------------------------------------------------------------------------
  * TeamCard.Section
  * -----------------------------------------------------------------------------------------------*/
 
@@ -149,8 +96,6 @@ const TeamCardDivider = ({ className, ...props }: ComponentProps<'hr'>) => {
 export const TeamCard = Object.assign(TeamCardRoot, {
   Header: TeamCardHeader,
   Content: TeamCardContent,
-  GameHeader: GameCardHeader,
-  Actions: GameCardActions,
   Section: TeamCardSection,
   Divider: TeamCardDivider,
 });

--- a/apps/spectator/src/app/teams/[id]/_components/team-info.tsx
+++ b/apps/spectator/src/app/teams/[id]/_components/team-info.tsx
@@ -1,0 +1,57 @@
+'use client';
+import { useSuspenseTeamGames, useSuspenseTeam } from '~/api';
+import { TeamCard } from './team-card';
+import { GameCard } from '~/components/ui/game-card';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { routes } from '~/constants/routes';
+
+export const TeamInfo = ({ id }: { id: number }) => {
+  const router = useRouter();
+
+  const { data: team } = useSuspenseTeam({ id });
+  const { data: games } = useSuspenseTeamGames({ id });
+
+  if (!team) return null;
+
+  return (
+    <div className="w-full">
+      <div className="my-3 gap-3 px-5">
+        <TeamCard>
+          <TeamCard.Header team={team} />
+          <TeamCard.Divider />
+          <TeamCard.Content>
+            {games.map(game => {
+              const { gameId, gameTeams, state } = game;
+              const [homeTeam, awayTeam] = gameTeams;
+              const gameWithId = { ...game, id: gameId };
+              return (
+                <GameCard key={gameId}>
+                  <GameCard.Container>
+                    <TeamCard.GameHeader game={gameWithId} />
+                    <Link href={`/${routes.game(gameId)}`} className="row-between pt-2">
+                      {homeTeam && <GameCard.Team team={homeTeam} position="home" />}
+                      <GameCard.Score game={gameWithId} />
+                      {awayTeam && <GameCard.Team team={awayTeam} position="away" />}
+                    </Link>
+
+                    {state === 'FINISHED' ? (
+                      <TeamCard.Actions
+                        onStatsClick={() => router.push(`/${routes.game(gameId)}`)}
+                      />
+                    ) : (
+                      <GameCard.Actions
+                        onBroadcastClick={() => router.push(`/${routes.game(gameId)}`)}
+                        onCheerClick={() => router.push(`/${routes.game(gameId)}?cheer=1`)}
+                      />
+                    )}
+                  </GameCard.Container>
+                </GameCard>
+              );
+            })}
+          </TeamCard.Content>
+        </TeamCard>
+      </div>
+    </div>
+  );
+};

--- a/apps/spectator/src/app/teams/[id]/_components/team-info.tsx
+++ b/apps/spectator/src/app/teams/[id]/_components/team-info.tsx
@@ -24,27 +24,35 @@ export const TeamInfo = ({ id }: { id: number }) => {
             {games.map(game => {
               const { gameId, gameTeams, state } = game;
               const [homeTeam, awayTeam] = gameTeams;
-              const gameWithId = { ...game, id: gameId };
+              const gameWithId = { ...game, id };
+
               return (
                 <GameCard key={gameId}>
                   <GameCard.Container>
-                    <TeamCard.GameHeader game={gameWithId} />
+                    <GameCard.Header game={gameWithId} showLeagueName />
                     <Link href={`/${routes.game(gameId)}`} className="row-between pt-2">
                       {homeTeam && <GameCard.Team team={homeTeam} position="home" />}
                       <GameCard.Score game={gameWithId} />
                       {awayTeam && <GameCard.Team team={awayTeam} position="away" />}
                     </Link>
 
-                    {state === 'FINISHED' ? (
-                      <TeamCard.Actions
-                        onStatsClick={() => router.push(`/${routes.game(gameId)}`)}
-                      />
-                    ) : (
-                      <GameCard.Actions
-                        onBroadcastClick={() => router.push(`/${routes.game(gameId)}`)}
-                        onCheerClick={() => router.push(`/${routes.game(gameId)}?cheer=1`)}
-                      />
-                    )}
+                    <GameCard.Actions
+                      onStatsClick={
+                        state === 'FINISHED'
+                          ? () => router.push(`/${routes.game(gameId)}`)
+                          : undefined
+                      }
+                      onBroadcastClick={
+                        state !== 'FINISHED'
+                          ? () => router.push(`/${routes.game(gameId)}`)
+                          : undefined
+                      }
+                      onCheerClick={
+                        state !== 'FINISHED'
+                          ? () => router.push(`/${routes.game(gameId)}?cheer=1`)
+                          : undefined
+                      }
+                    />
                   </GameCard.Container>
                 </GameCard>
               );

--- a/apps/spectator/src/app/teams/[id]/page.tsx
+++ b/apps/spectator/src/app/teams/[id]/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from '@suspensive/react';
+import { Header } from '~/components/layout';
+import { TeamInfo } from './_components/team-info';
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+const Page = async ({ params }: Props) => {
+  const { id: _id } = await params;
+  const id = Number(_id);
+  return (
+    <>
+      <Header arrow />
+      <div className="column-between w-full">
+        <Suspense clientOnly>
+          <TeamInfo id={id} />
+        </Suspense>
+      </div>
+    </>
+  );
+};
+
+export default Page;

--- a/apps/spectator/src/components/ui/game-card.tsx
+++ b/apps/spectator/src/components/ui/game-card.tsx
@@ -66,12 +66,14 @@ const GameCardContainer = ({ children, className, ...props }: ComponentProps<'di
 
 interface GameCardHeaderProps extends ComponentProps<'div'> {
   game: GameListType;
+  showLeagueName?: boolean;
 }
 
-const GameCardHeader = ({ game, className, ...props }: GameCardHeaderProps) => {
+const GameCardHeader = ({ game, showLeagueName, className, ...props }: GameCardHeaderProps) => {
   return (
     <div className={twMerge('row-between', className)} {...props}>
       <Typography color={colors.neutral500} fontSize={13} weight="medium">
+        {showLeagueName && `${game.leagueName} ‧ `}
         {game.round === 2 ? '결승' : `${game.round}강`}
         {' ‧ '}
         {formatTime(game.startTime, { format: 'MM.DD. HH:mm' })}
@@ -166,40 +168,59 @@ const GameCardScore = ({ game, className, ...props }: GameCardScoreProps) => {
 interface GameCardActionsProps extends ComponentProps<'div'> {
   onBroadcastClick?: () => void;
   onCheerClick?: () => void;
+  onStatsClick?: () => void;
 }
 
 const GameCardActions = ({
   onBroadcastClick,
   onCheerClick,
+  onStatsClick,
   className,
   ...props
 }: GameCardActionsProps) => {
   return (
     <div className={twMerge('center-y gap-2 self-center pt-2', className)} {...props}>
-      <Button
-        className="!border !border-neutral-100 min-w-12"
-        variant="ghost"
-        color="black"
-        size="xs"
-        onClick={e => {
-          e.stopPropagation();
-          onBroadcastClick?.();
-        }}
-      >
-        중계
-      </Button>
-      <Button
-        className="!border !border-neutral-100 min-w-12"
-        variant="ghost"
-        color="black"
-        size="xs"
-        onClick={e => {
-          e.stopPropagation();
-          onCheerClick?.();
-        }}
-      >
-        응원
-      </Button>
+      {onStatsClick ? (
+        <Button
+          className="!border !border-neutral-100 min-w-12"
+          variant="ghost"
+          color="black"
+          size="xs"
+          onClick={e => {
+            e.stopPropagation();
+            onStatsClick();
+          }}
+        >
+          기록
+        </Button>
+      ) : (
+        <>
+          <Button
+            className="!border !border-neutral-100 min-w-12"
+            variant="ghost"
+            color="black"
+            size="xs"
+            onClick={e => {
+              e.stopPropagation();
+              onBroadcastClick?.();
+            }}
+          >
+            중계
+          </Button>
+          <Button
+            className="!border !border-neutral-100 min-w-12"
+            variant="ghost"
+            color="black"
+            size="xs"
+            onClick={e => {
+              e.stopPropagation();
+              onCheerClick?.();
+            }}
+          >
+            응원
+          </Button>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 팀 상세 페이지 개발
  - 팀별 페이지 라우팅 추가
  - 팀별 카드 컴포넌트 제작 `teamCard`
  - `gameCard` 컴포넌트 리팩토링
  - 팀 승률 뱃지 컴포넌트 `score-badge`
  - 득점왕 모달창

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
