### PR TITLE
feat(spectator): 응원톡 실시간 업데이트 로직 개선 및 최적화

### DIFF
--- a/apps/spectator/src/api/mutations/useCreateCheerTalk.ts
+++ b/apps/spectator/src/api/mutations/useCreateCheerTalk.ts
@@ -11,7 +11,7 @@ const postCreateCheerTalk = (request: Request) => {
 export const useCreateCheerTalk = () =>
   useMutation({
     mutationFn: postCreateCheerTalk,
-    onError: (error: any) => {
+    onError: (error: { status?: number; response?: { status: number } }) => {
       const status = error.status || error.response?.status;
       if (status === 400) {
         toast.error('부적절한 단어가 포함되어 있어 전송할 수 없어요');

--- a/apps/spectator/src/api/mutations/useCreateCheerTalk.ts
+++ b/apps/spectator/src/api/mutations/useCreateCheerTalk.ts
@@ -1,4 +1,5 @@
 import { fetcher, useMutation } from '@hcc/api-base';
+import { toast } from '@hcc/ui'; // 토스트 메시지를 위한 import
 import type { CheerTalkType } from '~/api';
 
 type Request = Pick<CheerTalkType, 'gameTeamId' | 'content'>;
@@ -7,4 +8,15 @@ const postCreateCheerTalk = (request: Request) => {
   return fetcher.post('cheer-talks', { json: request });
 };
 
-export const useCreateCheerTalk = () => useMutation({ mutationFn: postCreateCheerTalk });
+export const useCreateCheerTalk = () =>
+  useMutation({
+    mutationFn: postCreateCheerTalk,
+    onError: (error: any) => {
+      const status = error.status || error.response?.status;
+      if (status === 400) {
+        toast.error('부적절한 단어가 포함되어 있어 전송할 수 없어요');
+      } else {
+        toast.error('메시지 전송에 실패했습니다. 다시 시도해 주세요.');
+      }
+    },
+  });

--- a/apps/spectator/src/app/(dashboard)/_components/recent-tab/index.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/recent-tab/index.tsx
@@ -38,6 +38,7 @@ export const RecentTab = () => {
 
                   <GameCard.Actions
                     onBroadcastClick={() => router.push(`/${routes.game(game.id)}`)}
+                    onCheerClick={() => router.push(`/${routes.game(game.id)}?cheer=1`)}
                   />
                 </GameCard.Container>
                 {index !== league.games.length - 1 && <GameCard.Divider />}
@@ -82,7 +83,7 @@ export const RecentTab = () => {
           fontSize={14}
           weight="medium"
         >
-          진행 중인 경기가 없어요. 💨
+          진행 중인 경기가 없어요 💨
         </Typography>
       )}
     </div>

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
@@ -75,8 +75,20 @@ export const CheerTalkList = ({
     return handleInitialScroll();
   }, [handleInitialScroll]);
 
-  const allMessages = [...cheerTalkList, ...socketTalkList];
+  // const allMessages = [...cheerTalkList, ...socketTalkList];
+  const allMessages = (() => {
+    const messageMap = new Map<number, GameCheerTalkWithTeamInfo>();
 
+    cheerTalkList.forEach(talk => {
+      messageMap.set(talk.cheerTalkId, talk);
+    });
+
+    socketTalkList.forEach(talk => {
+      messageMap.set(talk.cheerTalkId, talk);
+    });
+
+    return Array.from(messageMap.values()).sort((a, b) => a.cheerTalkId - b.cheerTalkId);
+  })();
   return (
     <Fragment>
       <div ref={scrollRef} className="w-full flex-1 overflow-y-auto">

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Spinner } from '@hcc/ui';
-import { Fragment, useCallback, useEffect, useRef } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef } from 'react';
 import { type GameCheerTalkWithTeamInfo, useSuspenseGame } from '~/api';
 import useIntersectionObserver from '~/hooks/useIntersectionObserver';
 import { useThrottle } from '~/hooks/useThrottle';
@@ -76,19 +76,16 @@ export const CheerTalkList = ({
   }, [handleInitialScroll]);
 
   // const allMessages = [...cheerTalkList, ...socketTalkList];
-  const allMessages = (() => {
+  const allMessages = useMemo(() => {
     const messageMap = new Map<number, GameCheerTalkWithTeamInfo>();
-
     cheerTalkList.forEach(talk => {
       messageMap.set(talk.cheerTalkId, talk);
     });
-
     socketTalkList.forEach(talk => {
       messageMap.set(talk.cheerTalkId, talk);
     });
-
     return Array.from(messageMap.values()).sort((a, b) => a.cheerTalkId - b.cheerTalkId);
-  })();
+  }, [cheerTalkList, socketTalkList]);
   return (
     <Fragment>
       <div ref={scrollRef} className="w-full flex-1 overflow-y-auto">

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/index.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/index.tsx
@@ -66,40 +66,49 @@ export const CheerTalk = ({ gameId }: Props) => {
 
   return (
     <div className="column gap-2 border-neutral-100 border-t p-4">
-      <Typography color={colors.neutral900} weight="semibold">
-        실시간 응원톡
-      </Typography>
-
-      <BottomSheet open={isOpen} onOpenChange={handleOpenChange}>
-        <BottomSheet.Trigger className="cursor-pointer">
-          <div className="center gap-2">
-            <div className="center size-8 rounded-full bg-[var(--color-primary-600)]">
-              <ChatFillIcon className="text-white" />
-            </div>
-            <Typography
-              fontSize={13}
-              weight="medium"
-              className="rounded-full bg-neutral-100 px-3 py-2"
-            >
-              응원톡에 들어가 여러분의 팀을 응원해보세요! 🙌
+      <div className="flex flex-row justify-between gap-2">
+        <div>
+          <BottomSheet open={isOpen} onOpenChange={handleOpenChange}>
+            <Typography color={colors.neutral900} weight="semibold">
+              실시간 응원톡
             </Typography>
-          </div>
-        </BottomSheet.Trigger>
-        <BottomSheet.Portal>
-          <BottomSheet.Content className="!h-full max-h-[90%]">
-            <BottomSheet.Title className="sr-only">응원톡 작성</BottomSheet.Title>
-            <div className="column-between h-full overflow-hidden">
-              <CheerTalkTimeline gameId={gameId} />
-              <CheerTalkList
-                gameId={gameId}
-                cheerTalkList={cheerTalks}
-                socketTalkList={socketTalkList}
-                {...rest}
-              />
-            </div>
-          </BottomSheet.Content>
-        </BottomSheet.Portal>
-      </BottomSheet>
+
+            <BottomSheet.Trigger className="cursor-pointer">
+              <div className="row-between gap-2">
+                <Typography
+                  fontSize={14}
+                  weight="medium"
+                  // className="rounded-full bg-neutral-100 px-3 py-2"
+                >
+                  응원톡에 들어가 여러분의 팀을 응원해보세요! 🙌
+                </Typography>
+              </div>
+            </BottomSheet.Trigger>
+            <BottomSheet.Portal>
+              <BottomSheet.Content className="!h-full max-h-[90%]">
+                <BottomSheet.Title className="sr-only">응원톡 작성</BottomSheet.Title>
+                <div className="column-between h-full overflow-hidden">
+                  <CheerTalkTimeline gameId={gameId} />
+                  <CheerTalkList
+                    gameId={gameId}
+                    cheerTalkList={cheerTalks}
+                    socketTalkList={socketTalkList}
+                    {...rest}
+                  />
+                </div>
+              </BottomSheet.Content>
+            </BottomSheet.Portal>
+          </BottomSheet>
+        </div>
+        <button
+          type="button"
+          onClick={() => setIsOpen(true)}
+          className="center flex-row gap-1 rounded-full bg-[var(--color-primary-600)] p-3 text-white transition-opacity hover:opacity-90"
+        >
+          <ChatFillIcon className="text-white" />
+          입장하기
+        </button>
+      </div>
     </div>
   );
 };

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/useCheerTalkById.ts
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/useCheerTalkById.ts
@@ -21,6 +21,6 @@ export default function useCheerTalkById(gameId: number) {
         .reverse(),
       pageParams: [...data.pageParams].reverse(),
     }),
-    staleTime: 1000,
+    staleTime: Number.POSITIVE_INFINITY,
   });
 }


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 응원톡 로직 수정
  - 1초 주기 API 리프레시를 제거하여 서버 부하 감소 및 불필요한 요청 차단
  - 소켓(STOMP) 연결 환경 변수 누락 수정 및 실시간 수신 활성화
  - API 데이터와 소켓 데이터 간 중복 cheerTalkId 필터링 로직 추가
  
- 직관적인 욕설인 경우 400에러 핸들링 추가
- `GameCard` 응원 버튼 라우팅 추가
## 📝 참고 자료
```
**as-is**
실시간 신규 메시지: 소켓으로 수신
과거 응원톡: 커서 기반 페이징 API
UI 갱신: 1초마다 API 폴링

**문제**
1초 폴링 ⇒ 불필요한 서버 부하
소켓 메시지 + API 응답 ⇒ 중복 수신 가능성

**to-be**
API 조회: 게임 상세 페이지 진입 시에 “처음 한 번만” 과거 내역 조회
실시간: 이후에는 소켓만으로 신규 메시지 수신
1초 리프레시 로직 제거
```
## ♾️ 기타

- 추가로 필요한 작업 내용
