### PR TITLE
fix: 팀 수정시 학번이 null이어도 수정가능하도록

### DIFF
--- a/apps/manager/src/app/(private)/teams/[id]/form-section.tsx
+++ b/apps/manager/src/app/(private)/teams/[id]/form-section.tsx
@@ -34,11 +34,11 @@ export const FormSection = ({ id }: Props) => {
 
     try {
       await mutateAsync({ id, ...data, logoImageUrl: imageUrl, teamPlayers });
-      toast.success('팀이 수정되었어요.');
+      toast.success('팀이 수정되었어요');
       router.back();
     } catch (error) {
       console.error(error);
-      toast.error('팀 수정에 실패했어요.');
+      toast.error('팀 수정에 실패했어요');
     }
   };
 

--- a/apps/manager/src/app/(private)/teams/_components/team-form.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/team-form.tsx
@@ -68,7 +68,10 @@ export const TeamForm = ({ className, onSubmit, initialData, ...props }: Props) 
               0: <TeamBasicInfoStep onNext={() => (step === 0 ? setStep(1) : undefined)} />,
               1: (
                 <Suspense fallback={<Spinner />} clientOnly>
-                  <TeamPlayersStep onPrevious={() => (step === 1 ? setStep(0) : undefined)} />
+                  <TeamPlayersStep
+                    onPrevious={() => (step === 1 ? setStep(0) : undefined)}
+                    onRequestSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
+                  />
                 </Suspense>
               ),
             }}

--- a/apps/manager/src/app/(private)/teams/_components/team-form.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/team-form.tsx
@@ -68,10 +68,7 @@ export const TeamForm = ({ className, onSubmit, initialData, ...props }: Props) 
               0: <TeamBasicInfoStep onNext={() => (step === 0 ? setStep(1) : undefined)} />,
               1: (
                 <Suspense fallback={<Spinner />} clientOnly>
-                  <TeamPlayersStep
-                    onPrevious={() => (step === 1 ? setStep(0) : undefined)}
-                    onRequestSubmit={form.handleSubmit(handleFormSubmit, handleFormError)}
-                  />
+                  <TeamPlayersStep onPrevious={() => (step === 1 ? setStep(0) : undefined)} />
                 </Suspense>
               ),
             }}

--- a/apps/manager/src/app/(private)/teams/_components/team-players-step.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/team-players-step.tsx
@@ -5,17 +5,15 @@ import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 
 import { type TeamFormType, useSuspensePlayers } from '~/api';
 import { PlayerAppendDialog } from '~/app/(private)/teams/_components/player-append-dialog';
-import { AlertDialog } from '~/components/ui';
 
 import { AddPlayerBottomSheet } from './assistants/add-player-bottom-sheet';
 import { FloatingActionButton } from './assistants/floating-action-button';
 
 type Props = {
   onPrevious: () => void;
-  onRequestSubmit: () => void;
 };
 
