### PR TITLE
fix(manager): 토큰 만료시 로그인 리다이렉트 복구

### DIFF
--- a/apps/manager/middleware.ts
+++ b/apps/manager/middleware.ts
@@ -25,17 +25,7 @@ export default function middleware(req: NextRequest) {
 }
 
 function getTokenFromCookies(request: NextRequest) {
-  const cookiesHeader = request.headers.get('cookie');
-  if (!cookiesHeader) return null;
-
-  const cookies = new Map(
-    cookiesHeader.split('; ').map((cookie) => {
-      const [key, ...rest] = cookie.split('=');
-      return [key, rest.join('=')] as [string, string];
-    }),
-  );
-
-  return cookies.get(COOKIE_NAME);
+  return request.cookies.get(COOKIE_NAME)?.value;
 }
 
 export const config = {

--- a/apps/manager/middleware.ts
+++ b/apps/manager/middleware.ts
@@ -1,0 +1,43 @@
+import type { NextRequest } from 'next/server';
+
+import { NextResponse } from 'next/server';
+
+const COOKIE_NAME = 'HCC_SES';
+const LOGIN_PATH = '/auth/login';
+
+export default function middleware(req: NextRequest) {
+  const accessToken = getTokenFromCookies(req);
+  const pathUrl = req.nextUrl.pathname;
+
+  if (!accessToken && !pathUrl.startsWith(LOGIN_PATH)) {
+    const url = req.nextUrl.clone();
+    url.pathname = LOGIN_PATH;
+    return NextResponse.redirect(url);
+  }
+
+  if (accessToken && pathUrl.startsWith(LOGIN_PATH)) {
+    const url = req.nextUrl.clone();
+    url.pathname = '/';
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+function getTokenFromCookies(request: NextRequest) {
+  const cookiesHeader = request.headers.get('cookie');
+  if (!cookiesHeader) return null;
+
+  const cookies = new Map(
+    cookiesHeader.split('; ').map((cookie) => {
+      const [key, ...rest] = cookie.split('=');
+      return [key, rest.join('=')] as [string, string];
+    }),
+  );
+
+  return cookies.get(COOKIE_NAME);
+}
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|fonts|images).*)'],
+};

--- a/packages/api-base/src/fetcher.ts
+++ b/packages/api-base/src/fetcher.ts
@@ -8,6 +8,8 @@ const defaultOption: Options = {
   credentials: 'include',
 };
 
+let isRedirecting = false;
+
 export const getInstance = (apiUrl?: string) =>
   ky.create({
     prefixUrl: apiUrl,
@@ -19,8 +21,11 @@ export const getInstance = (apiUrl?: string) =>
             if (response.status === 401) {
               if (request.url.includes('logout')) return response;
 
-              alert('로그인이 만료되었어요. 다시 로그인해주세요.');
-              window.location.href = '/auth/login';
+              if (!isRedirecting) {
+                isRedirecting = true;
+                alert('로그인이 만료되었어요. 다시 로그인해주세요.');
+                window.location.href = '/auth/login';
+              }
               return response;
             }
 

--- a/packages/api-base/src/fetcher.ts
+++ b/packages/api-base/src/fetcher.ts
@@ -19,12 +19,7 @@ export const getInstance = (apiUrl?: string) =>
             if (response.status === 401) {
               if (request.url.includes('logout')) return response;
 
-              const currentPath = window.location.pathname;
-
-              const isInternalNavigation = document?.referrer?.includes(window.location.host);
-              if (currentPath !== '/' || isInternalNavigation) {
-                alert('로그인이 만료되었어요. 다시 로그인해주세요.');
-              }
+              alert('로그인이 만료되었어요. 다시 로그인해주세요.');
               window.location.href = '/auth/login';
               return response;
             }


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 토큰 만료시에도 로그인 창으로 리다이렉팅이 되지 않는 문제 발견
  - `middleware.ts`를 추가하여 페이지 이동 시 쿠키 체크, 만료면 서버에서 바로 redirect
  - 임시로 추가한 currentPath !== '/', isInternalNavigation 조건을 제거


## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
