### PR TITLE
fix: 엔터 폼 제출 제한 및 팀 등록시 이미지 등록 관련 메시지 추가

### DIFF
--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/form-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/form-section.tsx
@@ -218,6 +218,9 @@ const FormSectionInner = ({ leagueId, gameId }: Props) => {
       <form
         className="flex h-full w-full flex-col bg-white p-4"
         onSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') e.preventDefault();
+        }}
       >
         <StepProgress
           currentStep={step}

--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/form-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/form-section.tsx
@@ -141,9 +141,10 @@ const GameEditBasicStep = ({ leagueId, onNext }: BasicStepProps) => {
 // ── Step 2: 경기 영상 ──────────────────────────────────────────────────────
 type VideoStepProps = {
   onPrevious: () => void;
+  onSubmit: () => void;
 };
 
-const GameEditVideoStep = ({ onPrevious }: VideoStepProps) => {
+const GameEditVideoStep = ({ onPrevious, onSubmit }: VideoStepProps) => {
   const { register } = useFormContext<GameUpdateFormType>();
 
   return (
@@ -168,7 +169,7 @@ const GameEditVideoStep = ({ onPrevious }: VideoStepProps) => {
           >
             이전 단계
           </Button>
-          <Button type="submit" className="flex-1" size="lg" color="black">
+          <Button type="button" className="flex-1" size="lg" color="black" onClick={onSubmit}>
             경기 수정
           </Button>
         </div>
@@ -217,10 +218,7 @@ const FormSectionInner = ({ leagueId, gameId }: Props) => {
     <FormProvider {...form}>
       <form
         className="flex h-full w-full flex-col bg-white p-4"
-        onSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') e.preventDefault();
-        }}
+        onSubmit={(e) => e.preventDefault()}
       >
         <StepProgress
           currentStep={step}
@@ -244,7 +242,12 @@ const FormSectionInner = ({ leagueId, gameId }: Props) => {
             />
           )}
 
-          {step === 2 && <GameEditVideoStep onPrevious={() => setStep(1)} />}
+          {step === 2 && (
+            <GameEditVideoStep
+              onPrevious={() => setStep(1)}
+              onSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
+            />
+          )}
         </div>
       </form>
     </FormProvider>

--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/form-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/form-section.tsx
@@ -198,6 +198,15 @@ const FormSectionInner = ({ leagueId, gameId }: Props) => {
   const { mutate } = useUpdateGames();
 
   const handleFormSubmit = (formData: GameUpdateFormType) => {
+    if (step !== 2) {
+      toast.warning('모든 단계를 완료해야 경기 수정이 가능해요');
+      return;
+    }
+    if (!form.formState.isValid) {
+      toast.error('입력값을 확인해주세요. 모든 단계의 입력값이 유효해야 해요.');
+      return;
+    }
+
     mutate(
       { ...formData, leagueId, gameId },
       {
@@ -218,9 +227,6 @@ const FormSectionInner = ({ leagueId, gameId }: Props) => {
       <form
         className="flex h-full w-full flex-col bg-white p-4"
         onSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') e.preventDefault();
-        }}
       >
         <StepProgress
           currentStep={step}

--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
@@ -245,7 +245,7 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
       activeTeamPlayers.filter(
         (p) =>
           p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          p.jerseyNumber.toString().includes(searchQuery),
+          p.jerseyNumber?.toString().includes(searchQuery),
       ),
     [activeTeamPlayers, searchQuery],
   );

--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
@@ -356,9 +356,6 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
           placeholder="선수 이름이나 등번호로 검색..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') e.preventDefault();
-          }}
           size="md"
         />
       </div>

--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/game-lineup-edit-section.tsx
@@ -356,6 +356,9 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
           placeholder="선수 이름이나 등번호로 검색..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') e.preventDefault();
+          }}
           size="md"
         />
       </div>

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
@@ -266,9 +266,6 @@ export const GameLineupStep = ({ leagueId, onNext, onPrevious }: Props) => {
           placeholder="선수 이름이나 등번호로 검색..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') e.preventDefault();
-          }}
           size="md"
         />
       </div>

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
@@ -150,7 +150,7 @@ export const GameLineupStep = ({ leagueId, onNext, onPrevious }: Props) => {
     return currentPlayers.filter(
       (player) =>
         player.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        player.jerseyNumber.toString().includes(searchQuery),
+        player.jerseyNumber?.toString().includes(searchQuery),
     );
   }, [activeTab, team1Players, team2Players, searchQuery]);
 