-export const TeamPlayersStep = ({ onPrevious, onRequestSubmit }: Props) => {
+export const TeamPlayersStep = ({ onPrevious }: Props) => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
   const { control, watch } = useFormContext<TeamFormType>();
   const teamName = watch('name');
@@ -71,38 +69,28 @@ export const TeamPlayersStep = ({ onPrevious, onRequestSubmit }: Props) => {
         {fields.map((field, index) => (
           <div key={field.id} className="center-y gap-3">
             <div className="center-y flex-1 gap-3">
-              <Controller
-                name={`teamPlayers.${index}.name`}
-                control={control}
-                render={({ field: f }) => (
-                  <Input
-                    {...f}
-                    size="lg"
-                    placeholder="선수 이름"
-                    value={
-                      f.value ??
-                      data.find((player) => player.playerId === field.playerId)?.name ??
-                      '-'
-                    }
-                  />
-                )}
+              <Input
+                size="lg"
+                placeholder="선수 이름"
+                value={field.name || '-'}
+                readOnly
+                onClick={() =>
+                  toast.info('이름과 학번은 선수 관리에서 수정할 수 있어요', {
+                    id: 'readonly-player-field',
+                  })
+                }
               />
 
-              <Controller
-                name={`teamPlayers.${index}.studentNumber`}
-                control={control}
-                render={({ field: f }) => (
-                  <Input
-                    {...f}
-                    size="lg"
-                    placeholder="학번"
-                    value={
-                      f.value ??
-                      data.find((player) => player.playerId === field.playerId)?.studentNumber ??
-                      '-'
-                    }
-                  />
-                )}
+              <Input
+                size="lg"
+                placeholder="학번"
+                value={field.studentNumber || '-'}
+                readOnly
+                onClick={() =>
+                  toast.info('이름과 학번은 선수 관리에서 수정할 수 있어요', {
+                    id: 'readonly-player-field',
+                  })
+                }
               />
 
               <Controller
@@ -156,28 +144,9 @@ export const TeamPlayersStep = ({ onPrevious, onRequestSubmit }: Props) => {
         <Button type="button" onClick={onPrevious} variant="subtle" color="black" size="lg">
           이전 단계
         </Button>
-        {teamPlayers.some((player) => !player.studentNumber?.trim()) ? (
-          <AlertDialog
-            title="등록되지 않은 학번이 있어요"
-            description="종합 기록에 반영되지 않을 수 있어요"
-            primaryTitle="확인"
-            onPrimaryClick={onRequestSubmit}
-          >
-            <Button type="button" size="lg" color="black" disabled={!isValid}>
-              완료
-            </Button>
-          </AlertDialog>
-        ) : (
-          <Button
-            type="button"
-            size="lg"
-            color="black"
-            disabled={!isValid}
-            onClick={onRequestSubmit}
-          >
-            완료
-          </Button>
-        )}
+        <Button type="submit" size="lg" color="black" disabled={!isValid}>
+          완료
+        </Button>
       </div>
     </Fragment>
   );

--- a/apps/manager/src/app/(private)/teams/_components/team-players-step.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/team-players-step.tsx
@@ -1,10 +1,11 @@
 import { CancelIcon } from '@hcc/icons';
 import { Button, colors, Input, Typography, toast } from '@hcc/ui';
-import { Fragment, useState } from 'react';
+import { Fragment, useRef, useState } from 'react';
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 
 import { type TeamFormType, useSuspensePlayers } from '~/api';
 import { PlayerAppendDialog } from '~/app/(private)/teams/_components/player-append-dialog';
+import { AlertDialog } from '~/components/ui';
 
 import { AddPlayerBottomSheet } from './assistants/add-player-bottom-sheet';
 import { FloatingActionButton } from './assistants/floating-action-button';
@@ -15,6 +16,7 @@ type Props = {
 
 export const TeamPlayersStep = ({ onPrevious }: Props) => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  const submitButtonRef = useRef<HTMLButtonElement>(null);
   const { control, watch } = useFormContext<TeamFormType>();
   const teamName = watch('name');
   const teamUnit = watch('unit');
@@ -30,10 +32,7 @@ export const TeamPlayersStep = ({ onPrevious }: Props) => {
     teamPlayers.length > 0 &&
     teamPlayers.every(
       (player) =>
-        !!player.name?.trim() &&
-        !!player.studentNumber?.trim() &&
-        player.jerseyNumber !== undefined &&
-        player.jerseyNumber !== null,
+        !!player.name?.trim() && player.jerseyNumber !== undefined && player.jerseyNumber !== null,
     );
 
   const handleAppendPlayer = (id: number) => {
@@ -153,13 +152,28 @@ export const TeamPlayersStep = ({ onPrevious }: Props) => {
         teamColor={teamColor}
         logoImageUrl={logoImageUrl}
       />
+      <button ref={submitButtonRef} type="submit" className="hidden" />
+
       <div className="column sticky bottom-0 w-full gap-2 bg-white pt-3 pb-5">
         <Button type="button" onClick={onPrevious} variant="subtle" color="black" size="lg">
           이전 단계
         </Button>
-        <Button type="submit" size="lg" color="black" disabled={!isValid}>
-          완료
-        </Button>
+        {teamPlayers.some((player) => !player.studentNumber?.trim()) ? (
+          <AlertDialog
+            title="등록되지 않은 학번이 있어요"
+            description="종합 기록에 반영되지 않을 수 있어요"
+            primaryTitle="확인"
+            onPrimaryClick={() => submitButtonRef.current?.click()}
+          >
+            <Button type="button" size="lg" color="black" disabled={!isValid}>
+              완료
+            </Button>
+          </AlertDialog>
+        ) : (
+          <Button type="submit" size="lg" color="black" disabled={!isValid}>
+            완료
+          </Button>
+        )}
       </div>
     </Fragment>
   );

--- a/apps/manager/src/app/(private)/teams/_components/team-players-step.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/team-players-step.tsx
@@ -1,6 +1,6 @@
 import { CancelIcon } from '@hcc/icons';
 import { Button, colors, Input, Typography, toast } from '@hcc/ui';
-import { Fragment, useRef, useState } from 'react';
+import { Fragment, useState } from 'react';
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 
 import { type TeamFormType, useSuspensePlayers } from '~/api';
@@ -12,11 +12,11 @@ import { FloatingActionButton } from './assistants/floating-action-button';
 
 type Props = {
   onPrevious: () => void;
+  onRequestSubmit: () => void;
 };
 
-export const TeamPlayersStep = ({ onPrevious }: Props) => {
+export const TeamPlayersStep = ({ onPrevious, onRequestSubmit }: Props) => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
-  const submitButtonRef = useRef<HTMLButtonElement>(null);
   const { control, watch } = useFormContext<TeamFormType>();
   const teamName = watch('name');
   const teamUnit = watch('unit');
@@ -152,8 +152,6 @@ export const TeamPlayersStep = ({ onPrevious }: Props) => {
         teamColor={teamColor}
         logoImageUrl={logoImageUrl}
       />
-      <button ref={submitButtonRef} type="submit" className="hidden" />
-
       <div className="column sticky bottom-0 w-full gap-2 bg-white pt-3 pb-5">
         <Button type="button" onClick={onPrevious} variant="subtle" color="black" size="lg">
           이전 단계
@@ -163,14 +161,20 @@ export const TeamPlayersStep = ({ onPrevious }: Props) => {
             title="등록되지 않은 학번이 있어요"
             description="종합 기록에 반영되지 않을 수 있어요"
             primaryTitle="확인"
-            onPrimaryClick={() => submitButtonRef.current?.click()}
+            onPrimaryClick={onRequestSubmit}
           >
             <Button type="button" size="lg" color="black" disabled={!isValid}>
               완료
             </Button>
           </AlertDialog>
         ) : (
-          <Button type="submit" size="lg" color="black" disabled={!isValid}>
+          <Button
+            type="button"
+            size="lg"
+            color="black"
+            disabled={!isValid}
+            onClick={onRequestSubmit}
+          >
             완료
           </Button>
         )}


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 팀 수정시 학번이 null인 선수가 있어도 수정이 가능하도록 변경했어요
  - 배경: 현재 팀 등록은 학번이 필수이지만, 예전에 학번 없이 등록된 선수가 존재하는 팀의 수정을 위함
  - 학번 없이 수정을 완료하려는 경우 경고 팝업을 띄움
  - ~해당 api에서도 학번 필드가 없어서 학번을 수정해도 반영되지 않는 문제는 있음 ! (정책은 물어볼게요)~
  => 이름, 학번 필드는 수정이 안되도록 함, 유저가 수정하려고 할 때 알림 토스트가 뜨도록 수정함!!!

## 📝 참고 자료



https://github.com/user-attachments/assets/5b5e3700-0afc-48bd-9936-7275ba93a1c9



