### PR TITLE
fix(manager): 팀 정보 수정 및 경기 정보 수정에 기능 추가

### DIFF
--- a/apps/manager/src/api/mutations/index.ts
+++ b/apps/manager/src/api/mutations/index.ts
@@ -17,3 +17,7 @@ export * from './useUpdateLeagueTeams';
 export * from './useUpdatePlayers';
 export * from './useUpdateTeams';
 export * from './useUpdateTeamPlayers';
+export * from './useCreateGameTeamsLineup';
+export * from './useDeleteGameTeamsLineup';
+export * from './useUpdateGamesCandidate';
+export * from './useUpdateGamesStarter';

--- a/apps/manager/src/api/mutations/index.ts
+++ b/apps/manager/src/api/mutations/index.ts
@@ -21,3 +21,5 @@ export * from './useCreateGameTeamsLineup';
 export * from './useDeleteGameTeamsLineup';
 export * from './useUpdateGamesCandidate';
 export * from './useUpdateGamesStarter';
+export * from './useUpdateGamesCaptainRegister';
+export * from './useUpdateGamesCaptainRevoke';

--- a/apps/manager/src/api/mutations/useCreateGameTeamsLineup.ts
+++ b/apps/manager/src/api/mutations/useCreateGameTeamsLineup.ts
@@ -1,0 +1,29 @@
+import { fetcher, useMutation, useQueryClient } from '@hcc/api-base';
+
+import { queryKeys } from '~/api/queryKey';
+
+import type { GameTeamLineupCreateRequest } from '../types/games';
+
+export const postGameTeamsLineup = ({ gameTeamId, ...request }: GameTeamLineupCreateRequest) => {
+  const payload = {
+    teamPlayerId: request.teamPlayerId,
+    state: request.state,
+    isCaptain: request.isCaptain,
+  };
+  console.log('[API] 라인업에 선수 추가 (POST /lineup-players):', {
+    url: `game-teams/${gameTeamId}/lineup-players`,
+    body: payload,
+  });
+  return fetcher.post<void>(`game-teams/${gameTeamId}/lineup-players`, { json: payload });
+};
+
+export const useCreateGameTeamsLineup = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: postGameTeamsLineup,
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: queryKeys.games.lineup._def });
+    },
+  });
+};

--- a/apps/manager/src/api/mutations/useCreateGameTeamsLineup.ts
+++ b/apps/manager/src/api/mutations/useCreateGameTeamsLineup.ts
@@ -5,12 +5,7 @@ import { queryKeys } from '~/api/queryKey';
 import type { GameTeamLineupCreateRequest } from '../types/games';
 
 export const postGameTeamsLineup = ({ gameTeamId, ...request }: GameTeamLineupCreateRequest) => {
-  const payload = {
-    teamPlayerId: request.teamPlayerId,
-    state: request.state,
-    isCaptain: request.isCaptain,
-  };
-  return fetcher.post<void>(`game-teams/${gameTeamId}/lineup-players`, { json: payload });
+  return fetcher.post<void>(`game-teams/${gameTeamId}/lineup-players`, { json: request });
 };
 
 export const useCreateGameTeamsLineup = () => {

--- a/apps/manager/src/api/mutations/useCreateGameTeamsLineup.ts
+++ b/apps/manager/src/api/mutations/useCreateGameTeamsLineup.ts
@@ -10,10 +10,6 @@ export const postGameTeamsLineup = ({ gameTeamId, ...request }: GameTeamLineupCr
     state: request.state,
     isCaptain: request.isCaptain,
   };
-  console.log('[API] 라인업에 선수 추가 (POST /lineup-players):', {
-    url: `game-teams/${gameTeamId}/lineup-players`,
-    body: payload,
-  });
   return fetcher.post<void>(`game-teams/${gameTeamId}/lineup-players`, { json: payload });
 };
 

--- a/apps/manager/src/api/mutations/useDeleteGameTeamsLineup.ts
+++ b/apps/manager/src/api/mutations/useDeleteGameTeamsLineup.ts
@@ -1,0 +1,29 @@
+import { fetcher, useMutation, useQueryClient } from '@hcc/api-base';
+
+import { queryKeys } from '~/api/queryKey';
+
+type Request = {
+  gameTeamId: number;
+  lineupPlayerId: number;
+};
+
+export const deleteGameTeamsLineup = ({ gameTeamId, lineupPlayerId }: Request) => {
+  console.log('[API] 라인업에서 선수 제거 (DELETE /lineup-players):', {
+    gameTeamId,
+    lineupPlayerId,
+  });
+  return fetcher.delete<void>(`game-teams/${gameTeamId}/lineup-players/${lineupPlayerId}`, {
+    json: null,
+  });
+};
+
+export const useDeleteGameTeamsLineup = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteGameTeamsLineup,
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: queryKeys.games.lineup._def });
+    },
+  });
+};

--- a/apps/manager/src/api/mutations/useDeleteGameTeamsLineup.ts
+++ b/apps/manager/src/api/mutations/useDeleteGameTeamsLineup.ts
@@ -8,10 +8,6 @@ type Request = {
 };
 
 export const deleteGameTeamsLineup = ({ gameTeamId, lineupPlayerId }: Request) => {
-  console.log('[API] 라인업에서 선수 제거 (DELETE /lineup-players):', {
-    gameTeamId,
-    lineupPlayerId,
-  });
   return fetcher.delete<void>(`game-teams/${gameTeamId}/lineup-players/${lineupPlayerId}`, {
     json: null,
   });

--- a/apps/manager/src/api/mutations/useUpdateGamesCandidate.ts
+++ b/apps/manager/src/api/mutations/useUpdateGamesCandidate.ts
@@ -10,7 +10,6 @@ export const patchTeamPlayers = ({
   gameId,
   lineupPlayerId,
 }: Request & { lineupPlayerId: number }) => {
-  console.log('[API] 선수를 후보로 변경 (PATCH /candidate):', { gameId, lineupPlayerId });
   return fetcher.patch<void>(`games/${gameId}/lineup-players/${lineupPlayerId}/candidate`, {
     json: null,
   });

--- a/apps/manager/src/api/mutations/useUpdateGamesCandidate.ts
+++ b/apps/manager/src/api/mutations/useUpdateGamesCandidate.ts
@@ -6,7 +6,7 @@ type Request = {
   gameId: number;
 };
 
-export const patchTeamPlayers = ({
+export const patchLineupPlayerToCandidate = ({
   gameId,
   lineupPlayerId,
 }: Request & { lineupPlayerId: number }) => {
@@ -19,7 +19,7 @@ export const useUpdateGamesCandidate = () => {
   const qc = useQueryClient();
 
   return useMutation({
-    mutationFn: patchTeamPlayers,
+    mutationFn: patchLineupPlayerToCandidate,
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: queryKeys.games.lineup._def });
     },

--- a/apps/manager/src/api/mutations/useUpdateGamesCandidate.ts
+++ b/apps/manager/src/api/mutations/useUpdateGamesCandidate.ts
@@ -1,0 +1,28 @@
+import { fetcher, useMutation, useQueryClient } from '@hcc/api-base';
+
+import { queryKeys } from '~/api/queryKey';
+
+type Request = {
+  gameId: number;
+};
+
+export const patchTeamPlayers = ({
+  gameId,
+  lineupPlayerId,
+}: Request & { lineupPlayerId: number }) => {
+  console.log('[API] 선수를 후보로 변경 (PATCH /candidate):', { gameId, lineupPlayerId });
+  return fetcher.patch<void>(`games/${gameId}/lineup-players/${lineupPlayerId}/candidate`, {
+    json: null,
+  });
+};
+
+export const useUpdateGamesCandidate = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchTeamPlayers,
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: queryKeys.games.lineup._def });
+    },
+  });
+};