@@ -266,9 +266,6 @@ export const GameLineupStep = ({ leagueId, onNext, onPrevious }: Props) => {
           placeholder="선수 이름이나 등번호로 검색..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') e.preventDefault();
-          }}
           size="md"
         />
       </div>

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
@@ -266,6 +266,9 @@ export const GameLineupStep = ({ leagueId, onNext, onPrevious }: Props) => {
           placeholder="선수 이름이나 등번호로 검색..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') e.preventDefault();
+          }}
           size="md"
         />
       </div>

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
@@ -147,14 +147,12 @@ export const GameLineupStep = ({ leagueId, onNext, onPrevious }: Props) => {
     const currentPlayers = activeTab === 1 ? team1Players : team2Players;
     if (!currentPlayers) return [];
 
-    return currentPlayers.filter((player) => {
-      const playerName = getPlayerName(player.playerId).toLowerCase();
-      return (
-        playerName.includes(searchQuery.toLowerCase()) ||
-        player.jerseyNumber.toString().includes(searchQuery)
-      );
-    });
-  }, [activeTab, team1Players, team2Players, searchQuery, getPlayerName]);
+    return currentPlayers.filter(
+      (player) =>
+        player.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        player.jerseyNumber.toString().includes(searchQuery),
+    );
+  }, [activeTab, team1Players, team2Players, searchQuery]);
 
   const renderPlayerList = (teamNumber: 1 | 2) => {
     const playersData = teamNumber === 1 ? team1Players : team2Players;
@@ -268,6 +266,9 @@ export const GameLineupStep = ({ leagueId, onNext, onPrevious }: Props) => {
           placeholder="선수 이름이나 등번호로 검색..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') e.preventDefault();
+          }}
           size="md"
         />
       </div>

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-video-step.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-video-step.tsx
@@ -5,9 +5,10 @@ import type { GameFormType } from '~/api';
 
 type Props = {
   onPrevious: () => void;
+  onSubmit: () => void;
 };
 
