### PR TITLE
feat(spectator): 경기 중계화면 개편

### DIFF
--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-form.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-form.tsx
@@ -26,17 +26,21 @@ export const CheerTalkForm = ({
   const isFinished = gameState === 'FINISHED';
   const canSubmit = message.trim() && !isFinished;
 
-  const handleSubmit = useCallback(
-    (e?: FormEvent<HTMLFormElement>, customMessage?: string) => {
-      e?.preventDefault();
-
-      const content = customMessage || message;
+  const sendMessage = useCallback(
+    (content: string) => {
       if (!content.trim() || isFinished) return;
       mutate({ gameTeamId: teamId, content }, { onSuccess: () => scrollToBottom() });
-
       setMessage('');
     },
-    [isFinished, mutate, teamId, message, scrollToBottom],
+    [isFinished, mutate, teamId, scrollToBottom],
+  );
+
+  const handleSubmit = useCallback(
+    (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      sendMessage(message);
+    },
+    [sendMessage, message],
   );
 
   const placeholder = isFinished
@@ -48,7 +52,7 @@ export const CheerTalkForm = ({
     <form className="column relative w-full gap-1 bg-[#F7F8FB] px-4 py-3" onSubmit={handleSubmit}>
       <div className="center-y w-full gap-3 overflow-hidden">
         <fieldset
-          className="center-y flex-shrink-0 gap-2 rounded-full border border-neutral-200 bg-white px-3 py-1.5"
+          className="center-y shrink-0 gap-2 rounded-full border border-neutral-200 bg-white px-3 py-1.5"
           disabled={isFinished}
         >
           {gameTeams.map((team) => (
@@ -71,9 +75,9 @@ export const CheerTalkForm = ({
               key={msg}
               type="button"
               disabled={isFinished}
-              onClick={() => handleSubmit(undefined, msg)}
+              onClick={() => sendMessage(msg)}
               className={twMerge(
-                'flex-shrink-0 whitespace-nowrap rounded-full border border-neutral-200 bg-white px-3 py-1.5 text-xs font-Regular text-neutral-600 transition-colors',
+                'shrink-0 whitespace-nowrap rounded-full border border-neutral-200 bg-white px-3 py-1.5 text-xs font-Regular text-neutral-600 transition-colors',
                 'hover:bg-neutral-50 active:bg-neutral-100 disabled:opacity-50 disabled:cursor-not-allowed',
               )}
             >

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-form.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-form.tsx
@@ -10,6 +10,8 @@ interface CheerTalkFormProps {
   gameState: GameStateType;
 }
 
+const RECOMMENDED_MESSAGES = ['가즈아🔥', '나이스👍', '까비😭️'];
+
 export const CheerTalkForm = ({ gameTeams, scrollToBottom, gameState }: CheerTalkFormProps) => {
   const { mutate } = useCreateCheerTalk();
   const [message, setMessage] = useState('');
@@ -19,15 +21,16 @@ export const CheerTalkForm = ({ gameTeams, scrollToBottom, gameState }: CheerTal
   const canSubmit = message.trim() && !isFinished;
 
   const handleSubmit = useCallback(
-    (e: FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      if (!canSubmit) return;
+    (e?: FormEvent<HTMLFormElement>, customMessage?: string) => {
+      e?.preventDefault();
 
-      mutate({ gameTeamId: teamId, content: message }, { onSuccess: () => scrollToBottom() });
+      const content = customMessage || message;
+      if (!content.trim() || isFinished) return;
+      mutate({ gameTeamId: teamId, content }, { onSuccess: () => scrollToBottom() });
 
       setMessage('');
     },
-    [canSubmit, mutate, teamId, message, scrollToBottom],
+    [isFinished, mutate, teamId, message, scrollToBottom],
   );
 
   const placeholder = isFinished
@@ -37,25 +40,47 @@ export const CheerTalkForm = ({ gameTeams, scrollToBottom, gameState }: CheerTal
   if (gameTeams.length === 0) return null;
 
   return (
-    <form className="column w-full gap-1 bg-white p-4" onSubmit={handleSubmit}>
-      <fieldset className="center-y gap-2" disabled={isFinished}>
-        {gameTeams.map((team) => (
-          <label className="center-y gap-1 text-xs font-medium" key={team.gameTeamId}>
-            <input
-              type="radio"
-              checked={teamId === team.gameTeamId}
-              value={team.gameTeamId}
-              onChange={(e) => setTeamId(Number(e.target.value))}
+    <form className="column w-full gap-1 bg-[#F7F8FB] px-4 py-3" onSubmit={handleSubmit}>
+      <div className="center-y w-full gap-3 overflow-hidden">
+        <fieldset
+          className="center-y flex-shrink-0 gap-2 rounded-full border border-neutral-200 bg-white px-3 py-1.5"
+          disabled={isFinished}
+        >
+          {gameTeams.map((team) => (
+            <label className="center-y font-Regular gap-1 text-xs" key={team.gameTeamId}>
+              <input
+                type="radio"
+                checked={teamId === team.gameTeamId}
+                value={team.gameTeamId}
+                onChange={(e) => setTeamId(Number(e.target.value))}
+                disabled={isFinished}
+              />
+              {team.gameTeamName}
+            </label>
+          ))}
+        </fieldset>
+
+        <div className="scrollbar-hide flex gap-1.5 overflow-x-auto py-1">
+          {RECOMMENDED_MESSAGES.map((msg) => (
+            <button
+              key={msg}
+              type="button"
               disabled={isFinished}
-            />
-            {team.gameTeamName}
-          </label>
-        ))}
-      </fieldset>
+              onClick={() => handleSubmit(undefined, msg)}
+              className={twMerge(
+                'flex-shrink-0 whitespace-nowrap rounded-full border border-neutral-200 bg-white px-3 py-1.5 text-xs font-Regular text-neutral-600 transition-colors',
+                'hover:bg-neutral-50 active:bg-neutral-100 disabled:opacity-50 disabled:cursor-not-allowed',
+              )}
+            >
+              {msg}
+            </button>
+          ))}
+        </div>
+      </div>
 
       <div className="center-y w-full gap-2">
         <input
-          className="w-full rounded-lg bg-neutral-100 px-3 py-2 text-sm font-medium"
+          className="w-full rounded-3xl border-1 border-neutral-200 bg-neutral-100 px-3 py-2 text-sm font-medium"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           placeholder={placeholder}

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-form.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-form.tsx
@@ -85,7 +85,7 @@ export const CheerTalkForm = ({
 
       <div className="center-y w-full gap-2">
         <input
-          className="w-full rounded-3xl border-1 border-neutral-200 bg-neutral-100 px-3 py-2 text-sm font-medium"
+          className="w-full rounded-3xl border border-neutral-200 bg-neutral-100 px-3 py-2 text-sm font-medium"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           onFocus={onInputFocus}

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-form.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-form.tsx
@@ -8,11 +8,17 @@ interface CheerTalkFormProps {
   gameTeams: GameTeamType[];
   scrollToBottom: () => void;
   gameState: GameStateType;
+  onInputFocus: () => void;
 }
 
 const RECOMMENDED_MESSAGES = ['가즈아🔥', '나이스👍', '까비😭️'];
 
-export const CheerTalkForm = ({ gameTeams, scrollToBottom, gameState }: CheerTalkFormProps) => {
+export const CheerTalkForm = ({
+  gameTeams,
+  scrollToBottom,
+  gameState,
+  onInputFocus,
+}: CheerTalkFormProps) => {
   const { mutate } = useCreateCheerTalk();
   const [message, setMessage] = useState('');
   const [teamId, setTeamId] = useState(gameTeams[0]?.gameTeamId ?? 0);
@@ -38,9 +44,8 @@ export const CheerTalkForm = ({ gameTeams, scrollToBottom, gameState }: CheerTal
     : '응원톡을 남겨보세요!';
 
   if (gameTeams.length === 0) return null;
-
   return (
-    <form className="column w-full gap-1 bg-[#F7F8FB] px-4 py-3" onSubmit={handleSubmit}>
+    <form className="column relative w-full gap-1 bg-[#F7F8FB] px-4 py-3" onSubmit={handleSubmit}>
       <div className="center-y w-full gap-3 overflow-hidden">
         <fieldset
           className="center-y flex-shrink-0 gap-2 rounded-full border border-neutral-200 bg-white px-3 py-1.5"
@@ -83,6 +88,7 @@ export const CheerTalkForm = ({ gameTeams, scrollToBottom, gameState }: CheerTal
           className="w-full rounded-3xl border-1 border-neutral-200 bg-neutral-100 px-3 py-2 text-sm font-medium"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
+          onFocus={onInputFocus}
           placeholder={placeholder}
           aria-label="응원 메시지 입력"
           disabled={isFinished}

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-item.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-item.tsx
@@ -1,54 +1,103 @@
 import { formatTime } from '@hcc/toolkit';
-import { colors, Typography } from '@hcc/ui';
+import { Button, colors, Modal, Typography } from '@hcc/ui';
 import Image from 'next/image';
+import { useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
-import type { TeamDirection } from '~/api';
+import { type TeamDirection, useCreateCheerTalkReport } from '~/api';
 
 type Props = {
+  cheerTalkId: number;
   direction: TeamDirection;
   logoImageUrl: string;
   content: string;
   createdAt: string;
 };
 
-export default function CheerTalkItem({ direction, logoImageUrl, content, createdAt }: Props) {
-  return (
-    <div
-      className={twMerge(
-        'column gap-2 rounded-lg p-2.5',
-        direction === 'HOME' ? 'self-start bg-[#F5F5F7]' : 'self-end bg-[#F2F8FF]',
-      )}
-    >
-      <div className="center-y gap-1">
-        <Typography color={colors.neutral600} fontSize={10} weight="medium" asChild>
-          <button type="button">신고</button>
-        </Typography>
-        <Typography color={colors.neutral600} fontSize={10} weight="medium" asChild>
-          <span>|</span>
-        </Typography>
-        <Typography color={colors.neutral600} fontSize={10} weight="medium" asChild>
-          <time>{formatTime(createdAt, { format: 'YYYY년 MM월 DD일 HH:mm' })}</time>
-        </Typography>
-      </div>
+export default function CheerTalkItem({
+  cheerTalkId,
+  direction,
+  logoImageUrl,
+  content,
+  createdAt,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const { mutate: report } = useCreateCheerTalkReport();
 
+  const handleReport = () => {
+    report({ cheerTalkId });
+    setOpen(false);
+  };
+
+  return (
+    <>
       <div
         className={twMerge(
-          'flex items-center gap-1',
-          direction === 'HOME' ? 'flex-row' : 'flex-row-reverse',
+          'column gap-2 rounded-lg p-2.5',
+          direction === 'HOME' ? 'self-start bg-[#F5F5F7]' : 'self-end bg-[#F2F8FF]',
         )}
       >
-        <Image
-          className="size-[18px] overflow-hidden rounded-full object-cover"
-          src={logoImageUrl}
-          alt={`${direction} 팀 로고`}
-          width={18}
-          height={18}
-        />
-        <Typography color={colors.neutral900} fontSize={14}>
-          {content}
-        </Typography>
+        <div className="center-y gap-1">
+          <Typography color={colors.neutral600} fontSize={10} weight="medium" asChild>
+            <button type="button" onClick={() => setOpen(true)}>
+              신고
+            </button>
+          </Typography>
+          <Typography color={colors.neutral600} fontSize={10} weight="medium" asChild>
+            <span>|</span>
+          </Typography>
+          <Typography color={colors.neutral600} fontSize={10} weight="medium" asChild>
+            <time>{formatTime(createdAt, { format: 'YYYY년 MM월 DD일 HH:mm' })}</time>
+          </Typography>
+        </div>
+
+        <div
+          className={twMerge(
+            'flex items-center gap-1',
+            direction === 'HOME' ? 'flex-row' : 'flex-row-reverse',
+          )}
+        >
+          <Image
+            className="size-4.5 overflow-hidden rounded-full object-cover"
+            src={logoImageUrl}
+            alt={`${direction} 팀 로고`}
+            width={18}
+            height={18}
+          />
+          <Typography color={colors.neutral900} fontSize={14}>
+            {content}
+          </Typography>
+        </div>
       </div>
-    </div>
+
+      <Modal open={open} onOpenChange={setOpen}>
+        <Modal.Content className="w-90 rounded-lg bg-white px-6 py-6 shadow-xl">
+          <Modal.Title className="mb-2 text-base font-semibold text-neutral-900">
+            정말 이 응원톡을 신고할까요?
+          </Modal.Title>
+          <Modal.Description className="mb-6 text-sm text-neutral-500">
+            신고한 응원톡은 검토 후 가려집니다.
+          </Modal.Description>
+          <div className="flex gap-3">
+            <Modal.Close asChild>
+              <Button
+                color="black"
+                variant="ghost"
+                className="flex-1 rounded-xl border border-neutral-200 py-2.5 text-sm font-medium text-neutral-700"
+              >
+                그만두기
+              </Button>
+            </Modal.Close>
+            <Button
+              color="black"
+              onClick={handleReport}
+              className="flex-1 rounded-xl bg-neutral-900 py-2.5 text-sm font-medium text-white"
+            >
+              신고하기
+            </Button>
+          </div>
+        </Modal.Content>
+      </Modal>
+    </>
   );
 }

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { Spinner } from '@hcc/ui';
-import { Fragment, useCallback, useEffect, useMemo, useRef } from 'react';
+import { CloseIcon } from '@hcc/icons';
+import { colors, Spinner, Typography } from '@hcc/ui';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { type GameCheerTalkWithTeamInfo, useSuspenseGame } from '~/api';
 import useIntersectionObserver from '~/hooks/useIntersectionObserver';
@@ -30,6 +31,7 @@ export const CheerTalkList = ({
   isFetchingNextPage,
 }: CheerTalkListProps) => {
   const { data: game } = useSuspenseGame({ gameId });
+  const [isNoticeVisible, setIsNoticeVisible] = useState(false);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -89,7 +91,7 @@ export const CheerTalkList = ({
 
   return (
     <Fragment>
-      <div ref={scrollRef} className="scrollbar-hide w-full flex-1 overflow-y-auto">
+      <div ref={scrollRef} className="scrollbar-hide relative w-full flex-1 overflow-y-auto">
         <div ref={intersectionRef} className="h-1" />
         {isFetchingNextPage && (
           <div className="flex justify-center py-2">
@@ -105,11 +107,29 @@ export const CheerTalkList = ({
 
         <div ref={bottomRef} />
       </div>
+      {isNoticeVisible && (
+        <div className="right-4 bottom-2 left-4 z-20 mx-4 mb-2">
+          <div className="animate-in fade-in slide-in-from-bottom-2 flex items-center justify-between rounded-lg border border-neutral-100 bg-white p-3 shadow-lg">
+            <Typography fontSize={12} color={colors.neutral700} className="leading-5">
+              타인에게 불쾌감을 주거나 법령을 위반하는 활동을 할 경우, 운영정책에 따라 메시지 삭제
+              및 서비스 이용이 제한 될 수 있습니다.
+            </Typography>
+            <button
+              type="button"
+              onClick={() => setIsNoticeVisible(false)}
+              className="text-neutral-400 hover:text-neutral-600"
+            >
+              <CloseIcon size={16} />
+            </button>
+          </div>
+        </div>
+      )}
       <div className="pb-safe flex-shrink-0 border-t border-neutral-100 bg-white">
         <CheerTalkForm
           gameTeams={game.gameTeams}
           scrollToBottom={scrollToBottomWithDelay}
           gameState={game.state}
+          onInputFocus={() => setIsNoticeVisible(true)}
         />
       </div>
     </Fragment>

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
@@ -76,7 +76,6 @@ export const CheerTalkList = ({
     return handleInitialScroll();
   }, [handleInitialScroll]);
 
-  // const allMessages = [...cheerTalkList, ...socketTalkList];
   const allMessages = useMemo(() => {
     const messageMap = new Map<number, GameCheerTalkWithTeamInfo>();
     cheerTalkList.forEach((talk) => {
@@ -87,27 +86,32 @@ export const CheerTalkList = ({
     });
     return Array.from(messageMap.values()).sort((a, b) => a.cheerTalkId - b.cheerTalkId);
   }, [cheerTalkList, socketTalkList]);
+
   return (
     <Fragment>
-      <div ref={scrollRef} className="w-full flex-1 overflow-y-auto">
-        <div ref={intersectionRef} />
+      <div ref={scrollRef} className="scrollbar-hide w-full flex-1 overflow-y-auto">
+        <div ref={intersectionRef} className="h-1" />
+        {isFetchingNextPage && (
+          <div className="flex justify-center py-2">
+            <Spinner color="primary" />
+          </div>
+        )}
 
-        {isFetchingNextPage && <Spinner color="primary" />}
-
-        <div className="column gap-2.5 px-4">
+        <div className="column gap-2.5 px-4 py-4">
           {allMessages.map((talk) => (
-            <CheerTalkItem key={`socket-${talk.cheerTalkId}`} {...talk} />
+            <CheerTalkItem key={`talk-${talk.cheerTalkId}`} {...talk} />
           ))}
         </div>
 
         <div ref={bottomRef} />
       </div>
-
-      <CheerTalkForm
-        gameTeams={game.gameTeams}
-        scrollToBottom={scrollToBottomWithDelay}
-        gameState={game.state}
-      />
+      <div className="pb-safe flex-shrink-0 border-t border-neutral-100 bg-white">
+        <CheerTalkForm
+          gameTeams={game.gameTeams}
+          scrollToBottom={scrollToBottomWithDelay}
+          gameState={game.state}
+        />
+      </div>
     </Fragment>
   );
 };

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
@@ -107,24 +107,24 @@ export const CheerTalkList = ({
 
         <div ref={bottomRef} />
       </div>
-      {isNoticeVisible && (
-        <div className="right-4 bottom-2 left-4 z-20 mx-4 mb-2">
-          <div className="animate-in fade-in slide-in-from-bottom-2 flex items-center justify-between rounded-lg border border-neutral-100 bg-white p-3 shadow-lg">
-            <Typography fontSize={12} color={colors.neutral700} className="leading-5">
-              타인에게 불쾌감을 주거나 법령을 위반하는 활동을 할 경우, 운영정책에 따라 메시지 삭제
-              및 서비스 이용이 제한 될 수 있습니다.
-            </Typography>
-            <button
-              type="button"
-              onClick={() => setIsNoticeVisible(false)}
-              className="text-neutral-400 hover:text-neutral-600"
-            >
-              <CloseIcon size={16} />
-            </button>
+      <div className="pb-safe relative flex-shrink-0 border-t border-neutral-100 bg-white">
+        {isNoticeVisible && (
+          <div className="absolute right-4 bottom-full left-4 z-20 mb-2">
+            <div className="animate-in fade-in slide-in-from-bottom-2 flex items-center justify-between rounded-lg border border-neutral-100 bg-white p-3 shadow-lg">
+              <Typography fontSize={12} color={colors.neutral700} className="leading-5">
+                타인에게 불쾌감을 주거나 법령을 위반하는 활동을 할 경우, 운영정책에 따라 메시지 삭제
+                및 서비스 이용이 제한 될 수 있습니다.
+              </Typography>
+              <button
+                type="button"
+                onClick={() => setIsNoticeVisible(false)}
+                className="text-neutral-400 hover:text-neutral-600"
+              >
+                <CloseIcon size={16} />
+              </button>
+            </div>
           </div>
-        </div>
-      )}
-      <div className="pb-safe flex-shrink-0 border-t border-neutral-100 bg-white">
+        )}
         <CheerTalkForm
           gameTeams={game.gameTeams}
           scrollToBottom={scrollToBottomWithDelay}

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/index.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/index.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import { ChatFillIcon } from '@hcc/icons';
-import { BottomSheet, colors, Typography } from '@hcc/ui';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useMemo, useState, useEffect, useCallback } from 'react';
+import { useMemo, useState } from 'react';
 
 import type { CheerTalkType, GameCheerTalkWithTeamInfo } from '~/api';
 
@@ -19,8 +16,6 @@ type Props = {
 };
 
 export const CheerTalk = ({ gameId }: Props) => {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
-
   const [socketTalkList, setSocketTalkList] = useState<GameCheerTalkWithTeamInfo[]>([]);
   const { getTeamInfo } = useSuspenseGameTeamInfo(gameId);
 
@@ -43,75 +38,18 @@ export const CheerTalk = ({ gameId }: Props) => {
     callback: handleSocketMessage,
   });
 
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const pathname = usePathname();
-
-  useEffect(() => {
-    if (searchParams.get('cheer')) {
-      setIsOpen(true);
-    }
-  }, [searchParams]);
-
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      setIsOpen(open);
-
-      if (!open && searchParams.get('cheer')) {
-        const sp = new URLSearchParams(Array.from(searchParams.entries()));
-        sp.delete('cheer');
-        const search = sp.toString();
-        router.replace(search ? `${pathname}?${search}` : pathname);
-      }
-    },
-    [searchParams, router, pathname],
-  );
-
   return (
-    <div className="column gap-2 border-t border-neutral-100 p-4">
-      <div className="flex flex-row justify-between gap-2">
-        <div>
-          <BottomSheet open={isOpen} onOpenChange={handleOpenChange}>
-            <Typography color={colors.neutral900} weight="semibold">
-              실시간 응원톡
-            </Typography>
-
-            <BottomSheet.Trigger className="cursor-pointer">
-              <div className="row-between gap-2">
-                <Typography
-                  fontSize={14}
-                  weight="medium"
-                  // className="rounded-full bg-neutral-100 px-3 py-2"
-                >
-                  응원톡에 들어가 여러분의 팀을 응원해보세요! 🙌
-                </Typography>
-              </div>
-            </BottomSheet.Trigger>
-            <BottomSheet.Portal>
-              <BottomSheet.Content className="!h-full max-h-[90%]">
-                <BottomSheet.Title className="sr-only">응원톡 작성</BottomSheet.Title>
-                <div className="column-between h-full overflow-hidden">
-                  <CheerTalkTimeline gameId={gameId} />
-                  <CheerTalkList
-                    gameId={gameId}
-                    cheerTalkList={cheerTalks}
-                    socketTalkList={socketTalkList}
-                    {...rest}
-                  />
-                </div>
-              </BottomSheet.Content>
-            </BottomSheet.Portal>
-          </BottomSheet>
-        </div>
-        <button
-          type="button"
-          onClick={() => setIsOpen(true)}
-          className="center flex-row gap-1 rounded-full bg-[var(--color-primary-600)] p-3 text-white transition-opacity hover:opacity-90"
-        >
-          <ChatFillIcon className="text-white" />
-          입장하기
-        </button>
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="flex-shrink-0">
+        <CheerTalkTimeline gameId={gameId} />
       </div>
+
+      <CheerTalkList
+        gameId={gameId}
+        cheerTalkList={cheerTalks}
+        socketTalkList={socketTalkList}
+        {...rest}
+      />
     </div>
   );
 };

--- a/apps/spectator/src/app/games/[id]/page.tsx
+++ b/apps/spectator/src/app/games/[id]/page.tsx
@@ -69,7 +69,7 @@ const Page = async ({ searchParams, params }: Props) => {
 
         <Tabs.Content
           value="cheer"
-          className="flex min-h-0 flex-1 flex-col overflow-hidden outline-none"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden bg-[#EBEBEB] outline-none"
         >
           <Suspense clientOnly>
             <CheerTalk gameId={id} />

--- a/apps/spectator/src/app/games/[id]/page.tsx
+++ b/apps/spectator/src/app/games/[id]/page.tsx
@@ -13,7 +13,7 @@ import { routes } from '~/constants/routes';
 import { Banner } from './_components/banner';
 import { CheerTalk } from './_components/cheer-talk';
 
-const validTabs = ['lineup', 'timeline', 'video'];
+const validTabs = ['cheer', 'lineup', 'timeline', 'video'];
 
 type Props = {
   searchParams: Promise<{ tab?: string }>;
@@ -29,16 +29,17 @@ const Page = async ({ searchParams, params }: Props) => {
   }
 
   const { tab: _tab } = await searchParams;
-  const tab = validTabs.includes(_tab || '') ? _tab : 'lineup';
+  const tab = validTabs.includes(_tab || '') ? _tab : 'cheer';
 
   if (_tab && !validTabs.includes(_tab)) {
-    redirect('?tab=lineup');
+    redirect('?tab=cheer');
   }
 
   return (
-    <>
+    <div className="flex h-screen flex-col overflow-hidden bg-white">
       <Header arrow />
-      <div className="w-full">
+
+      <div className="flex-shrink-0">
         <Suspense clientOnly>
           <Banner gameId={id} />
         </Suspense>
@@ -47,45 +48,52 @@ const Page = async ({ searchParams, params }: Props) => {
           <CheerVS gameId={id} />
         </Suspense>
 
-        <Suspense clientOnly>
-          <CheerTalk gameId={id} />
-        </Suspense>
-
         <hr className="h-2 w-full border-none bg-neutral-50" />
-
-        <Tabs.Root className="column w-full" defaultValue={tab}>
-          <Tabs.List className="center sticky top-12 z-10 h-12 gap-5 border-b border-neutral-100 bg-white">
-            <TabTrigger className="size-full" value="lineup">
-              라인업
-            </TabTrigger>
-            <TabTrigger className="size-full" value="timeline">
-              타임라인
-            </TabTrigger>
-            <TabTrigger className="size-full" value="video">
-              영상
-            </TabTrigger>
-          </Tabs.List>
-
-          <Tabs.Content value="lineup">
-            <Suspense clientOnly>
-              <LineupTab gameId={id} />
-            </Suspense>
-          </Tabs.Content>
-
-          <Tabs.Content value="timeline">
-            <Suspense clientOnly>
-              <TimelineTab gameId={id} />
-            </Suspense>
-          </Tabs.Content>
-
-          <Tabs.Content value="video">
-            <Suspense clientOnly>
-              <VideoTab gameId={id} />
-            </Suspense>
-          </Tabs.Content>
-        </Tabs.Root>
       </div>
-    </>
+
+      <Tabs.Root className="flex min-h-0 flex-1 flex-col" defaultValue={tab}>
+        <Tabs.List className="center sticky top-0 z-10 flex h-12 flex-shrink-0 gap-5 border-b border-neutral-100 bg-white">
+          <TabTrigger className="size-full" value="cheer">
+            응원
+          </TabTrigger>
+          <TabTrigger className="size-full" value="lineup">
+            라인업
+          </TabTrigger>
+          <TabTrigger className="size-full" value="timeline">
+            타임라인
+          </TabTrigger>
+          <TabTrigger className="size-full" value="video">
+            영상
+          </TabTrigger>
+        </Tabs.List>
+
+        <Tabs.Content
+          value="cheer"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden outline-none"
+        >
+          <Suspense clientOnly>
+            <CheerTalk gameId={id} />
+          </Suspense>
+        </Tabs.Content>
+        <Tabs.Content value="lineup" className="min-h-0 flex-1 overflow-y-auto outline-none">
+          <Suspense clientOnly>
+            <LineupTab gameId={id} />
+          </Suspense>
+        </Tabs.Content>
+
+        <Tabs.Content value="timeline" className="min-h-0 flex-1 overflow-y-auto outline-none">
+          <Suspense clientOnly>
+            <TimelineTab gameId={id} />
+          </Suspense>
+        </Tabs.Content>
+
+        <Tabs.Content value="video" className="min-h-0 flex-1 overflow-y-auto outline-none">
+          <Suspense clientOnly>
+            <VideoTab gameId={id} />
+          </Suspense>
+        </Tabs.Content>
+      </Tabs.Root>
+    </div>
   );
 };
 


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 경기 중계 시 응원탭 추가
  - 바텀시트로 올라오던 응원톡을 탭 내부로 이동
  - 응원탭이 default인 상태
  - 입력창 focus 시 경고창 ui 개발
   - 추천 문구 3개 고정 및 누르면 바로 전송되는 형태
<img width="400" height="900" alt="image" src="https://github.com/user-attachments/assets/8e5b9aa4-c046-492b-a1e2-1461c8dfecd9" />

## 추가된 내용
신고버튼 눌렀을 때 onClick핸들러가 비어있어서 신고 로직 추가했습니다.
커밋이 꼬여서 로직 분리한 내용이 신고로직이랑 같이 올라가있어요 ㅜ