--- a/apps/manager/src/api/mutations/useUpdateGamesCaptainRegister.ts
+++ b/apps/manager/src/api/mutations/useUpdateGamesCaptainRegister.ts
@@ -1,0 +1,25 @@
+import { fetcher, useMutation, useQueryClient } from '@hcc/api-base';
+
+import { queryKeys } from '~/api/queryKey';
+
+type Request = {
+  gameId: number;
+  lineupPlayerId: number;
+};
+
+export const patchLineupPlayerCaptainRegister = ({ gameId, lineupPlayerId }: Request) => {
+  return fetcher.patch<void>(`games/${gameId}/lineup-players/${lineupPlayerId}/captain/register`, {
+    json: null,
+  });
+};
+
+export const useUpdateGamesCaptainRegister = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchLineupPlayerCaptainRegister,
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: queryKeys.games.lineup._def });
+    },
+  });
+};

--- a/apps/manager/src/api/mutations/useUpdateGamesCaptainRevoke.ts
+++ b/apps/manager/src/api/mutations/useUpdateGamesCaptainRevoke.ts
@@ -1,0 +1,25 @@
+import { fetcher, useMutation, useQueryClient } from '@hcc/api-base';
+
+import { queryKeys } from '~/api/queryKey';
+
+type Request = {
+  gameId: number;
+  lineupPlayerId: number;
+};
+
+export const patchLineupPlayerCaptainRevoke = ({ gameId, lineupPlayerId }: Request) => {
+  return fetcher.patch<void>(`games/${gameId}/lineup-players/${lineupPlayerId}/captain/revoke`, {
+    json: null,
+  });
+};
+
+export const useUpdateGamesCaptainRevoke = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchLineupPlayerCaptainRevoke,
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: queryKeys.games.lineup._def });
+    },
+  });
+};

--- a/apps/manager/src/api/mutations/useUpdateGamesStarter.ts
+++ b/apps/manager/src/api/mutations/useUpdateGamesStarter.ts
@@ -6,7 +6,7 @@ type Request = {
   gameId: number;
 };
 
-export const patchTeamPlayersStarter = ({
+export const patchLineupPlayerToStarter = ({
   gameId,
   lineupPlayerId,
 }: Request & { lineupPlayerId: number }) => {
@@ -19,7 +19,7 @@ export const useUpdateGamesStarter = () => {
   const qc = useQueryClient();
 
   return useMutation({
-    mutationFn: patchTeamPlayersStarter,
+    mutationFn: patchLineupPlayerToStarter,
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: queryKeys.games.lineup._def });
     },

--- a/apps/manager/src/api/mutations/useUpdateGamesStarter.ts
+++ b/apps/manager/src/api/mutations/useUpdateGamesStarter.ts
@@ -1,0 +1,28 @@
+import { fetcher, useMutation, useQueryClient } from '@hcc/api-base';
+
+import { queryKeys } from '~/api/queryKey';
+
+type Request = {
+  gameId: number;
+};
+
+export const patchTeamPlayersStarter = ({
+  gameId,
+  lineupPlayerId,
+}: Request & { lineupPlayerId: number }) => {
+  console.log('[API] 선수를 선발로 변경 (PATCH /starter):', { gameId, lineupPlayerId });
+  return fetcher.patch<void>(`games/${gameId}/lineup-players/${lineupPlayerId}/starter`, {
+    json: null,
+  });
+};
+
+export const useUpdateGamesStarter = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchTeamPlayersStarter,
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: queryKeys.games.lineup._def });
+    },
+  });
+};

--- a/apps/manager/src/api/mutations/useUpdateGamesStarter.ts
+++ b/apps/manager/src/api/mutations/useUpdateGamesStarter.ts
@@ -10,7 +10,6 @@ export const patchTeamPlayersStarter = ({
   gameId,
   lineupPlayerId,
 }: Request & { lineupPlayerId: number }) => {
-  console.log('[API] 선수를 선발로 변경 (PATCH /starter):', { gameId, lineupPlayerId });
   return fetcher.patch<void>(`games/${gameId}/lineup-players/${lineupPlayerId}/starter`, {
     json: null,
   });

--- a/apps/manager/src/api/queries/index.ts
+++ b/apps/manager/src/api/queries/index.ts
@@ -2,6 +2,7 @@ export * from './useCheerTalkBlock';
 export * from './useCheerTalkReport';
 export * from './useCheerTalks';
 export * from './useGame';
+export * from './useGameLineup';
 export * from './useGames';
 export * from './useGameTimeLine';
 export * from './useLeague';

--- a/apps/manager/src/api/queryKey.ts
+++ b/apps/manager/src/api/queryKey.ts
@@ -113,7 +113,7 @@ const cheerTalkQueryKeys = createQueryKeys('cheertalks', {
   }),
 });
 
-const GameTeamLineypQueryKeys = createQueryKeys('gameteamslineup', {
+const GameTeamLineupQueryKeys = createQueryKeys('gameteamslineup', {
   create: {
     queryKey: null,
   },
@@ -124,5 +124,5 @@ export const queryKeys = mergeQueryKeys(
   teamQueryKeys,
   cheerTalkQueryKeys,
   gameQueryKeys,
-  GameTeamLineypQueryKeys,
+  GameTeamLineupQueryKeys,
 );

--- a/apps/manager/src/api/queryKey.ts
+++ b/apps/manager/src/api/queryKey.ts
@@ -113,10 +113,16 @@ const cheerTalkQueryKeys = createQueryKeys('cheertalks', {
   }),
 });
 
+const GameTeamLineypQueryKeys = createQueryKeys('gameteamslineup', {
+  create: {
+    queryKey: null,
+  },
+});
 export const queryKeys = mergeQueryKeys(
   leagueQueryKeys,
   playerQueryKeys,
   teamQueryKeys,
   cheerTalkQueryKeys,
   gameQueryKeys,
+  GameTeamLineypQueryKeys,
 );

--- a/apps/manager/src/api/queryKey.ts
+++ b/apps/manager/src/api/queryKey.ts
@@ -113,16 +113,10 @@ const cheerTalkQueryKeys = createQueryKeys('cheertalks', {
   }),
 });
 
-const GameTeamLineupQueryKeys = createQueryKeys('gameteamslineup', {
-  create: {
-    queryKey: null,
-  },
-});
 export const queryKeys = mergeQueryKeys(
   leagueQueryKeys,
   playerQueryKeys,
   teamQueryKeys,
   cheerTalkQueryKeys,
   gameQueryKeys,
-  GameTeamLineupQueryKeys,
 );

--- a/apps/manager/src/api/types/games.ts
+++ b/apps/manager/src/api/types/games.ts
@@ -49,15 +49,21 @@ export type GameDetailPayload = { gameId: number };
 
 export type GameLineupPayload = { gameId: number };
 
