### PR TITLE
fix(manager): 첫 화면 진입시 엑세스토큰 알림창 에러 문제해결

### DIFF
--- a/packages/api-base/src/fetcher.ts
+++ b/packages/api-base/src/fetcher.ts
@@ -15,7 +15,16 @@ export const instance = ky.create({
   hooks: {
     afterResponse: [
       async (request, _, response) => {
-        if (!response.ok && response.status === 401 && !request.url.includes('logout')) {
+        if (!response.ok && response.status === 401) {
+          if (request.url.includes('logout')) return response;
+
+          const currentPath = window.location.pathname;
+
+          const isInternalNavigation = document?.referrer?.includes(window.location.host);
+          if (currentPath === '/' && !isInternalNavigation) {
+            window.location.href = '/auth/login';
+            return response;
+          }
           alert('로그인이 만료되었어요. 다시 로그인해주세요.');
           window.location.href = '/auth/login';
         }

--- a/packages/api-base/src/fetcher.ts
+++ b/packages/api-base/src/fetcher.ts
@@ -21,12 +21,11 @@ export const instance = ky.create({
           const currentPath = window.location.pathname;
 
           const isInternalNavigation = document?.referrer?.includes(window.location.host);
-          if (currentPath === '/' && !isInternalNavigation) {
-            window.location.href = '/auth/login';
-            return response;
+          if (currentPath !== '/' || isInternalNavigation) {
+            alert('로그인이 만료되었어요. 다시 로그인해주세요.');
           }
-          alert('로그인이 만료되었어요. 다시 로그인해주세요.');
           window.location.href = '/auth/login';
+          return response;
         }
         return response;
       },


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 엑세스토큰 문제 수정 `api-base/src/fetcher.ts` 
  - "/" 메인 화면을 처음 진입 시 401에러여도 알림창이 안뜨고 바로 login페이지로 라우팅 하도록 함
  - 사용중(내부 활동 중이었던 경우)에 401 에러시 알림창이 뜨고 login페이지로 라우팅 됨 

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
