### PR TITLE
feat(spectator): 종료된 응원탭 색상 변경

### DIFF
--- a/apps/spectator/src/app/games/[id]/_components/cheer-vs.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-vs.tsx
@@ -28,10 +28,8 @@ export const CheerVS = ({ gameId }: Props) => {
 
   const getBackgroundColor = (isHome: boolean) => {
     if (isFinished) {
-      const isHomeLosing = homeTeamCheer.cheerCount < awayTeamCheer.cheerCount;
-      const isAwayLosing = awayTeamCheer.cheerCount < homeTeamCheer.cheerCount;
-
-      if ((isHome && isHomeLosing) || (!isHome && isAwayLosing)) {
+      const cheerDiff = homeTeamCheer.cheerCount - awayTeamCheer.cheerCount;
+      if ((isHome && cheerDiff < 0) || (!isHome && cheerDiff > 0)) {
         return 'bg-[#B8C0CC]';
       }
     }
@@ -156,7 +154,7 @@ const CheerTeamBox = ({
         !isFinished && 'active:scale-[0.995]',
         isFinished && 'cursor-default',
 
-        bgColor ? bgColor : direction === 'left' ? 'bg-[#002843]' : 'bg-[#9C1714]',
+        bgColor,
         direction === 'right' && 'flex-row-reverse',
         (isPending || isFinished) && 'opacity-80',
       )}

--- a/apps/spectator/src/app/games/[id]/_components/cheer-vs.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-vs.tsx
@@ -24,6 +24,19 @@ export const CheerVS = ({ gameId }: Props) => {
   const [homeTeamCheer, awayTeamCheer] = cheerData;
   const [homeTeam, awayTeam] = gameData.gameTeams;
 
+  const isFinished = gameData.state === 'FINISHED';
+  console.log('isFinished:', isFinished);
+  const getBackgroundColor = (isHome: boolean) => {
+    if (isFinished) {
+      const isHomeLosing = homeTeamCheer.cheerCount < awayTeamCheer.cheerCount;
+      const isAwayLosing = awayTeamCheer.cheerCount < homeTeamCheer.cheerCount;
+
+      if ((isHome && isHomeLosing) || (!isHome && isAwayLosing)) {
+        return 'bg-[#B8C0CC]';
+      }
+    }
+    return isHome ? 'bg-[#002843]' : 'bg-[#9C1714]';
+  };
   const { homeCheerRatio, awayCheerRatio } = useMemo(() => {
     const total = homeTeamCheer.cheerCount + awayTeamCheer.cheerCount;
 
@@ -44,7 +57,14 @@ export const CheerVS = ({ gameId }: Props) => {
   return (
     <div className="center-y m-4 gap-0.5">
       <div style={{ flexGrow: homeCheerRatio }}>
-        <CheerTeamBox gameId={gameId} direction="left" {...homeTeam} {...homeTeamCheer} />
+        <CheerTeamBox
+          gameId={gameId}
+          direction="left"
+          bgColor={getBackgroundColor(true)}
+          isFinished={isFinished}
+          {...homeTeam}
+          {...homeTeamCheer}
+        />
       </div>
 
       <div className="relative z-above shrink-0">
@@ -63,7 +83,14 @@ export const CheerVS = ({ gameId }: Props) => {
       </div>
 
       <div style={{ flexGrow: awayCheerRatio }}>
-        <CheerTeamBox gameId={gameId} direction="right" {...awayTeam} {...awayTeamCheer} />
+        <CheerTeamBox
+          gameId={gameId}
+          direction="right"
+          bgColor={getBackgroundColor(false)}
+          isFinished={isFinished}
+          {...awayTeam}
+          {...awayTeamCheer}
+        />
       </div>
     </div>
   );
@@ -72,6 +99,8 @@ export const CheerVS = ({ gameId }: Props) => {
 type CheerTeamBoxProps = (GameCheerType & GameTeamType) & {
   gameId: number;
   direction: 'left' | 'right';
+  bgColor: string;
+  isFinished: boolean;
 };
 
 const CheerTeamBox = ({
@@ -81,6 +110,8 @@ const CheerTeamBox = ({
   cheerCount,
   logoImageUrl,
   direction,
+  bgColor,
+  isFinished,
 }: CheerTeamBoxProps) => {
   const [pendingCount, setPendingCount] = useState(0);
   const pendingCountRef = useRef(0);
@@ -109,6 +140,7 @@ const CheerTeamBox = ({
   );
 
   const handleCheer = () => {
+    if (isFinished) return;
     pendingCountRef.current += 1;
     setPendingCount(prev => prev + 1);
   };
@@ -117,12 +149,13 @@ const CheerTeamBox = ({
     <button
       className={twMerge(
         'center-y relative h-14 w-full cursor-pointer gap-2 rounded-xl px-3 transition-all duration-150 active:scale-[0.995]',
-        direction === 'left' ? 'bg-[#002843]' : 'flex-row-reverse bg-[#9C1714]',
+        bgColor ? bgColor : direction === 'left' ? 'bg-[#002843]' : 'bg-[#9C1714]',
+        direction === 'right' && 'flex-row-reverse',
         isPending && 'opacity-80',
       )}
       type="button"
       onClick={handleCheer}
-      disabled={isPending}
+      disabled={isPending || isFinished}
     >
       <Image
         className="h-9 w-9 rounded-full object-cover"

--- a/apps/spectator/src/app/games/[id]/_components/cheer-vs.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-vs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { colors, Typography } from '@hcc/ui';
+import { colors, Typography, toast } from '@hcc/ui';
 import Image from 'next/image';
 import { useMemo, useRef, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
@@ -25,7 +25,7 @@ export const CheerVS = ({ gameId }: Props) => {
   const [homeTeam, awayTeam] = gameData.gameTeams;
 
   const isFinished = gameData.state === 'FINISHED';
-  console.log('isFinished:', isFinished);
+
   const getBackgroundColor = (isHome: boolean) => {
     if (isFinished) {
       const isHomeLosing = homeTeamCheer.cheerCount < awayTeamCheer.cheerCount;
@@ -140,7 +140,11 @@ const CheerTeamBox = ({
   );
 
   const handleCheer = () => {
-    if (isFinished) return;
+    if (isFinished) {
+      toast.error('종료된 리그에는 응원탭을 누를 수 없어요');
+      return;
+    }
+
     pendingCountRef.current += 1;
     setPendingCount(prev => prev + 1);
   };
@@ -149,13 +153,16 @@ const CheerTeamBox = ({
     <button
       className={twMerge(
         'center-y relative h-14 w-full cursor-pointer gap-2 rounded-xl px-3 transition-all duration-150 active:scale-[0.995]',
+        !isFinished && 'active:scale-[0.995]',
+        isFinished && 'cursor-default',
+
         bgColor ? bgColor : direction === 'left' ? 'bg-[#002843]' : 'bg-[#9C1714]',
         direction === 'right' && 'flex-row-reverse',
-        isPending && 'opacity-80',
+        (isPending || isFinished) && 'opacity-80',
       )}
       type="button"
       onClick={handleCheer}
-      disabled={isPending || isFinished}
+      disabled={isPending}
     >
       <Image
         className="h-9 w-9 rounded-full object-cover"

--- a/apps/spectator/src/app/layout.tsx
+++ b/apps/spectator/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { AnalyticsProvider } from '~/app/analytics';
 import { Layout } from '~/components/layout';
 import { Pretendard } from './_fonts';
 import { Provider } from './provider';
+import { Toaster } from '@hcc/ui';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://www.hufscheer.com'),
@@ -40,6 +41,7 @@ const RootLayout = ({ children }: PropsWithChildren) => {
         </Provider>
 
         <AnalyticsProvider />
+        <Toaster />
       </body>
     </html>
   );


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 종료된 응원탭 색상 변경
  - 응원수가 적은 팀 회색으로 배경색 변경
  - 종료된 경기에 응원탭을 눌렀을 때 토스트 알림

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
