### PR TITLE
refactor: 게임 상태 뱃지 문구 수정

### DIFF
--- a/apps/spectator/src/app/leagues/[id]/_components/game-list.tsx
+++ b/apps/spectator/src/app/leagues/[id]/_components/game-list.tsx
@@ -40,7 +40,7 @@ const GameListContent = ({
         <Fragment key={game.id}>
           <GameCard game={game}>
             <GameCard.Container className="gap-4">
-              <GameCard.Header />
+              <GameCard.Header state={state} />
 
               <div className="flex gap-4">
                 <Link href={`/${routes.game(game.id)}`} className="column flex-1 gap-2">

--- a/apps/spectator/src/components/ui/game-card.tsx
+++ b/apps/spectator/src/components/ui/game-card.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import type { BadgeProps } from '@hcc/ui';
+
 import { formatTime } from '@hcc/toolkit';
 import { Badge, Button, colors, Typography } from '@hcc/ui';
 import Image from 'next/image';
 import { createContext, useContext, type ComponentProps } from 'react';
 import { twMerge } from 'tailwind-merge';
 
-import type { GameListType } from '~/api';
+import type { GameListType, GameStateType } from '~/api';
 
 import { cn } from '~/utils/cn';
 
@@ -57,12 +59,13 @@ const GameCardContainer = ({ children, className, ...props }: ComponentProps<'di
  * -----------------------------------------------------------------------------------------------*/
 
 interface GameCardHeaderProps extends ComponentProps<'div'> {
-  // game: GameListType;
+  state?: GameStateType;
   showLeagueName?: boolean;
 }
 
-const GameCardHeader = ({ showLeagueName, className, ...props }: GameCardHeaderProps) => {
-  const { leagueName, round, startTime, gameQuarter } = useGameCardContext();
+const GameCardHeader = ({ showLeagueName, className, state, ...props }: GameCardHeaderProps) => {
+  const { leagueName, round, startTime, gameState } = useGameCardContext();
+  const { label, variant } = getGameStateInfo(state ?? gameState);
 
   return (
     <div className={twMerge('row-between', className)} {...props}>
@@ -72,9 +75,27 @@ const GameCardHeader = ({ showLeagueName, className, ...props }: GameCardHeaderP
         {' ‧ '}
         {formatTime(startTime, { format: 'MM.DD. HH:mm' })}
       </Typography>
-      <Badge size="sm">{gameQuarter}</Badge>
+
+      <Badge size="sm" variant={variant}>
+        {label}
+      </Badge>
     </div>
   );
+};
+
+const getGameStateInfo = (
+  gameState: GameStateType,
+): { label: string; variant: BadgeProps['variant'] } => {
+  switch (gameState) {
+    case 'SCHEDULED':
+      return { label: '예정', variant: 'primary' };
+    case 'PLAYING':
+      return { label: '🔴 Live', variant: 'danger' };
+    case 'FINISHED':
+      return { label: '경기 종료', variant: 'default' };
+    default:
+      return { label: gameState, variant: 'default' };
+  }
 };
 
 /* -------------------------------------------------------------------------------------------------

--- a/apps/spectator/src/components/ui/game-card.tsx
+++ b/apps/spectator/src/components/ui/game-card.tsx
@@ -90,7 +90,7 @@ const getGameStateInfo = (
     case 'SCHEDULED':
       return { label: '예정', variant: 'primary' };
     case 'PLAYING':
-      return { label: '🔴 Live', variant: 'danger' };
+      return { label: 'Live', variant: 'danger' };
     case 'FINISHED':
       return { label: '경기 종료', variant: 'default' };
     default:

--- a/apps/spectator/src/components/ui/game-card.tsx
+++ b/apps/spectator/src/components/ui/game-card.tsx
@@ -76,7 +76,7 @@ const GameCardHeader = ({ showLeagueName, className, state, ...props }: GameCard
         {formatTime(startTime, { format: 'MM.DD. HH:mm' })}
       </Typography>
 
-      <Badge size="sm" variant={variant}>
+      <Badge size="sm" variant={variant} className={cn(variant === 'danger' && 'shimmer-overlay')}>
         {label}
       </Badge>
     </div>

--- a/apps/spectator/src/styles/globals.css
+++ b/apps/spectator/src/styles/globals.css
@@ -19,6 +19,7 @@
   --color-white: #ffffff;
 
   --spacing-navbar-height: 4rem;
+  --animate-shimmer: shimmer 1.5s ease-in-out infinite;
 
   @keyframes arrow {
     0%,
@@ -29,4 +30,29 @@
       transform: translateX(4px);
     }
   }
+
+  @keyframes shimmer {
+    0% {
+      background-position: -6.25rem 0;
+    }
+    100% {
+      background-position: 6.25rem 0;
+    }
+  }
+}
+
+.shimmer-overlay {
+  position: relative;
+  overflow: hidden;
+}
+
+.shimmer-overlay::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-repeat: no-repeat;
+  background: linear-gradient(90deg, transparent 0%, rgb(255 255 255 / 38%) 50%, transparent 100%);
+  background-size: 6.25rem 100%;
+  animation: var(--animate-shimmer);
 }


### PR DESCRIPTION
## ✅ 작업 내용

- 게임 상태 뱃지 문구 수정했습니다.
- 기존에는 경기 전, 전반, 후반, 등 모든 정보를 보여줬는데, 3가지 케이스로 나눠서 더 직관적으로 수정했습니다.

<img width="569" height="784" alt="스크린샷 2026-03-29 오후 10 47 01" src="https://github.com/user-attachments/assets/01bb411d-4fa9-4e71-8d9a-278d42496cf1" />

## ♾️ 기타

- 회의 때 다들 동의했으나, 디자이너 컨펌은 아직 받지 못해서 이에 따라 수정될 수 있음