-export const GameVideoStep = ({ onPrevious }: Props) => {
+export const GameVideoStep = ({ onPrevious, onSubmit }: Props) => {
   const { register } = useFormContext<GameFormType>();
 
   return (
@@ -24,7 +25,7 @@ export const GameVideoStep = ({ onPrevious }: Props) => {
         <Button type="button" onClick={onPrevious} variant="subtle" color="black" size="lg">
           이전 단계
         </Button>
-        <Button type="submit" size="lg" color="black">
+        <Button type="button" size="lg" color="black" onClick={onSubmit}>
           완료
         </Button>
       </div>

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-video-step.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-video-step.tsx
@@ -5,10 +5,9 @@ import type { GameFormType } from '~/api';
 
 type Props = {
   onPrevious: () => void;
-  onSubmit: () => void;
 };
 
-export const GameVideoStep = ({ onPrevious, onSubmit }: Props) => {
+export const GameVideoStep = ({ onPrevious }: Props) => {
   const { register } = useFormContext<GameFormType>();
 
   return (
@@ -25,7 +24,7 @@ export const GameVideoStep = ({ onPrevious, onSubmit }: Props) => {
         <Button type="button" onClick={onPrevious} variant="subtle" color="black" size="lg">
           이전 단계
         </Button>
-        <Button type="button" size="lg" color="black" onClick={onSubmit}>
+        <Button type="submit" size="lg" color="black">
           완료
         </Button>
       </div>

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/index.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/index.tsx
@@ -45,7 +45,7 @@ export const GameForm = ({ leagueId, className, onSubmit, initialData, ...props 
     <FormProvider {...form}>
       <form
         className={twMerge('flex h-full w-full flex-col bg-white p-4', className)}
-        onSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
+        onSubmit={(e) => e.preventDefault()}
         {...props}
       >
         <div className="mx-auto flex h-full w-full max-w-4xl flex-col">
@@ -76,7 +76,12 @@ export const GameForm = ({ leagueId, className, onSubmit, initialData, ...props 
                     />
                   </Suspense>
                 ),
-                2: <GameVideoStep onPrevious={() => (step === 2 ? setStep(1) : undefined)} />,
+                2: (
+                  <GameVideoStep
+                    onPrevious={() => (step === 2 ? setStep(1) : undefined)}
+                    onSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
+                  />
+                ),
               }}
             />
           </div>

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/index.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/index.tsx
@@ -46,9 +46,6 @@ export const GameForm = ({ leagueId, className, onSubmit, initialData, ...props 
       <form
         className={twMerge('flex h-full w-full flex-col bg-white p-4', className)}
         onSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') e.preventDefault();
-        }}
         {...props}
       >
         <div className="mx-auto flex h-full w-full max-w-4xl flex-col">

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/index.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/index.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from '@hcc/ui';
+import { Spinner, toast } from '@hcc/ui';
 import { Suspense } from '@suspensive/react';
 import { type ComponentProps, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -34,6 +34,11 @@ export const GameForm = ({ leagueId, className, onSubmit, initialData, ...props 
   });
 
   const handleFormSubmit = async (data: GameFormType) => {
+    if (step !== 2) {
+      toast.warning('모든 단계를 완료해야 경기 생성이 가능합니다.');
+      return;
+    }
+
     const result = onSubmit(data);
     if (result instanceof Promise) {
       return result;
@@ -45,7 +50,7 @@ export const GameForm = ({ leagueId, className, onSubmit, initialData, ...props 
     <FormProvider {...form}>
       <form
         className={twMerge('flex h-full w-full flex-col bg-white p-4', className)}
-        onSubmit={(e) => e.preventDefault()}
+        onSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
         {...props}
       >
         <div className="mx-auto flex h-full w-full max-w-4xl flex-col">
@@ -76,12 +81,7 @@ export const GameForm = ({ leagueId, className, onSubmit, initialData, ...props 
                     />
                   </Suspense>
                 ),
-                2: (
-                  <GameVideoStep
-                    onPrevious={() => (step === 2 ? setStep(1) : undefined)}
-                    onSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
-                  />
-                ),
+                2: <GameVideoStep onPrevious={() => (step === 2 ? setStep(1) : undefined)} />,
               }}
             />
           </div>

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/index.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/index.tsx
@@ -46,6 +46,9 @@ export const GameForm = ({ leagueId, className, onSubmit, initialData, ...props 
       <form
         className={twMerge('flex h-full w-full flex-col bg-white p-4', className)}
         onSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') e.preventDefault();
+        }}
         {...props}
       >
         <div className="mx-auto flex h-full w-full max-w-4xl flex-col">

--- a/apps/manager/src/app/(private)/teams/_components/assistants/add-player-bottom-sheet.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/assistants/add-player-bottom-sheet.tsx
@@ -386,7 +386,6 @@ export const AddPlayerBottomSheet = ({
             if (e.key === 'Enter') e.preventDefault();
           }}
         >
-          {' '}
           <div className={twMerge('flex-1 overflow-y-auto')}>
             {displayMessages.map((msg) => {
               if (msg.type === 'assistant' && msg.stage && msg.stage !== 'input') {

--- a/apps/manager/src/app/(private)/teams/_components/assistants/add-player-bottom-sheet.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/assistants/add-player-bottom-sheet.tsx
@@ -211,6 +211,21 @@ export const AddPlayerBottomSheet = ({
       return;
     }
 
+    if (!logoImageUrl) {
+      setDisplayMessages((prev) => [
+        ...prev,
+        {
+          id: `${Date.now()}`,
+          type: 'assistant',
+          stage: 'complete',
+          message:
+            '팀 로고 이미지가 등록되지 않았어요.\n팀 정보에서 로고 이미지를 먼저 등록해주세요.',
+        },
+      ]);
+      scrollToBottom();
+      return;
+    }
+
     setIsClosing(true);
 
     let imageUrl: string;
@@ -281,6 +296,7 @@ export const AddPlayerBottomSheet = ({
     registerNL,
     router,
     onOpenChange,
+    scrollToBottom,
     isClosing,
     isRegistering,
   ]);

--- a/apps/manager/src/app/(private)/teams/_components/assistants/add-player-bottom-sheet.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/assistants/add-player-bottom-sheet.tsx
@@ -379,7 +379,14 @@ export const AddPlayerBottomSheet = ({
           <BottomSheet.Title className={twMerge('px-6')}>훕치치 어시스턴트</BottomSheet.Title>
         </BottomSheet.Header>
 
-        <div className={twMerge('px-6 h-[60vh] overflow-y-auto flex flex-col')}>
+        <div
+          className={twMerge('px-6 h-[60vh] overflow-y-auto flex flex-col')}
+          role="presentation"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') e.preventDefault();
+          }}
+        >
+          {' '}
           <div className={twMerge('flex-1 overflow-y-auto')}>
             {displayMessages.map((msg) => {
               if (msg.type === 'assistant' && msg.stage && msg.stage !== 'input') {

--- a/apps/manager/src/app/(private)/teams/_components/assistants/registration-ui.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/assistants/registration-ui.tsx
@@ -230,6 +230,7 @@ const ParseResultCard = ({
       {isEditing ? (
         <div className="flex gap-2">
           <Button
+            type="button"
             color="primary"
             variant="ghost"
             onClick={() => setIsEditing(false)}
@@ -238,6 +239,7 @@ const ParseResultCard = ({
             취소
           </Button>
           <Button
+            type="button"
             color="primary"
             onClick={() => {
               onEdit?.(editedPlayers);
@@ -251,6 +253,7 @@ const ParseResultCard = ({
       ) : (
         <div className="flex gap-2">
           <Button
+            type="button"
             color="primary"
             variant="ghost"
             onClick={() => setIsEditing(true)}
@@ -260,6 +263,7 @@ const ParseResultCard = ({
           </Button>
           {!hasError && !hasMissingJerseyNumber && (
             <Button
+              type="button"
               onClick={() => onConfirm?.(players.map((p) => ({ studentNumber: p.studentNumber })))}
               className="bg-primary flex-1 rounded px-3 py-2 text-sm text-white hover:opacity-90"
             >
@@ -332,6 +336,7 @@ const DuplicateCheckCard = ({
         </table>
 
         <Button
+          type="button"
           onClick={() =>
             onSelectDuplicates?.(duplicates.filter((p) => selected.has(p.studentNumber)))
           }
@@ -415,6 +420,7 @@ const FinalConfirmCard = ({ players, teamName, onConfirm }: FinalConfirmCardProp
       </table>
 
       <Button
+        type="button"
         onClick={() =>
           onConfirm?.(Array.from(selected).map((studentNumber) => ({ studentNumber })))
         }

--- a/apps/manager/src/app/(private)/teams/_components/assistants/registration-ui.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/assistants/registration-ui.tsx
@@ -438,6 +438,7 @@ interface CompleteCardProps {
 const CompleteCard = ({ onClose }: CompleteCardProps) => {
   return (
     <Button
+      type="button"
       onClick={onClose}
       className="bg-primary w-full rounded px-3 py-3 text-sm font-medium text-white hover:opacity-90"
     >


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 팀 등록시 이미지가 없는 상황에 대한 alert메시지를 추가했어요
- 경기 생성 시 팀원 검색 기능 추가
- 경기 생성시 팀원 검색 중 엔터키를 누르면 경기가 생성되는 문제 발견
  - 학번 입력시 에러 메세지뜨는 문제 수정(옵셔널체이닝 추가)
  - ~form 태그 내에서 onKeyDown을 추가하여 엔터키로 폼이 제출되는 현상 방지~ -> preventDefault를 추가하여 마지막 단계에서 완료 버튼을 눌러야만 폼이 전송되도록 수정
  - 어시스턴트 내에서도 엔터키에 대한 비슷한 이슈가 있어 onKeyDown추가

## 고민한 부분
form 태그 위에서 엔터키를 전체를 다 막는게 좋을지, 특정 입력 필드에만 적용하는게 좋을지가 고민이네요