### PR TITLE
fix(manager): 헤더바에 필요없는 버튼 삭제

### DIFF
--- a/apps/manager/src/app/(private)/page.tsx
+++ b/apps/manager/src/app/(private)/page.tsx
@@ -1,21 +1,12 @@
-import { Typography } from '@hcc/ui';
 import { ErrorBoundary, Suspense } from '@suspensive/react';
-import Link from 'next/link';
 import { Header } from '~/components/layout';
-import { routes } from '~/constants/routes';
 import { BottomMenu } from './_components/bottom-menu';
 import { MatchOverview } from './_components/match-overview';
-
-const LeagueMenu = () => (
-  <Typography color="var(--color-primary-600)" weight="semibold" asChild>
-    <Link href={`/${routes.leagues}`}>대회 관리</Link>
-  </Typography>
-);
 
 const Page = () => {
   return (
     <>
-      <Header menu={<LeagueMenu />} />
+      <Header />
 
       <div className="column-between h-full w-full overflow-hidden">
         <ErrorBoundary fallback={<div />}>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 매니저 메인 화면에서 헤더바에 있던 대회관리 버튼 삭제

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