-export type GameTeamPlayerType = {
+export type ReplacedPlayerType = {
   id: number;
+  number: number;
+  playerName: string;
+};
+
+export type GameTeamPlayerType = {
+  lineupPlayerId: number;
+  playerId: number;
   playerName: string;
   description?: string;
-  number: number;
-  jerseyNumber?: number;
+  jerseyNumber: number;
   isCaptain: boolean;
   isReplaced: boolean;
-  replacedPlayer: Pick<GameTeamPlayerType, 'id' | 'number' | 'playerName'> | null;
+  replacedPlayer: ReplacedPlayerType | null;
   state: 'STARTER' | 'CANDIDATE';
 };
 
@@ -72,4 +78,10 @@ export type GameLineupPlayingType = {
   gameTeamId: number;
   teamName: string;
   gameTeamPlayers: GameTeamPlayerType[];
+};
+export type GameTeamLineupCreateRequest = {
+  teamPlayerId: number;
+  state: 'STARTER' | 'CANDIDATE';
+  isCaptain: boolean;
+  gameTeamId: number;
 };

--- a/apps/manager/src/api/types/teams.ts
+++ b/apps/manager/src/api/types/teams.ts
@@ -1,5 +1,7 @@
 export type TeamPlayerType = {
   playerId: number;
+  name?: string;
+  studentNumber?: string;
   jerseyNumber: number;
 };
 

--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/form-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/form-section.tsx
@@ -1,32 +1,205 @@
 'use client';
 
-import { Button, Input, Select, Typography, toast } from '@hcc/ui';
+import { Button, Input, Spinner, Typography, toast } from '@hcc/ui';
+import { Suspense } from '@suspensive/react';
 import { useRouter } from 'next/navigation';
-import { useForm } from 'react-hook-form';
+import { useState } from 'react';
+import { Controller, FormProvider, useForm, useFormContext } from 'react-hook-form';
+import { twMerge } from 'tailwind-merge';
 
 import { type GameUpdateFormType, useSuspenseGame, useSuspenseLeague, useUpdateGames } from '~/api';
+import { InputSelect } from '~/components/ui/input-select';
 import { quarterOptions, roundOptions, stateOptions } from '~/constants/leagues';
 import { handleFormError } from '~/utils/form-util';
+
+import { StepProgress } from '../_components/game-form/step-progress';
+import { GameLineupEditSection } from './game-lineup-edit-section';
 
 type Props = {
   leagueId: number;
   gameId: number;
 };
 
-export const FormSection = ({ leagueId, gameId }: Props) => {
-  const router = useRouter();
+const STEPS = [
+  { id: 'basic', title: '경기 정보' },
+  { id: 'lineup', title: '라인업' },
+  { id: 'video', title: '경기 영상' },
+] as const;
+
+// ── Step 0: 경기 기본 정보 ──────────────────────────────────────────────────
+type BasicStepProps = {
+  leagueId: number;
+  onNext: () => void;
+};
+
+const GameEditBasicStep = ({ leagueId, onNext }: BasicStepProps) => {
+  const { register, watch, control } = useFormContext<GameUpdateFormType>();
   const { data: league } = useSuspenseLeague({ leagueId });
+
+  const [name, round, quarter, state, startTime] = watch([
+    'name',
+    'round',
+    'quarter',
+    'state',
+    'startTime',
+  ]);
+
+  const isValid = Boolean(name?.trim() && round && quarter && state && startTime);
+
+  const roundOptions_ = roundOptions
+    .filter((item) => league.maxRound >= item.round)
+    .map((item) => ({ value: item.value.toString(), label: item.label }));
+
+  const quarterListOptions = Object.entries(quarterOptions).map(([key, value]) => ({
+    value: key,
+    label: value,
+  }));
+
+  const stateListOptions = Object.entries(stateOptions).map(([key, value]) => ({
+    value: key,
+    label: value,
+  }));
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-y-auto">
+        <Typography weight="semibold">경기 정보</Typography>
+
+        <div className="column mt-4 gap-3">
+          <Input
+            {...register('name', { required: '명칭은 필수 입력값이에요.' })}
+            size="lg"
+            type="text"
+            placeholder="명칭"
+          />
+
+          <Controller
+            name="round"
+            control={control}
+            render={({ field }) => (
+              <InputSelect
+                label="라운드"
+                options={roundOptions_}
+                value={field.value?.toString()}
+                onValueChange={field.onChange}
+              />
+            )}
+          />
+
+          <Controller
+            name="quarter"
+            control={control}
+            render={({ field }) => (
+              <InputSelect
+                label="쿼터"
+                options={quarterListOptions}
+                value={field.value}
+                onValueChange={field.onChange}
+              />
+            )}
+          />
+
+          <Controller
+            name="state"
+            control={control}
+            render={({ field }) => (
+              <InputSelect
+                label="상황"
+                options={stateListOptions}
+                value={field.value}
+                onValueChange={field.onChange}
+              />
+            )}
+          />
+
+          <Input
+            {...register('startTime', { required: '시작 일시는 필수 입력값이에요.' })}
+            size="lg"
+            type="datetime-local"
+            placeholder="시작 일시"
+            required
+          />
+        </div>
+      </div>
+
+      <div className="flex-shrink-0 border-t border-gray-200 bg-white pt-4">
+        <Button
+          type="button"
+          className="w-full"
+          size="lg"
+          color="black"
+          onClick={onNext}
+          disabled={!isValid}
+        >
+          다음 단계
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+// ── Step 2: 경기 영상 ──────────────────────────────────────────────────────
+type VideoStepProps = {
+  onPrevious: () => void;
+};
+
+const GameEditVideoStep = ({ onPrevious }: VideoStepProps) => {
+  const { register } = useFormContext<GameUpdateFormType>();
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-y-auto">
+        <Typography weight="semibold">영상</Typography>
+
+        <div className="column mt-4 gap-3">
+          <Input size="lg" type="text" placeholder="영상 URL" {...register('videoId')} />
+        </div>
+      </div>
+
+      <div className={twMerge('flex-shrink-0 border-t border-gray-200 bg-white pt-4')}>
+        <div className="flex gap-3">
+          <Button
+            type="button"
+            className="flex-1"
+            size="lg"
+            color="primary"
+            variant="ghost"
+            onClick={onPrevious}
+          >
+            이전 단계
+          </Button>
+          <Button type="submit" className="flex-1" size="lg" color="black">
+            경기 수정
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ── FormSection (메인) ─────────────────────────────────────────────────────
+const FormSectionInner = ({ leagueId, gameId }: Props) => {
+  const router = useRouter();
   const { data } = useSuspenseGame({ gameId });
 
-  const { register, handleSubmit } = useForm<GameUpdateFormType>({
-    defaultValues: { ...data, name: data.gameName, quarter: data.gameQuarter },
+  const [step, setStep] = useState<0 | 1 | 2>(0);
+
+  const form = useForm<GameUpdateFormType>({
+    defaultValues: {
+      name: data.gameName,
+      round: data.round,
+      quarter: data.gameQuarter,
+      state: data.state,
+      startTime: data.startTime,
+      videoId: data.videoId,
+    },
   });
 
   const { mutate } = useUpdateGames();
 
-  const handleFormSubmit = (data: GameUpdateFormType) => {
+  const handleFormSubmit = (formData: GameUpdateFormType) => {
     mutate(
-      { ...data, leagueId, gameId },
+      { ...formData, leagueId, gameId },
       {
         onSuccess: () => {
           toast.success('경기가 수정되었습니다.');
@@ -41,73 +214,44 @@ export const FormSection = ({ leagueId, gameId }: Props) => {
   };
 
   return (
-    <form
-      className="w-full bg-white p-4"
-      onSubmit={handleSubmit(handleFormSubmit, handleFormError)}
-    >
-      <Typography weight="semibold">경기 정보</Typography>
-
-      <div className="column mt-4 gap-3">
-        <Input
-          {...register('name', { required: '명칭은 필수 입력값이에요.' })}
-          size="lg"
-          type="text"
-          placeholder="명칭"
+    <FormProvider {...form}>
+      <form
+        className="flex h-full w-full flex-col bg-white p-4"
+        onSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
+      >
+        <StepProgress
+          currentStep={step}
+          totalSteps={STEPS.length}
+          steps={STEPS.map((s) => s.title)}
         />
 
-        <Select
-          {...register('round', { required: '라운드는 필수 입력값이에요.' })}
-          size="lg"
-          placeholder="라운드"
-          required
-        >
-          {roundOptions
-            .filter((item) => league.maxRound >= item.round)
-            .map((item) => (
-              <option key={item.value} value={item.value}>
-                {item.label}
-              </option>
-            ))}
-        </Select>
+        <div className="mt-6 flex-1 overflow-hidden">
+          {step === 0 && (
+            <Suspense fallback={<Spinner className="self-center" />} clientOnly>
+              <GameEditBasicStep leagueId={leagueId} onNext={() => setStep(1)} />
+            </Suspense>
+          )}
 
-        <Select
-          {...register('quarter', { required: '쿼터는 필수 입력값이에요.' })}
-          size="lg"
-          placeholder="쿼터"
-          required
-        >
-          {Object.entries(quarterOptions).map(([quarter, value]) => (
-            <option key={quarter} value={quarter}>
-              {value}
-            </option>
-          ))}
-        </Select>
+          {step === 1 && (
+            <GameLineupEditSection
+              gameId={gameId}
+              leagueId={leagueId}
+              onNext={() => setStep(2)}
+              onPrevious={() => setStep(0)}
+            />
+          )}
 
-        <Select
-          {...register('state', { required: '상황은 필수 입력값이에요.' })}
-          size="lg"
-          placeholder="상황"
-          required
-        >
-          {Object.entries(stateOptions).map(([state, value]) => (
-            <option key={state} value={state}>
-              {value}
-            </option>
-          ))}
-        </Select>
+          {step === 2 && <GameEditVideoStep onPrevious={() => setStep(1)} />}
+        </div>
+      </form>
+    </FormProvider>
+  );
+};
 
-        <Input
-          {...register('startTime', { required: '시작 일시는 필수 입력값이에요.' })}
-          size="lg"
-          type="datetime-local"
-          placeholder="시작 일시"
-          required
-        />
-      </div>
-
-      <Button className="mt-4 w-full" color="black" type="submit" size="lg">
-        경기 수정
-      </Button>
-    </form>
+export const FormSection = ({ leagueId, gameId }: Props) => {
+  return (
+    <Suspense clientOnly>
+      <FormSectionInner leagueId={leagueId} gameId={gameId} />
+    </Suspense>
   );
 };

--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
@@ -160,12 +160,6 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
     originalSelection: PlayerSelectionState[],
     newSelection: PlayerSelectionState[],
   ) => {
-    console.log('[경기 라인업 편집] applyTeamChanges 시작:', {
-      gameTeamId,
-      originalSelection,
-      newSelection,
-    });
-
     const originalMap = new Map(originalSelection.map((p) => [p.teamPlayerId, p]));
     const newMap = new Map(newSelection.map((p) => [p.teamPlayerId, p]));
 
@@ -175,21 +169,11 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
       if (!next) {
         // 라인업에서 제거 → DELETE
         if (orig.lineupPlayerId !== undefined) {
-          console.log('[경기 라인업 편집] 선수 제거:', {
-            teamPlayerId: orig.teamPlayerId,
-            lineupPlayerId: orig.lineupPlayerId,
-          });
           await deleteLineupPlayer({ gameTeamId, lineupPlayerId: orig.lineupPlayerId });
         }
       } else if (orig.state !== next.state && orig.isCaptain === next.isCaptain) {
         // 선발 ↔ 후보 상태만 변경 → PATCH (lineupPlayerId 유지)
         if (orig.lineupPlayerId !== undefined) {
-          console.log('[경기 라인업 편집] 선수 상태 변경:', {
-            teamPlayerId: orig.teamPlayerId,
-            lineupPlayerId: orig.lineupPlayerId,
-            from: orig.state,
-            to: next.state,
-          });
           if (next.state === 'STARTER') {
             await patchStarter({ gameId, lineupPlayerId: orig.lineupPlayerId });
           } else {
@@ -199,17 +183,8 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
       } else if (orig.state !== next.state || orig.isCaptain !== next.isCaptain) {
         // 주장 변경 포함 → DELETE + POST (주장 변경 전용 PATCH 없음)
         if (orig.lineupPlayerId !== undefined) {
-          console.log('[경기 라인업 편집] 주장 변경 - 선수 제거:', {
-            teamPlayerId: orig.teamPlayerId,
-            lineupPlayerId: orig.lineupPlayerId,
-          });
           await deleteLineupPlayer({ gameTeamId, lineupPlayerId: orig.lineupPlayerId });
         }
-        console.log('[경기 라인업 편집] 주장 변경 - 선수 추가:', {
-          teamPlayerId: next.teamPlayerId,
-          state: next.state,
-          isCaptain: next.isCaptain,
-        });
         await createLineup({
           gameTeamId,
           teamPlayerId: next.teamPlayerId,
@@ -223,11 +198,6 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
     for (const next of newSelection) {
       if (!originalMap.has(next.teamPlayerId)) {
         // 새로 추가된 선수 → POST
-        console.log('[경기 라인업 편집] 선수 추가:', {
-          teamPlayerId: next.teamPlayerId,
-          state: next.state,
-          isCaptain: next.isCaptain,
-        });
         await createLineup({
           gameTeamId,
           teamPlayerId: next.teamPlayerId,
@@ -240,31 +210,14 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
 
   const handleSaveAndNext = async () => {
     if (!gameTeam1 || !gameTeam2) return;
-    console.log('[경기 라인업 편집] 저장 시작:', {
-      team1GameTeamId: gameTeam1.gameTeamId,
-      team2GameTeamId: gameTeam2.gameTeamId,
-    });
     setSaving(true);
     try {
-      console.log('[경기 라인업 편집] Team 1 라인업 적용:', {
-        gameTeamId: gameTeam1.gameTeamId,
-        originalCount: originalTeam1Selection.length,
-        newCount: team1Selection.length,
-      });
       await applyTeamChanges(gameTeam1.gameTeamId, originalTeam1Selection, team1Selection);
-
-      console.log('[경기 라인업 편집] Team 2 라인업 적용:', {
-        gameTeamId: gameTeam2.gameTeamId,
-        originalCount: originalTeam2Selection.length,
-        newCount: team2Selection.length,
-      });
       await applyTeamChanges(gameTeam2.gameTeamId, originalTeam2Selection, team2Selection);
 
-      console.log('[경기 라인업 편집] 라인업 저장 완료');
       toast.success('라인업이 수정되었습니다.');
       onNext();
     } catch (error) {
-      console.error('[경기 라인업 편집] 라인업 수정 실패:', error);
       toast.error('라인업 수정에 실패했습니다. 잠시 후 다시 시도해주세요.');
     } finally {
       setSaving(false);

--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
@@ -1,0 +1,477 @@
+'use client';
+
+import { Button, Input, Spinner, toast } from '@hcc/ui';
+import { Suspense } from '@suspensive/react';
+import { useMemo, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import {
+  useCreateGameTeamsLineup,
+  useDeleteGameTeamsLineup,
+  useUpdateGamesCandidate,
+  useUpdateGamesStarter,
+  useSuspenseGame,
+  useSuspenseGameLineup,
+  useSuspenseLeagueTeams,
+  useSuspenseLeagueTeamsPlayers,
+  type GameLineupType,
+  type LeagueTeamsPlayerType,
+} from '~/api';
+
+type PlayerSelectionState = {
+  teamPlayerId: number;
+  lineupPlayerId?: number;
+  state: 'STARTER' | 'CANDIDATE';
+  isCaptain: boolean;
+};
+
+type Props = {
+  gameId: number;
+  leagueId: number;
+  onNext: () => void;
+  onPrevious: () => void;
+};
+
+const initializeSelection = (
+  lineupData: GameLineupType | undefined,
+  playerByPlayerId: Map<number, LeagueTeamsPlayerType>,
+): PlayerSelectionState[] => {
+  if (!lineupData) return [];
+  const allPlayers = [...lineupData.starterPlayers, ...lineupData.candidatePlayers];
+  return allPlayers.flatMap((lp) => {
+    const teamPlayer = playerByPlayerId.get(lp.playerId);
+    if (!teamPlayer) return [];
+    return [
+      {
+        teamPlayerId: teamPlayer.teamPlayerId,
+        lineupPlayerId: lp.lineupPlayerId,
+        state: lp.state,
+        isCaptain: lp.isCaptain,
+      },
+    ];
+  });
+};
+
+const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
+  const { data: game } = useSuspenseGame({ gameId });
+  const { data: lineup } = useSuspenseGameLineup({ gameId });
+  const { data: leagueTeams } = useSuspenseLeagueTeams({ leagueId });
+
+  const gameTeam1 = game.gameTeams[0];
+  const gameTeam2 = game.gameTeams[1];
+
+  // gameTeamId로 lineup 매칭 (가장 신뢰할 수 있는 방법)
+  const lineup1 = lineup.find((l) => l.gameTeamId === gameTeam1?.gameTeamId);
+  const lineup2 = lineup.find((l) => l.gameTeamId === gameTeam2?.gameTeamId);
+
+  // lineup의 teamName을 우선 사용, 없으면 gameTeamName으로 fallback
+  const team1Name = lineup1?.teamName ?? gameTeam1?.gameTeamName ?? '';
+  const team2Name = lineup2?.teamName ?? gameTeam2?.gameTeamName ?? '';
+
+  const leagueTeam1 = leagueTeams.find((lt) => lt.teamName === team1Name);
+  const leagueTeam2 = leagueTeams.find((lt) => lt.teamName === team2Name);
+
+  const { data: team1Players } = useSuspenseLeagueTeamsPlayers({
+    leagueTeamId: leagueTeam1?.leagueTeamId ?? 0,
+  });
+  const { data: team2Players } = useSuspenseLeagueTeamsPlayers({
+    leagueTeamId: leagueTeam2?.leagueTeamId ?? 0,
+  });
+
+  // playerId → LeagueTeamsPlayerType 매핑
+  const team1PlayerByPlayerId = useMemo(() => {
+    const map = new Map<number, LeagueTeamsPlayerType>();
+    team1Players.forEach((p) => map.set(p.playerId, p));
+    return map;
+  }, [team1Players]);
+
+  const team2PlayerByPlayerId = useMemo(() => {
+    const map = new Map<number, LeagueTeamsPlayerType>();
+    team2Players.forEach((p) => map.set(p.playerId, p));
+    return map;
+  }, [team2Players]);
+
+  // 마운트 시 lineup API 데이터로 초기 선택 상태 설정
+  const [originalTeam1Selection] = useState<PlayerSelectionState[]>(() =>
+    initializeSelection(lineup1, team1PlayerByPlayerId),
+  );
+  const [originalTeam2Selection] = useState<PlayerSelectionState[]>(() =>
+    initializeSelection(lineup2, team2PlayerByPlayerId),
+  );
+  const [team1Selection, setTeam1Selection] = useState<PlayerSelectionState[]>(() =>
+    initializeSelection(lineup1, team1PlayerByPlayerId),
+  );
+  const [team2Selection, setTeam2Selection] = useState<PlayerSelectionState[]>(() =>
+    initializeSelection(lineup2, team2PlayerByPlayerId),
+  );
+
+  const [activeTab, setActiveTab] = useState<1 | 2>(1);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const { mutateAsync: createLineup } = useCreateGameTeamsLineup();
+  const { mutateAsync: deleteLineupPlayer } = useDeleteGameTeamsLineup();
+  const { mutateAsync: patchStarter } = useUpdateGamesStarter();
+  const { mutateAsync: patchCandidate } = useUpdateGamesCandidate();
+
+  const getPlayerState = (teamNumber: 1 | 2, teamPlayerId: number) => {
+    const selection = teamNumber === 1 ? team1Selection : team2Selection;
+    return selection.find((p) => p.teamPlayerId === teamPlayerId);
+  };
+
+  const handlePlayerSelection = (
+    teamNumber: 1 | 2,
+    teamPlayerId: number,
+    newState: 'STARTER' | 'CANDIDATE',
+  ) => {
+    const setSelection = teamNumber === 1 ? setTeam1Selection : setTeam2Selection;
+    setSelection((prev) => {
+      const existing = prev.find((p) => p.teamPlayerId === teamPlayerId);
+      if (existing) {
+        if (existing.state === newState) {
+          return prev.filter((p) => p.teamPlayerId !== teamPlayerId);
+        }
+        return prev.map((p) =>
+          p.teamPlayerId === teamPlayerId
+            ? { ...p, state: newState, isCaptain: newState === 'CANDIDATE' ? false : p.isCaptain }
+            : p,
+        );
+      }
+      return [...prev, { teamPlayerId, state: newState, isCaptain: false }];
+    });
+  };
+
+  const handleCaptainSelection = (teamNumber: 1 | 2, teamPlayerId: number) => {
+    const setSelection = teamNumber === 1 ? setTeam1Selection : setTeam2Selection;
+    const currentSelection = teamNumber === 1 ? team1Selection : team2Selection;
+    const player = currentSelection.find((p) => p.teamPlayerId === teamPlayerId);
+    if (!player || player.state === 'CANDIDATE') return;
+
+    setSelection((prev) =>
+      prev.map((p) => ({
+        ...p,
+        isCaptain: p.teamPlayerId === teamPlayerId ? !p.isCaptain : false,
+      })),
+    );
+  };
+
+  const applyTeamChanges = async (
+    gameTeamId: number,
+    originalSelection: PlayerSelectionState[],
+    newSelection: PlayerSelectionState[],
+  ) => {
+    console.log('[경기 라인업 편집] applyTeamChanges 시작:', {
+      gameTeamId,
+      originalSelection,
+      newSelection,
+    });
+
+    const originalMap = new Map(originalSelection.map((p) => [p.teamPlayerId, p]));
+    const newMap = new Map(newSelection.map((p) => [p.teamPlayerId, p]));
+
+    for (const orig of originalSelection) {
+      const next = newMap.get(orig.teamPlayerId);
+
+      if (!next) {
+        // 라인업에서 제거 → DELETE
+        if (orig.lineupPlayerId !== undefined) {
+          console.log('[경기 라인업 편집] 선수 제거:', {
+            teamPlayerId: orig.teamPlayerId,
+            lineupPlayerId: orig.lineupPlayerId,
+          });
+          await deleteLineupPlayer({ gameTeamId, lineupPlayerId: orig.lineupPlayerId });
+        }
+      } else if (orig.state !== next.state && orig.isCaptain === next.isCaptain) {
+        // 선발 ↔ 후보 상태만 변경 → PATCH (lineupPlayerId 유지)
+        if (orig.lineupPlayerId !== undefined) {
+          console.log('[경기 라인업 편집] 선수 상태 변경:', {
+            teamPlayerId: orig.teamPlayerId,
+            lineupPlayerId: orig.lineupPlayerId,
+            from: orig.state,
+            to: next.state,
+          });
+          if (next.state === 'STARTER') {
+            await patchStarter({ gameId, lineupPlayerId: orig.lineupPlayerId });
+          } else {
+            await patchCandidate({ gameId, lineupPlayerId: orig.lineupPlayerId });
+          }
+        }
+      } else if (orig.state !== next.state || orig.isCaptain !== next.isCaptain) {
+        // 주장 변경 포함 → DELETE + POST (주장 변경 전용 PATCH 없음)
+        if (orig.lineupPlayerId !== undefined) {
+          console.log('[경기 라인업 편집] 주장 변경 - 선수 제거:', {
+            teamPlayerId: orig.teamPlayerId,
+            lineupPlayerId: orig.lineupPlayerId,
+          });
+          await deleteLineupPlayer({ gameTeamId, lineupPlayerId: orig.lineupPlayerId });
+        }
+        console.log('[경기 라인업 편집] 주장 변경 - 선수 추가:', {
+          teamPlayerId: next.teamPlayerId,
+          state: next.state,
+          isCaptain: next.isCaptain,
+        });
+        await createLineup({
+          gameTeamId,
+          teamPlayerId: next.teamPlayerId,
+          state: next.state,
+          isCaptain: next.isCaptain,
+        });
+      }
+      // 변경 없음 → skip
+    }
+
+    for (const next of newSelection) {
+      if (!originalMap.has(next.teamPlayerId)) {
+        // 새로 추가된 선수 → POST
+        console.log('[경기 라인업 편집] 선수 추가:', {
+          teamPlayerId: next.teamPlayerId,
+          state: next.state,
+          isCaptain: next.isCaptain,
+        });
+        await createLineup({
+          gameTeamId,
+          teamPlayerId: next.teamPlayerId,
+          state: next.state,
+          isCaptain: next.isCaptain,
+        });
+      }
+    }
+  };
+
+  const handleSaveAndNext = async () => {
+    if (!gameTeam1 || !gameTeam2) return;
+    console.log('[경기 라인업 편집] 저장 시작:', {
+      team1GameTeamId: gameTeam1.gameTeamId,
+      team2GameTeamId: gameTeam2.gameTeamId,
+    });
+    setSaving(true);
+    try {
+      console.log('[경기 라인업 편집] Team 1 라인업 적용:', {
+        gameTeamId: gameTeam1.gameTeamId,
+        originalCount: originalTeam1Selection.length,
+        newCount: team1Selection.length,
+      });
+      await applyTeamChanges(gameTeam1.gameTeamId, originalTeam1Selection, team1Selection);
+
+      console.log('[경기 라인업 편집] Team 2 라인업 적용:', {
+        gameTeamId: gameTeam2.gameTeamId,
+        originalCount: originalTeam2Selection.length,
+        newCount: team2Selection.length,
+      });
+      await applyTeamChanges(gameTeam2.gameTeamId, originalTeam2Selection, team2Selection);
+
+      console.log('[경기 라인업 편집] 라인업 저장 완료');
+      toast.success('라인업이 수정되었습니다.');
+      onNext();
+    } catch (error) {
+      console.error('[경기 라인업 편집] 라인업 수정 실패:', error);
+      toast.error('라인업 수정에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const activeTeamPlayers = activeTab === 1 ? team1Players : team2Players;
+  const activeSelection = activeTab === 1 ? team1Selection : team2Selection;
+
+  const filteredAll = useMemo(
+    () =>
+      activeTeamPlayers.filter(
+        (p) =>
+          p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          p.jerseyNumber.toString().includes(searchQuery),
+      ),
+    [activeTeamPlayers, searchQuery],
+  );
+
+  const team1Starters = team1Selection.filter((p) => p.state === 'STARTER');
+  const team2Starters = team2Selection.filter((p) => p.state === 'STARTER');
+  const team1Captain = team1Selection.find((p) => p.isCaptain);
+  const team2Captain = team2Selection.find((p) => p.isCaptain);
+
+  // 선발 / 후보 / 미등록 선수 분리
+  const starters = filteredAll.filter(
+    (p) => activeSelection.find((s) => s.teamPlayerId === p.teamPlayerId)?.state === 'STARTER',
+  );
+  const candidates = filteredAll.filter(
+    (p) => activeSelection.find((s) => s.teamPlayerId === p.teamPlayerId)?.state === 'CANDIDATE',
+  );
+  const unregistered = filteredAll.filter(
+    (p) => !activeSelection.find((s) => s.teamPlayerId === p.teamPlayerId),
+  );
+
+  const renderPlayerRow = (player: LeagueTeamsPlayerType, teamNumber: 1 | 2) => {
+    const playerState = getPlayerState(teamNumber, player.teamPlayerId);
+    return (
+      <div
+        key={player.teamPlayerId}
+        className="flex items-center justify-between rounded-lg border p-3"
+      >
+        <div className="flex items-center gap-3">
+          <span className="font-medium">#{player.jerseyNumber}</span>
+          <span>{player.name}</span>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            size="md"
+            className="px-3"
+            color={playerState?.state === 'STARTER' ? 'primary' : 'black'}
+            variant={playerState?.state === 'STARTER' ? 'solid' : 'ghost'}
+            onClick={() => handlePlayerSelection(teamNumber, player.teamPlayerId, 'STARTER')}
+          >
+            선발
+          </Button>
+          <Button
+            type="button"
+            size="md"
+            className="px-3"
+            color={playerState?.state === 'CANDIDATE' ? 'primary' : 'black'}
+            variant={playerState?.state === 'CANDIDATE' ? 'solid' : 'ghost'}
+            onClick={() => handlePlayerSelection(teamNumber, player.teamPlayerId, 'CANDIDATE')}
+          >
+            후보
+          </Button>
+          {playerState?.state === 'STARTER' && (
+            <Button
+              type="button"
+              size="md"
+              className="px-3"
+              color={playerState.isCaptain ? 'primary' : 'black'}
+              variant={playerState.isCaptain ? 'solid' : 'ghost'}
+              onClick={() => handleCaptainSelection(teamNumber, player.teamPlayerId)}
+            >
+              주장
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className={twMerge('flex h-full flex-col')}>
+      {/* 팀 탭 */}
+      <div className={twMerge('mb-4 flex border-gray-200 border-b')}>
+        {([1, 2] as const).map((tab) => {
+          const name = tab === 1 ? team1Name : team2Name;
+          const starters_ = tab === 1 ? team1Starters : team2Starters;
+          const captain_ = tab === 1 ? team1Captain : team2Captain;
+          return (
+            <button
+              key={tab}
+              type="button"
+              className={twMerge(
+                'flex-1 border-b-2 px-4 py-3 text-center font-medium transition-colors',
+                activeTab === tab
+                  ? 'border-black text-black'
+                  : 'border-transparent text-gray-500 hover:text-gray-700',
+              )}
+              onClick={() => {
+                setActiveTab(tab);
+                setSearchQuery('');
+              }}
+            >
+              <div className="flex flex-col items-center gap-1">
+                <span>{name}</span>
+                <span className="text-xs text-gray-500">
+                  선발 {starters_.length}명 · 주장 {captain_ ? '✓' : '✗'}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 검색 */}
+      <div className="mb-4">
+        <Input
+          type="text"
+          placeholder="선수 이름이나 등번호로 검색..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          size="md"
+        />
+      </div>
+
+      {/* 선수 목록 (섹션별 분리) */}
+      <div className="flex-1 space-y-4 overflow-y-auto pb-4">
+        {/* 선발 선수 */}
+        {starters.length > 0 && (
+          <section>
+            <p className="mb-2 text-sm font-medium text-gray-700">
+              선발 선수 ({starters.length}명)
+            </p>
+            <div className="space-y-2">{starters.map((p) => renderPlayerRow(p, activeTab))}</div>
+          </section>
+        )}
+
+        {/* 후보 선수 */}
+        {candidates.length > 0 && (
+          <section>
+            <p className="mb-2 text-sm font-medium text-gray-700">
+              후보 선수 ({candidates.length}명)
+            </p>
+            <div className="space-y-2">{candidates.map((p) => renderPlayerRow(p, activeTab))}</div>
+          </section>
+        )}
+
+        {/* 미등록 선수 */}
+        {unregistered.length > 0 && (
+          <section>
+            <p className="mb-2 text-sm font-medium text-gray-700">
+              미등록 선수 ({unregistered.length}명)
+            </p>
+            <div className="space-y-2">
+              {unregistered.map((p) => renderPlayerRow(p, activeTab))}
+            </div>
+          </section>
+        )}
+
+        {filteredAll.length === 0 && (
+          <p className="py-8 text-center text-sm text-gray-400">선수가 없습니다.</p>
+        )}
+      </div>
+
+      {/* 하단 버튼 */}
+      <div className={twMerge('flex-shrink-0 border-gray-200 border-t bg-white pt-4')}>
+        <div className="flex gap-3">
+          <Button
+            type="button"
+            className="flex-1"
+            size="lg"
+            color="primary"
+            variant="ghost"
+            onClick={onPrevious}
+            disabled={saving}
+          >
+            이전 단계
+          </Button>
+          <Button
+            type="button"
+            className="flex-1"
+            size="lg"
+            color="black"
+            onClick={handleSaveAndNext}
+            disabled={saving}
+          >
+            {saving ? '저장 중...' : '다음 단계'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const GameLineupEditSection = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
+  return (
+    <Suspense fallback={<Spinner className="self-center" />} clientOnly>
+      <LineupEditContent
+        gameId={gameId}
+        leagueId={leagueId}
+        onNext={onNext}
+        onPrevious={onPrevious}
+      />
+    </Suspense>
+  );
+};

--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
@@ -57,8 +57,8 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
   const { data: lineup } = useSuspenseGameLineup({ gameId });
   const { data: leagueTeams } = useSuspenseLeagueTeams({ leagueId });
 
-  const gameTeam1 = game.gameTeams[0];
-  const gameTeam2 = game.gameTeams[1];
+  const gameTeam1 = game.gameTeams?.[0];
+  const gameTeam2 = game.gameTeams?.[1];
 
   // gameTeamId로 lineup 매칭 (가장 신뢰할 수 있는 방법)
   const lineup1 = lineup.find((l) => l.gameTeamId === gameTeam1?.gameTeamId);

--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
@@ -9,6 +9,8 @@ import {
   useCreateGameTeamsLineup,
   useDeleteGameTeamsLineup,
   useUpdateGamesCandidate,
+  useUpdateGamesCaptainRegister,
+  useUpdateGamesCaptainRevoke,
   useUpdateGamesStarter,
   useSuspenseGame,
   useSuspenseGameLineup,
@@ -113,6 +115,8 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
   const { mutateAsync: deleteLineupPlayer } = useDeleteGameTeamsLineup();
   const { mutateAsync: patchStarter } = useUpdateGamesStarter();
   const { mutateAsync: patchCandidate } = useUpdateGamesCandidate();
+  const { mutateAsync: patchCaptainRegister } = useUpdateGamesCaptainRegister();
+  const { mutateAsync: patchCaptainRevoke } = useUpdateGamesCaptainRevoke();
 
   const getPlayerState = (teamNumber: 1 | 2, teamPlayerId: number) => {
     const selection = teamNumber === 1 ? team1Selection : team2Selection;
@@ -172,7 +176,7 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
           await deleteLineupPlayer({ gameTeamId, lineupPlayerId: orig.lineupPlayerId });
         }
       } else if (orig.state !== next.state && orig.isCaptain === next.isCaptain) {
-        // 선발 ↔ 후보 상태만 변경 → PATCH (lineupPlayerId 유지)
+        // 선발 ↔ 후보 상태만 변경 → PATCH starter/candidate
         if (orig.lineupPlayerId !== undefined) {
           if (next.state === 'STARTER') {
             await patchStarter({ gameId, lineupPlayerId: orig.lineupPlayerId });
@@ -180,8 +184,17 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
             await patchCandidate({ gameId, lineupPlayerId: orig.lineupPlayerId });
           }
         }
-      } else if (orig.state !== next.state || orig.isCaptain !== next.isCaptain) {
-        // 주장 변경 포함 → DELETE + POST (주장 변경 전용 PATCH 없음)
+      } else if (orig.state === next.state && orig.isCaptain !== next.isCaptain) {
+        // 주장만 변경 → PATCH captain/register or revoke
+        if (orig.lineupPlayerId !== undefined) {
+          if (next.isCaptain) {
+            await patchCaptainRegister({ gameId, lineupPlayerId: orig.lineupPlayerId });
+          } else {
+            await patchCaptainRevoke({ gameId, lineupPlayerId: orig.lineupPlayerId });
+          }
+        }
+      } else if (orig.state !== next.state && orig.isCaptain !== next.isCaptain) {
+        // 상태 + 주장 동시 변경 → DELETE + POST
         if (orig.lineupPlayerId !== undefined) {
           await deleteLineupPlayer({ gameTeamId, lineupPlayerId: orig.lineupPlayerId });
         }

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/AddScoreSheet.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/AddScoreSheet.tsx
@@ -67,7 +67,7 @@ export default function AddScoreSheet({
 
     return selectedTeam.gameTeamPlayers.map((p) => ({
       label: `${p.jerseyNumber} ${p.playerName}`,
-      value: String(p.id),
+      value: String(p.lineupPlayerId),
     }));
   }, [lineup, team]);
 

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/SubstituteSheet.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/SubstituteSheet.tsx
@@ -58,7 +58,7 @@ export default function SubstituteSheet({
       .filter((p) => p.state === 'CANDIDATE') // 후보 선수만 필터링
       .map((p) => ({
         label: `${p.jerseyNumber} ${p.playerName}`,
-        value: String(p.id),
+        value: String(p.lineupPlayerId),
       }));
   }, [lineup, team]);
 
@@ -71,7 +71,7 @@ export default function SubstituteSheet({
       .filter((p) => p.state === 'STARTER') // 주전 선수만 필터링
       .map((p) => ({
         label: `${p.jerseyNumber} ${p.playerName}`,
-        value: String(p.id),
+        value: String(p.lineupPlayerId),
       }));
   }, [lineup, team]);
   const isFormValid = quarter && team && playerOut && playerIn && minute;

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/WarningSheet.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/WarningSheet.tsx
@@ -63,7 +63,7 @@ export default function WarningSheet({ gameId, onClose }: { gameId: number; onCl
 
     return selectedTeam.gameTeamPlayers.map((p) => ({
       label: `${p.jerseyNumber} ${p.playerName}`,
-      value: String(p.id),
+      value: String(p.lineupPlayerId),
     }));
   }, [lineup, team]);
   const isFormValid = quarter && team && player && card && minute;

--- a/apps/manager/src/app/(private)/leagues/_components/league-overview.tsx
+++ b/apps/manager/src/app/(private)/leagues/_components/league-overview.tsx
@@ -64,7 +64,7 @@ export const LeagueOverview = () => {
           </Link>
 
           <div className="row-between mt-4 gap-2.5">
-            <Button
+            {/* <Button
               className="flex-1"
               size="sm"
               color="black"
@@ -72,7 +72,7 @@ export const LeagueOverview = () => {
               onClick={() => router.push(`/${routes.teams}`)}
             >
               참가 팀 관리
-            </Button>
+            </Button> */}
             <Button
               className="flex-1"
               size="sm"

--- a/apps/manager/src/app/(private)/leagues/_components/league-overview.tsx
+++ b/apps/manager/src/app/(private)/leagues/_components/league-overview.tsx
@@ -16,47 +16,52 @@ export const LeagueOverview = () => {
   return (
     <Fragment>
       {data.map((league) => (
-        <Link href={`/${routes.league(league.id)}`} key={league.id} className="w-full bg-white p-5">
-          <div className="row-between w-full bg-white">
-            <div className="center-y gap-1.5">
-              <Badge size="sm" variant={league.leagueProgress === '진행 중' ? 'danger' : 'default'}>
-                {league.leagueProgress}
-              </Badge>
-              <Typography weight="semibold">{league.name}</Typography>
+        <div key={league.id} className="w-full bg-white p-5">
+          <Link href={`/${routes.league(league.id)}`} className="block">
+            <div className="row-between w-full bg-white">
+              <div className="center-y gap-1.5">
+                <Badge
+                  size="sm"
+                  variant={league.leagueProgress === '진행 중' ? 'danger' : 'default'}
+                >
+                  {league.leagueProgress}
+                </Badge>
+                <Typography weight="semibold">{league.name}</Typography>
+              </div>
+              <div className="center">
+                <ChevronForwardIcon size={24} />
+              </div>
             </div>
-            <div className="center">
-              <ChevronForwardIcon size={24} />
+
+            <hr className="my-4 h-[1px] w-full border-none bg-neutral-100" />
+
+            <div className="column w-full gap-2.5">
+              <Typography
+                color="var(--color-neutral-500)"
+                fontSize={14}
+                weight="medium"
+                lineHeight="none"
+              >
+                <strong>참여</strong> {league.sizeOfLeagueTeams}개 팀
+              </Typography>
+              <Typography
+                color="var(--color-neutral-500)"
+                fontSize={14}
+                weight="medium"
+                lineHeight="none"
+              >
+                <strong>라운드</strong> {league.maxRound}강
+              </Typography>
+              <Typography
+                color="var(--color-neutral-500)"
+                fontSize={14}
+                weight="medium"
+                lineHeight="none"
+              >
+                <strong>기간</strong> {formatTime(league.startAt)} - {formatTime(league.endAt)}
+              </Typography>
             </div>
-          </div>
-
-          <hr className="my-4 h-[1px] w-full border-none bg-neutral-100" />
-
-          <div className="column w-full gap-2.5">
-            <Typography
-              color="var(--color-neutral-500)"
-              fontSize={14}
-              weight="medium"
-              lineHeight="none"
-            >
-              <strong>참여</strong> {league.sizeOfLeagueTeams}개 팀
-            </Typography>
-            <Typography
-              color="var(--color-neutral-500)"
-              fontSize={14}
-              weight="medium"
-              lineHeight="none"
-            >
-              <strong>라운드</strong> {league.maxRound}강
-            </Typography>
-            <Typography
-              color="var(--color-neutral-500)"
-              fontSize={14}
-              weight="medium"
-              lineHeight="none"
-            >
-              <strong>기간</strong> {formatTime(league.startAt)} - {formatTime(league.endAt)}
-            </Typography>
-          </div>
+          </Link>
 
           <div className="row-between mt-4 gap-2.5">
             <Button
@@ -64,10 +69,7 @@ export const LeagueOverview = () => {
               size="sm"
               color="black"
               variant="subtle"
-              onClick={(e) => {
-                e.stopPropagation();
-                router.push(`/${routes.teams}`);
-              }}
+              onClick={() => router.push(`/${routes.teams}`)}
             >
               참가 팀 관리
             </Button>
@@ -76,15 +78,12 @@ export const LeagueOverview = () => {
               size="sm"
               color="black"
               variant="subtle"
-              onClick={(e) => {
-                e.stopPropagation();
-                router.push(`/${routes.cheertalks}`);
-              }}
+              onClick={() => router.push(`/${routes.cheertalks}`)}
             >
               응원톡 관리
             </Button>
           </div>
-        </Link>
+        </div>
       ))}
     </Fragment>
   );

--- a/apps/manager/src/app/(private)/teams/_components/assistants/registration-ui.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/assistants/registration-ui.tsx
@@ -116,6 +116,7 @@ const ParseResultCard = ({
 
   const displayPlayers = isEditing ? editedPlayers : players;
   const hasError = players.some((p) => p.error);
+  const hasMissingJerseyNumber = players.some((p) => p.jerseyNumber == null);
 
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4">
@@ -194,7 +195,7 @@ const ParseResultCard = ({
       </table>
 
       {/* 에러 표시 */}
-      {displayPlayers.some((p) => p.error) && (
+      {(displayPlayers.some((p) => p.error) || hasMissingJerseyNumber) && (
         <ul className="flex flex-col gap-1">
           {displayPlayers
             .filter((p) => p.error)
@@ -203,6 +204,11 @@ const ParseResultCard = ({
                 {p.error}
               </li>
             ))}
+          {hasMissingJerseyNumber && (
+            <li className="text-xs text-red-500">
+              등번호가 없는 선수가 있습니다. 등록할 수 없습니다.
+            </li>
+          )}
         </ul>
       )}
 
@@ -252,7 +258,7 @@ const ParseResultCard = ({
           >
             수정
           </Button>
-          {!hasError && (
+          {!hasError && !hasMissingJerseyNumber && (
             <Button
               onClick={() => onConfirm?.(players.map((p) => ({ studentNumber: p.studentNumber })))}
               className="bg-primary flex-1 rounded px-3 py-2 text-sm text-white hover:opacity-90"

--- a/apps/manager/src/app/(private)/teams/_components/team-players-step.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/team-players-step.tsx
@@ -26,7 +26,15 @@ export const TeamPlayersStep = ({ onPrevious }: Props) => {
 
   const teamPlayers = watch('teamPlayers') || [];
 
-  const isValid = teamPlayers.length > 0;
+  const isValid =
+    teamPlayers.length > 0 &&
+    teamPlayers.every(
+      (player) =>
+        !!player.name?.trim() &&
+        !!player.studentNumber?.trim() &&
+        player.jerseyNumber !== undefined &&
+        player.jerseyNumber !== null,
+    );
 
   const handleAppendPlayer = (id: number) => {
     if (teamPlayers.find((player) => player.playerId === id)) {
@@ -34,7 +42,14 @@ export const TeamPlayersStep = ({ onPrevious }: Props) => {
       return;
     }
 
-    append({ playerId: id, jerseyNumber: 0 });
+    const selectedPlayer = data?.find((player) => player.playerId === id);
+
+    append({
+      playerId: id,
+      name: selectedPlayer?.name ?? '',
+      studentNumber: selectedPlayer?.studentNumber ?? '',
+      jerseyNumber: 0,
+    });
   };
 
   return (
@@ -57,22 +72,38 @@ export const TeamPlayersStep = ({ onPrevious }: Props) => {
         {fields.map((field, index) => (
           <div key={field.id} className="center-y gap-3">
             <div className="center-y flex-1 gap-3">
-              <Input
-                size="lg"
-                placeholder="선수 이름"
-                value={data.find((player) => player.playerId === field.playerId)?.name ?? '-'}
-                disabled
-                readOnly
+              <Controller
+                name={`teamPlayers.${index}.name`}
+                control={control}
+                render={({ field: f }) => (
+                  <Input
+                    {...f}
+                    size="lg"
+                    placeholder="선수 이름"
+                    value={
+                      f.value ??
+                      data.find((player) => player.playerId === field.playerId)?.name ??
+                      '-'
+                    }
+                  />
+                )}
               />
 
-              <Input
-                size="lg"
-                placeholder="학번"
-                value={
-                  data.find((player) => player.playerId === field.playerId)?.studentNumber ?? '-'
-                }
-                disabled
-                readOnly
+              <Controller
+                name={`teamPlayers.${index}.studentNumber`}
+                control={control}
+                render={({ field: f }) => (
+                  <Input
+                    {...f}
+                    size="lg"
+                    placeholder="학번"
+                    value={
+                      f.value ??
+                      data.find((player) => player.playerId === field.playerId)?.studentNumber ??
+                      '-'
+                    }
+                  />
+                )}
               />
 
               <Controller

--- a/packages/api-base/src/fetcher.ts
+++ b/packages/api-base/src/fetcher.ts
@@ -16,17 +16,27 @@ export const instance = ky.create({
   hooks: {
     afterResponse: [
       async (request, _, response) => {
-        if (!response.ok && response.status === 401) {
-          if (request.url.includes('logout')) return response;
+        if (!response.ok) {
+          if (response.status === 401) {
+            if (request.url.includes('logout')) return response;
 
-          const currentPath = window.location.pathname;
+            const currentPath = window.location.pathname;
 
-          const isInternalNavigation = document?.referrer?.includes(window.location.host);
-          if (currentPath !== '/' || isInternalNavigation) {
-            alert('로그인이 만료되었어요. 다시 로그인해주세요.');
+            const isInternalNavigation = document?.referrer?.includes(window.location.host);
+            if (currentPath !== '/' || isInternalNavigation) {
+              alert('로그인이 만료되었어요. 다시 로그인해주세요.');
+            }
+            window.location.href = '/auth/login';
+            return response;
           }
-          window.location.href = '/auth/login';
-          return response;
+
+          try {
+            const cloned = response.clone();
+            const body = await cloned.json().catch(() => cloned.text());
+            console.error(`[API Error] ${response.status} ${request.method} ${request.url}`, body);
+          } catch {
+            console.error(`[API Error] ${response.status} ${request.method} ${request.url}`);
+          }
         }
         return response;
       },


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 팀 정보 수정 시 이름, 학번, 등번호 모두 수정 가능하도록 변경
- 경기 생성 > 경기 정보 수정 UI 및 기능 추가
  - `useCreateGameTeamsLineup` 라인업 선수 추가
  - `useDeleteGameTeamsLineup` 라인업 선수 삭제
  - `useUpdateGamesCandidate,` `useUpdateGamesStarter` 라인업 후보, 선발 변경
  -   `useUpdateGamesCaptainRegister` , `useUpdateGamesCaptainRevoke` 주장 등록, 해제 
- 대회 관리 >참가팀 관리, 응원톡 관리 라우팅 오류 수정 
  - 참가팀 관리는 우선 버튼 가림


## 추가로 해야할 일
**리팩토링 필수.. 🔥** 