### PR TITLE
fix(spectator): 이전 대회 탭 에러바운더리 분리

### DIFF
--- a/apps/spectator/src/app/(dashboard)/_components/previous-tab/index.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/previous-tab/index.tsx
@@ -18,7 +18,7 @@ export const PreviousTab = ({ year }: Props) => {
       <ErrorBoundary
         fallback={
           <div className="p-10 text-center text-gray-400">
-            데이터가 없거나 불러오는 중 오류가 발생했습니다.
+            데이터가 없거나 불러오는 중 오류가 발생했습니다
           </div>
         }
       >
@@ -62,8 +62,13 @@ const LeagueList = ({ year }: { year: number }) => {
             <ErrorBoundary
               fallback={
                 <div className="center-y rounded-md bg-gray-50 p-3">
-                  <Typography fontSize={13} color={colors.neutral500} weight="medium">
-                    리그 통계 데이터가 집계되지 않았어요.
+                  <Typography
+                    className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap"
+                    fontSize={13}
+                    color={colors.neutral500}
+                    weight="medium"
+                  >
+                    리그 통계 데이터가 집계되지 않았어요
                   </Typography>
                 </div>
               }

--- a/apps/spectator/src/app/(dashboard)/_components/previous-tab/index.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/previous-tab/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { colors, Typography } from '@hcc/ui';
+import { colors, Spinner, Typography } from '@hcc/ui';
 import { ErrorBoundary, Suspense } from '@suspensive/react';
 import { useSuspenseLeagues } from '~/api';
 import { LeagueCard } from './league-card';
@@ -11,54 +11,70 @@ interface Props {
 }
 
 export const PreviousTab = ({ year }: Props) => {
+  return (
+    <div className="column" key={year}>
+      <YearFilter year={year} />
+
+      <ErrorBoundary
+        fallback={
+          <div className="p-10 text-center text-gray-400">
+            데이터가 없거나 불러오는 중 오류가 발생했습니다.
+          </div>
+        }
+      >
+        <Suspense
+          fallback={
+            <div className="flex h-40 w-full items-center justify-center">
+              <Spinner size="md" color="primary" />
+            </div>
+          }
+        >
+          <LeagueList year={year} />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+};
+
+const LeagueList = ({ year }: { year: number }) => {
   const { data } = useSuspenseLeagues({ year, size: 50 });
 
   return (
-    <div className="column">
-      <YearFilter year={year} />
+    <div className="column gap-3 px-5 pb-5">
+      {data.map(league => (
+        <LeagueCard key={league.leagueId}>
+          <LeagueCard.Header league={league} />
+          <LeagueCard.Divider />
 
-      <div className="column gap-3 px-5 pb-5">
-        {data.map(league => (
-          <LeagueCard key={league.leagueId}>
-            <LeagueCard.Header league={league} />
+          <ErrorBoundary fallback={null}>
+            <Suspense fallback={null} clientOnly>
+              <LeagueCard.Teams leagueId={league.leagueId} />
+            </Suspense>
+          </ErrorBoundary>
 
-            <LeagueCard.Divider />
-
+          <div className="column w-full gap-4">
             <ErrorBoundary fallback={null}>
               <Suspense fallback={null} clientOnly>
-                <LeagueCard.Teams leagueId={league.leagueId} />
+                <LeagueCard.Scorers leagueId={league.leagueId} />
               </Suspense>
             </ErrorBoundary>
 
-            <div className="column w-full gap-4">
-              <ErrorBoundary fallback={null}>
-                <Suspense fallback={null} clientOnly>
-                  <LeagueCard.Scorers leagueId={league.leagueId} />
-                </Suspense>
-              </ErrorBoundary>
-
-              <ErrorBoundary
-                fallback={
-                  <div className="center-y rounded-md bg-gray-50 p-3">
-                    <Typography
-                      className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap"
-                      fontSize={13}
-                      color={colors.neutral500}
-                      weight="medium"
-                    >
-                      리그 통계 데이터가 집계되지 않았어요.
-                    </Typography>
-                  </div>
-                }
-              >
-                <Suspense fallback={null} clientOnly>
-                  <LeagueCard.Statistics leagueId={league.leagueId} />
-                </Suspense>
-              </ErrorBoundary>
-            </div>
-          </LeagueCard>
-        ))}
-      </div>
+            <ErrorBoundary
+              fallback={
+                <div className="center-y rounded-md bg-gray-50 p-3">
+                  <Typography fontSize={13} color={colors.neutral500} weight="medium">
+                    리그 통계 데이터가 집계되지 않았어요.
+                  </Typography>
+                </div>
+              }
+            >
+              <Suspense fallback={null} clientOnly>
+                <LeagueCard.Statistics leagueId={league.leagueId} />
+              </Suspense>
+            </ErrorBoundary>
+          </div>
+        </LeagueCard>
+      ))}
     </div>
   );
 };

--- a/apps/spectator/src/app/(dashboard)/_components/previous-tab/league-card.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/previous-tab/league-card.tsx
@@ -137,7 +137,7 @@ const LeagueCardScorers = ({
       </Typography>
       {data.length === 0 ? (
         <Typography className="mt-2" fontSize={13} color={colors.neutral500} weight="medium">
-          아직 득점 기록이 없어요.
+          아직 득점 기록이 없어요
         </Typography>
       ) : (
         <ul className="column mt-2 gap-1">

--- a/apps/spectator/src/app/(dashboard)/_components/previous-tab/year-filter.tsx
+++ b/apps/spectator/src/app/(dashboard)/_components/previous-tab/year-filter.tsx
@@ -1,5 +1,5 @@
 import Conveyer from '@egjs/conveyer';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { FilterBadge } from '~/components/ui';
 
@@ -11,6 +11,7 @@ interface Props {
 
 export const YearFilter = ({ year }: Props) => {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const containerRef = useRef<HTMLDivElement>(null);
   const conveyerRef = useRef<Conveyer | null>(null);
@@ -33,7 +34,12 @@ export const YearFilter = ({ year }: Props) => {
   );
 
   const handleSelectYear = (selectedYear: number) => {
-    const params = new URLSearchParams(window.location.search);
+    // const params = new URLSearchParams(window.location.search);
+    const params = new URLSearchParams(searchParams.toString());
+    if (!params.has('tab')) {
+      params.set('tab', 'previous');
+    }
+
     params.set('year', selectedYear.toString());
     router.push(`?${params.toString()}`);
   };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용
"이전 대회" 탭에서 상단 연도 필터버튼을 눌러도 라우팅이 안되거나 화면이 뜨지 않는 문제를 해결했습니다.

>  특정 연도의 데이터가 없는 상황(statistics API가 404 에러 뜸)에서 `ErrorBoundary`와 `Suspense`가 교체되는 과정에서 리액트 DOM 상태를 동기화하지 못하는 현상이 발생했습니다 (`removeChild` 에러)

**해결 방안**
1. DOM 트리 강제 재생성
`PreviousTab` 최상위 컨테이너에 `key={year}`를 부여하여 기존 DOM 노드 대신 새로 생성하여 DOM 충돌 차단
2. 에러 격리
데이터 로딩 로직을 `LeagueList` 컴포넌트로 분리하고 에러 바운더리를 변경하여 전체 컴포넌트 대신 특정 영역안에서만 에러가 갇히도록 함
-----
제가 보기엔 2026탭에서 에러가 있어서 DOM이 꼬인 문제 같았는데 다른 이유인 것 같으면 알려주세요! 그리고 아직 서버쪽에서 statistics api쪽 에러 처리가 안된 거 같아서 한번더 말씀 드려볼게요!
