### PR TITLE
hotfix: 리그 팀 삭제 api추가 및 팀수정 로직 변경

### DIFF
--- a/apps/manager/src/api/mutations/index.ts
+++ b/apps/manager/src/api/mutations/index.ts
@@ -3,6 +3,7 @@ export * from './useCreateLeagues';
 export * from './useCreatePlayers';
 export * from './useCreateTeams';
 export * from './useDeleteGames';
+export * from './useDeleteLeagueTeams';
 export * from './useDeleteLeagues';
 export * from './useDeletePlayers';
 export * from './useDeleteTeams';

--- a/apps/manager/src/api/mutations/useDeleteLeagueTeams.ts
+++ b/apps/manager/src/api/mutations/useDeleteLeagueTeams.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@hcc/api-base';
+
+import { fetcher, queryKeys } from '~/api/queryKey';
+
+type Request = {
+  leagueId: number;
+  teamIds: number[];
+};
+
+export const deleteLeagueTeams = ({ leagueId, teamIds }: Request) => {
+  return fetcher.delete<void>(`leagues/${leagueId}/teams`, { json: { teamIds } });
+};
+
+export const useDeleteLeagueTeams = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteLeagueTeams,
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: queryKeys.leagues._def });
+    },
+  });
+};

--- a/apps/manager/src/app/(private)/leagues/[id]/manage/_components/form-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/manage/_components/form-section.tsx
@@ -24,13 +24,16 @@ export const LeagueEditContainer = ({ leagueId }: { leagueId: number }) => {
   const { mutateAsync: deleteLeagueTeams } = useDeleteLeagueTeams();
 
   const handleUpdate = async (data: LeagueFormType) => {
-    try {
-      const existingTeams = teams ?? [];
-      const existingTeamIds = new Set(existingTeams.map((t) => t.teamId));
-      const newTeamIds = data.teamIds.filter((id) => !existingTeamIds.has(id));
-      const removedTeams = existingTeams.filter((t) => !data.teamIds.includes(t.teamId));
+    if (!teams) return;
 
-      const removedTeamIds = removedTeams.map((t) => t.teamId);
+    try {
+      const existingTeams = teams;
+      const existingTeamIds = new Set(existingTeams.map((t) => t.teamId));
+      const submittedTeamIds = new Set(data.teamIds);
+      const newTeamIds = data.teamIds.filter((id) => !existingTeamIds.has(id));
+      const removedTeamIds = existingTeams
+        .map((t) => t.teamId)
+        .filter((id) => !submittedTeamIds.has(id));
 
       await Promise.all([
         updateLeague({ leagueId, ...data }),

--- a/apps/manager/src/app/(private)/leagues/[id]/manage/_components/form-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/manage/_components/form-section.tsx
@@ -9,6 +9,7 @@ import {
   useUpdateLeagues,
   type LeagueFormType,
   useUpdateLeagueTeams,
+  useDeleteLeagueTeams,
 } from '~/api';
 
 import { LeagueForm } from '../../_components/league-form';
@@ -20,18 +21,23 @@ export const LeagueEditContainer = ({ leagueId }: { leagueId: number }) => {
   const { data: teams } = useLeagueTeams({ leagueId });
   const { mutateAsync: updateLeague } = useUpdateLeagues();
   const { mutateAsync: updateLeagueTeams } = useUpdateLeagueTeams();
+  const { mutateAsync: deleteLeagueTeams } = useDeleteLeagueTeams();
 
   const handleUpdate = async (data: LeagueFormType) => {
     try {
+      const existingTeams = teams ?? [];
+      const existingTeamIds = new Set(existingTeams.map((t) => t.teamId));
+      const newTeamIds = data.teamIds.filter((id) => !existingTeamIds.has(id));
+      const removedTeams = existingTeams.filter((t) => !data.teamIds.includes(t.teamId));
+
+      const removedTeamIds = removedTeams.map((t) => t.teamId);
+
       await Promise.all([
-        updateLeague({
-          leagueId,
-          ...data,
-        }),
-        updateLeagueTeams({
-          leagueId,
-          teamIds: data.teamIds,
-        }),
+        updateLeague({ leagueId, ...data }),
+        ...(newTeamIds.length > 0 ? [updateLeagueTeams({ leagueId, teamIds: newTeamIds })] : []),
+        ...(removedTeamIds.length > 0
+          ? [deleteLeagueTeams({ leagueId, teamIds: removedTeamIds })]
+          : []),
       ]);
       toast.success('대회 정보가 수정되었어요');
       router.push(`/leagues/${leagueId}`);


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 리그 팀 수정이 안되는 문제 발견
  - 리그 팀 수정 api구조가 추가하는 팀 (post) + 삭제할 팀 (delete) 인데 post만 하던 문제
  - `useDeleteLeagueTeams.ts`를 추가
  - 추가된 팀만 post로 보내고 삭제 로직까지 Promise.all로 api 호출

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
