### PR TITLE
feat(spectator): 팀별 트로피 진열장 ui

### DIFF
--- a/apps/spectator/src/app/teams/[id]/_components/team-info.tsx
+++ b/apps/spectator/src/app/teams/[id]/_components/team-info.tsx
@@ -5,6 +5,7 @@ import { GameCard } from '~/components/ui/game-card';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { routes } from '~/constants/routes';
+import { TeamTrophy } from './trophy';
 
 export const TeamInfo = ({ id }: { id: number }) => {
   const router = useRouter();
@@ -20,6 +21,7 @@ export const TeamInfo = ({ id }: { id: number }) => {
         <TeamCard>
           <TeamCard.Header team={team} />
           <TeamCard.Divider />
+          <TeamTrophy trophies={team.trophies} />
           <TeamCard.Content>
             {games.map(game => {
               const { gameId, gameTeams, state } = game;

--- a/apps/spectator/src/app/teams/[id]/_components/trophy.tsx
+++ b/apps/spectator/src/app/teams/[id]/_components/trophy.tsx
@@ -11,7 +11,10 @@ export const TeamTrophy: FC<Props> = ({ trophies }) => {
   return (
     <div className="scrollbar-hide flex w-full flex-row items-center justify-center gap-2 overflow-x-auto rounded-xl bg-neutral-100 px-2 py-1">
       {trophies.map(trophy => (
-        <div key={trophy.leagueId} className="flex-shrink-0 flex-col items-center gap-2 px-2 py-1">
+        <div
+          key={trophy.leagueId}
+          className="flex flex-shrink-0 flex-col items-center gap-2 px-2 py-1"
+        >
           <div className="text-center text-3xl">🏆</div>
           <div className="whitespace-nowrap text-neutral-700 text-xs">{trophy.leagueName}</div>
         </div>

--- a/apps/spectator/src/app/teams/[id]/_components/trophy.tsx
+++ b/apps/spectator/src/app/teams/[id]/_components/trophy.tsx
@@ -1,0 +1,21 @@
+import type { FC } from 'react';
+import type { TrophyType } from '~/api/types/teams';
+
+type Props = {
+  trophies?: TrophyType[];
+};
+
+export const TeamTrophy: FC<Props> = ({ trophies }) => {
+  if (!trophies || trophies.length === 0) return null;
+
+  return (
+    <div className="scrollbar-hide flex w-full flex-row items-center justify-center gap-2 overflow-x-auto rounded-xl bg-neutral-100 px-2 py-1">
+      {trophies.map(trophy => (
+        <div key={trophy.leagueId} className="flex-shrink-0 flex-col items-center gap-2 px-2 py-1">
+          <div className="text-center text-3xl">🏆</div>
+          <div className="whitespace-nowrap text-neutral-700 text-xs">{trophy.leagueName}</div>
+        </div>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 팀별보기 트로피 진열장 ui 추가

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
