### PR TITLE
fix: 경기 목록 순서 조정

### DIFF
--- a/apps/spectator/src/app/(home)/_components/tab.tsx
+++ b/apps/spectator/src/app/(home)/_components/tab.tsx
@@ -27,14 +27,14 @@ export const RecentTab = () => {
   const buttonLabel = hasPlayingGames ? '응원하러 가기' : '지난 경기 보러가기';
 
   // gameState가 PLAYING인 경기, SCHEDULED인 경기, FINISHED인 경기 순으로 정렬
-  // 각 경기 상태 내에서는 시작 시간이 빠른 순으로 정렬
+  // 각 경기 상태 내에서는 시작 시간이 느린 순으로 정렬
   const sortedGames = [...games].sort((a, b) => {
     const gameStateOrder = { PLAYING: 0, SCHEDULED: 1, FINISHED: 2 };
     const aOrder = gameStateOrder[a.gameState];
     const bOrder = gameStateOrder[b.gameState];
 
     if (aOrder !== bOrder) return aOrder - bOrder;
-    return new Date(a.startTime).getTime() - new Date(b.startTime).getTime();
+    return new Date(b.startTime).getTime() - new Date(a.startTime).getTime();
   });
 
   const { data: cheerCount } = useSuspenseLeagueCheerCount(

--- a/apps/spectator/src/app/(home)/_components/tab.tsx
+++ b/apps/spectator/src/app/(home)/_components/tab.tsx
@@ -24,9 +24,16 @@ export const RecentTab = () => {
   const hasPlayingGames = displayedGame.games.some((game) => game.gameState === 'PLAYING');
   const buttonLabel = hasPlayingGames ? '응원하러 가기' : '지난 경기 보러가기';
 
-  const sortedGames = [...displayedGame.games].sort(
-    (a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime(),
-  );
+  // gameState가 PLAYING인 경기, SCHEDULED인 경기, FINISHED인 경기 순으로 정렬
+  // 각 경기 상태 내에서는 시작 시간이 빠른 순으로 정렬
+  const sortedGames = [...displayedGame.games].sort((a, b) => {
+    const gameStateOrder = { PLAYING: 0, SCHEDULED: 1, FINISHED: 2 };
+    const aOrder = gameStateOrder[a.gameState];
+    const bOrder = gameStateOrder[b.gameState];
+
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    return new Date(a.startTime).getTime() - new Date(b.startTime).getTime();
+  });
 
   const { data: cheerCount } = useSuspenseLeagueCheerCount(
     { leagueId: displayedGame?.leagueId },

--- a/apps/spectator/src/app/(home)/_components/tab.tsx
+++ b/apps/spectator/src/app/(home)/_components/tab.tsx
@@ -21,12 +21,14 @@ export const RecentTab = () => {
 
   if (!displayedGame) return null;
 
-  const hasPlayingGames = displayedGame.games.some((game) => game.gameState === 'PLAYING');
+  const { games, leagueId, leagueName } = displayedGame;
+
+  const hasPlayingGames = !games.every(({ gameState }) => gameState === 'FINISHED');
   const buttonLabel = hasPlayingGames ? '응원하러 가기' : '지난 경기 보러가기';
 
   // gameState가 PLAYING인 경기, SCHEDULED인 경기, FINISHED인 경기 순으로 정렬
   // 각 경기 상태 내에서는 시작 시간이 빠른 순으로 정렬
-  const sortedGames = [...displayedGame.games].sort((a, b) => {
+  const sortedGames = [...games].sort((a, b) => {
     const gameStateOrder = { PLAYING: 0, SCHEDULED: 1, FINISHED: 2 };
     const aOrder = gameStateOrder[a.gameState];
     const bOrder = gameStateOrder[b.gameState];
@@ -44,8 +46,8 @@ export const RecentTab = () => {
     <div className="flex flex-1 flex-col gap-3">
       <GameList
         cheerCount={cheerCount.cheerTalkCount}
-        leagueId={displayedGame.leagueId}
-        leagueName={displayedGame.leagueName}
+        leagueId={leagueId}
+        leagueName={leagueName}
         games={sortedGames}
         buttonLabel={buttonLabel}
       />


### PR DESCRIPTION
## ✅ 작업 내용

- Live 경기가 있을 때는 제일 위로
- 아니면 예정 경기 -> 종료 경기 순
- 동일한 상태끼리는 경기 시작 시간 순

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용