### PR TITLE
fix: 최근 경기 페이지 게임 목록 수정

### DIFF
--- a/apps/spectator/src/api/queries/useLeagueRecentGames.ts
+++ b/apps/spectator/src/api/queries/useLeagueRecentGames.ts
@@ -1,0 +1,10 @@
+import { getQueryClient, useQuery, useSuspenseQuery } from '@hcc/api-base';
+
+import { queryKeys } from '../queryKey';
+
+export const useLeagueRecentGame = () => useQuery(queryKeys.leagues.recentGames());
+
+export const useSuspenseLeagueRecentGames = () => useSuspenseQuery(queryKeys.leagues.recentGames());
+
+export const fetchLeagueRecentGames = async () =>
+  await getQueryClient().fetchQuery(queryKeys.leagues.recentGames());

--- a/apps/spectator/src/api/queryKey.ts
+++ b/apps/spectator/src/api/queryKey.ts
@@ -140,6 +140,10 @@ const leagueQueryKeys = createQueryKeys('leagues', {
     queryKey: [payload],
     queryFn: () => fetcher.get<LeagueDetailType>(`leagues/${payload.leagueId}`),
   }),
+  recentGames: () => ({
+    queryKey: ['recent-games'],
+    queryFn: () => fetcher.get<GameListResponse[]>(`leagues/recent/games`),
+  }),
   recentSummary: (payload?: LeagueRecentSummaryPayload) => ({
     queryKey: [payload],
     queryFn: () =>

--- a/apps/spectator/src/api/types/games.ts
+++ b/apps/spectator/src/api/types/games.ts
@@ -35,11 +35,13 @@ export type GameListPayload = {
 
 export type GameListType = {
   id: number;
+  gameState: GameStateType;
 } & GameData;
 
 export type GameListResponse = {
   leagueId: number;
   leagueName: string;
+  leagueProgress: 'BEFORE_START' | 'IN_PROGRESS' | 'FINISHED';
   games: GameListType[];
 };
 

--- a/apps/spectator/src/api/types/leagues.ts
+++ b/apps/spectator/src/api/types/leagues.ts
@@ -9,10 +9,10 @@ export type LeagueType = {
 };
 
 export type LeagueListPayload = {
-  year: number;
+  year?: number;
   leagueProgress?: 'BEFORE_START' | 'IN_PROGRESS' | 'FINISHED';
   cursor?: number;
-  size: number;
+  size?: number;
 };
 
 export type LeagueDetailPayload = {

--- a/apps/spectator/src/app/(home)/_components/tab.tsx
+++ b/apps/spectator/src/app/(home)/_components/tab.tsx
@@ -9,22 +9,41 @@ import { Fragment } from 'react';
 
 import type { GameListType, LeagueCheerCountType } from '~/api';
 
-import { useSuspenseGames } from '~/api';
 import { useSuspenseLeagueCheerCount } from '~/api/queries/useLeagueCheerCount';
+import { useSuspenseLeagueRecentGames } from '~/api/queries/useLeagueRecentGames';
 import { GameCard } from '~/components/ui';
 import { routes } from '~/constants/routes';
 import { useTracker } from '~/hooks/useTracker';
 
 export const RecentTab = () => {
-  const { data: playing } = useSuspenseGames({ state: 'PLAYING', size: 20 });
-  const { data: finished } = useSuspenseGames({ state: 'FINISHED', size: 9999 });
+  const { data: recentGames } = useSuspenseLeagueRecentGames();
+  const displayedGame = recentGames.at(0);
+  // const { data: scheduled } = useSuspenseGames({ state: 'SCHEDULED', size: 99999999 });
+  // const { data: playing } = useSuspenseGames({ state: 'PLAYING', size: 99999999 });
+  // const { data: finished } = useSuspenseGames({ state: 'FINISHED', size: 99999999 });
 
-  const hasPlayingGames = playing.length !== 0;
-  const recentFinished = finished.sort((a, b) => a.leagueId - b.leagueId).at(-1);
-  const displayedGame = hasPlayingGames ? playing.at(-1) : recentFinished;
-  const buttonLabel = hasPlayingGames ? '응원하러 가기' : '지난 경기 보러가기';
+  // // const { data: scheduledLeague } = useSuspenseLeagues({});
+  // // const { data: playingLeague } = useSuspenseLeagues({});
+  // // const { data: finishedLeague } = useSuspenseLeagues({});
+
+  // // console.log('scheduledLeague', scheduledLeague);
+  // // console.log('playingLeague', playingLeague);
+  // // console.log('finishedLeague', finishedLeague);
+
+  // console.log('scheduled', scheduled);
+  // console.log('playing', playing);
+  // // console.log('finished', finished.sort((a, b) => a.leagueId - b.leagueId).at(-1));
+  // console.log('finished', finished);
+
+  // const hasPlayingGames = playing.length !== 0;
+  // // const recentFinished = finished.sort((a, b) => a.leagueId - b.leagueId).at(-1);
+  // // const displayedGame = hasPlayingGames ? playing.at(-1) : recentFinished;
+  // const displayedGame = getDisplayGame({ playing, scheduled, finished });
 
   if (!displayedGame) return null;
+
+  const hasPlayingGames = displayedGame.games.some((game) => game.state === 'PLAYING');
+  const buttonLabel = hasPlayingGames ? '응원하러 가기' : '지난 경기 보러가기';
 
   const { data: cheerCount } = useSuspenseLeagueCheerCount(
     { leagueId: displayedGame?.leagueId },
@@ -102,20 +121,21 @@ const GameList = ({ leagueId, leagueName, games, cheerCount, buttonLabel }: Game
               </GameCard.Container>
             </GameCard>
             {index !== games.length - 1 && <GameCard.Divider />}
-
-            <Button
-              asChild
-              variant="ghost"
-              size="sm"
-              color="primary"
-              className="gap"
-              onClick={() => sendEvent({ action: 'click', value: buttonLabel })}
-            >
-              <Link href={{ pathname: `/games/${game.id}`, query: { tab: 'cheer' } }}>
-                {buttonLabel}
-                <ChevronForwardIcon className="animate-[arrow_1s_ease-in-out_infinite] " />
-              </Link>
-            </Button>
+            {index === 0 && (
+              <Button
+                asChild
+                variant="ghost"
+                size="sm"
+                color="primary"
+                className="gap"
+                onClick={() => sendEvent({ action: 'click', value: buttonLabel })}
+              >
+                <Link href={{ pathname: `/games/${game.id}`, query: { tab: 'cheer' } }}>
+                  {buttonLabel}
+                  <ChevronForwardIcon className="animate-[arrow_1s_ease-in-out_infinite] " />
+                </Link>
+              </Button>
+            )}
           </Fragment>
         );
       })}

--- a/apps/spectator/src/app/(home)/_components/tab.tsx
+++ b/apps/spectator/src/app/(home)/_components/tab.tsx
@@ -21,8 +21,12 @@ export const RecentTab = () => {
 
   if (!displayedGame) return null;
 
-  const hasPlayingGames = displayedGame.games.some((game) => game.state === 'PLAYING');
+  const hasPlayingGames = displayedGame.games.some((game) => game.gameState === 'PLAYING');
   const buttonLabel = hasPlayingGames ? '응원하러 가기' : '지난 경기 보러가기';
+
+  const sortedGames = [...displayedGame.games].sort(
+    (a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime(),
+  );
 
   const { data: cheerCount } = useSuspenseLeagueCheerCount(
     { leagueId: displayedGame?.leagueId },
@@ -35,7 +39,7 @@ export const RecentTab = () => {
         cheerCount={cheerCount.cheerTalkCount}
         leagueId={displayedGame.leagueId}
         leagueName={displayedGame.leagueName}
-        games={displayedGame.games}
+        games={sortedGames}
         buttonLabel={buttonLabel}
       />
     </div>

--- a/apps/spectator/src/app/(home)/_components/tab.tsx
+++ b/apps/spectator/src/app/(home)/_components/tab.tsx
@@ -18,27 +18,6 @@ import { useTracker } from '~/hooks/useTracker';
 export const RecentTab = () => {
   const { data: recentGames } = useSuspenseLeagueRecentGames();
   const displayedGame = recentGames.at(0);
-  // const { data: scheduled } = useSuspenseGames({ state: 'SCHEDULED', size: 99999999 });
-  // const { data: playing } = useSuspenseGames({ state: 'PLAYING', size: 99999999 });
-  // const { data: finished } = useSuspenseGames({ state: 'FINISHED', size: 99999999 });
-
-  // // const { data: scheduledLeague } = useSuspenseLeagues({});
-  // // const { data: playingLeague } = useSuspenseLeagues({});
-  // // const { data: finishedLeague } = useSuspenseLeagues({});
-
-  // // console.log('scheduledLeague', scheduledLeague);
-  // // console.log('playingLeague', playingLeague);
-  // // console.log('finishedLeague', finishedLeague);
-
-  // console.log('scheduled', scheduled);
-  // console.log('playing', playing);
-  // // console.log('finished', finished.sort((a, b) => a.leagueId - b.leagueId).at(-1));
-  // console.log('finished', finished);
-
-  // const hasPlayingGames = playing.length !== 0;
-  // // const recentFinished = finished.sort((a, b) => a.leagueId - b.leagueId).at(-1);
-  // // const displayedGame = hasPlayingGames ? playing.at(-1) : recentFinished;
-  // const displayedGame = getDisplayGame({ playing, scheduled, finished });
 
   if (!displayedGame) return null;
 
@@ -51,17 +30,15 @@ export const RecentTab = () => {
   );
 
   return (
-    <>
-      <div className="flex flex-1 flex-col gap-3">
-        <GameList
-          cheerCount={cheerCount.cheerTalkCount}
-          leagueId={displayedGame.leagueId}
-          leagueName={displayedGame.leagueName}
-          games={displayedGame.games}
-          buttonLabel={buttonLabel}
-        />
-      </div>
-    </>
+    <div className="flex flex-1 flex-col gap-3">
+      <GameList
+        cheerCount={cheerCount.cheerTalkCount}
+        leagueId={displayedGame.leagueId}
+        leagueName={displayedGame.leagueName}
+        games={displayedGame.games}
+        buttonLabel={buttonLabel}
+      />
+    </div>
   );
 };
 

--- a/apps/spectator/src/app/leagues/[id]/_components/game-list.tsx
+++ b/apps/spectator/src/app/leagues/[id]/_components/game-list.tsx
@@ -29,8 +29,11 @@ const GameListContent = ({
   });
   const router = useRouter();
 
-  return data.map((league) =>
-    league.games.map((game, index) => {
+  return data.map((league) => {
+    const sortedGames = [...league.games].sort(
+      (a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime(),
+    );
+    return sortedGames.map((game, index) => {
       if (game.gameTeams.length < 2) return null;
 
       return (
@@ -54,11 +57,11 @@ const GameListContent = ({
               </div>
             </GameCard.Container>
           </GameCard>
-          {index !== league.games.length - 1 && <GameCard.Divider />}
+          {index !== sortedGames.length - 1 && <GameCard.Divider />}
         </Fragment>
       );
-    }),
-  );
+    });
+  });
 };
 
 export const GameList = (props: Props) => {

--- a/apps/spectator/src/app/teams/[id]/_components/team-info.tsx
+++ b/apps/spectator/src/app/teams/[id]/_components/team-info.tsx
@@ -27,7 +27,7 @@ export const TeamInfo = ({ id }: { id: number }) => {
           <TeamCard.Content>
             {games.map((game) => {
               const { gameId, state } = game;
-              const gameWithId = { ...game, id };
+              const gameWithId = { ...game, id, gameState: state };
 
               return (
                 <GameCard key={gameId} game={gameWithId}>


### PR DESCRIPTION
## ✅ 작업 내용

- 최근 경기 API 추가
- 근데 지금 최근 경기 API에서 게임들의 종료 여부랑 최근 경기의 종료 여부가 안나와서, 아래 이미지에서처럼 무조건 `지난 경기 보러가기` 라는 이름으로 버튼이 추가됨
- 원래는 경기가 진행 중이거나 예정되어 있는 상태라면 `응원하러 가기`라고 해야 함

<img width="590" height="548" alt="image" src="https://github.com/user-attachments/assets/4e74a656-79ce-4d1f-9903-092f2320c04e" />

- 백엔드 작업이 필요해서 일단 추가하도록 하겠음당

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
