### PR TITLE
feat: 종료된 경기의 상태 변경 시 실패 알럿 추가

### DIFF
--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/StatusChangeSheet.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/StatusChangeSheet.tsx
@@ -20,8 +20,8 @@ type ErrorResponseBody = {
 const getErrorMessage = async (error: unknown) => {
   if (!error || typeof error !== 'object' || !('response' in error)) return null;
 
-  const response = (error as { response?: Response }).response;
-  if (!response) return null;
+  const { response } = error as { response: unknown };
+  if (!(response instanceof Response)) return null;
 
   try {
     const contentType = response.headers.get('content-type') ?? '';

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/StatusChangeSheet.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/StatusChangeSheet.tsx
@@ -12,6 +12,30 @@ import { InputSelect } from '~/components/ui/input-select';
 type SelectOption = { label: string; value: string };
 
 type LabelType<T, K extends keyof T> = Pick<Record<keyof T, string>, K>;
+type ErrorResponseBody = {
+  message?: string;
+  error?: string;
+};
+
+const getErrorMessage = async (error: unknown) => {
+  if (!error || typeof error !== 'object' || !('response' in error)) return null;
+
+  const response = (error as { response?: Response }).response;
+  if (!response) return null;
+
+  try {
+    const contentType = response.headers.get('content-type') ?? '';
+    if (contentType.includes('application/json') || contentType.includes('+json')) {
+      const data = (await response.clone().json()) as ErrorResponseBody;
+      return data.message ?? data.error ?? null;
+    }
+
+    const text = await response.clone().text();
+    return text || null;
+  } catch {
+    return null;
+  }
+};
 
 const QUARTER_LABELS: LabelType<
   typeof QUARTER_TYPE,
@@ -75,9 +99,9 @@ export default function StatusChangeSheet({
         toast.success('상태 변경이 등록되었습니다.');
         onClose();
       },
-      onError: (error) => {
-        console.log(error);
-        toast.error('상태 변경 등록에 실패했습니다. 다시 시도해주세요.');
+      onError: async (error) => {
+        const serverMessage = await getErrorMessage(error);
+        toast.error(serverMessage ?? '상태 변경 등록에 실패했습니다. 다시 시도해주세요.');
       },
     });
   };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 이미 종료된 경기의 상태를 변경하려 할 때 서버에서 에러를 반환합니다.
- 해당 에러 객체에는 message가 들어 있어서, 그걸 보여줍니다.
- 그리고 만약 message가 없다면 fallback message를 반환합니다.

## 📝 참고 자료


https://github.com/user-attachments/assets/0158ba28-d8cc-445d-9529-d6817068c3c8



## ♾️ 기타

- 추가로 필요한 작업 내용
