### PR TITLE
fix: 응원탭에서 입력시 채팅영역이 줄어드는 문제 해결

### DIFF
--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-form.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-form.tsx
@@ -89,7 +89,7 @@ export const CheerTalkForm = ({
 
       <div className="center-y w-full gap-2">
         <input
-          className="w-full rounded-3xl border border-neutral-200 bg-neutral-100 px-3 py-2 text-sm font-medium"
+          className="w-full rounded-3xl border border-neutral-200 bg-neutral-100 px-3 py-2 text-base font-medium"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           onFocus={onInputFocus}

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
@@ -42,7 +42,7 @@ export const CheerTalkList = ({
   const [isNoticeVisible, setIsNoticeVisible] = useState(false);
 
   const formWrapperRef = useRef<HTMLDivElement>(null);
-  const hasScrolledToBottom = useRef(false);
+  const hasFirstFocused = useRef(false);
 
   const [formHeight, setFormHeight] = useState(0);
 
@@ -79,12 +79,6 @@ export const CheerTalkList = ({
 
     return () => observer.disconnect();
   }, []);
-
-  useEffect(() => {
-    if (cheerTalkList.length === 0 || hasScrolledToBottom.current) return;
-    hasScrolledToBottom.current = true;
-    scrollToBottom();
-  }, [cheerTalkList, scrollToBottom]);
 
   useEffect(() => {
     if (socketTalkList.length === 0) return;
@@ -146,7 +140,13 @@ export const CheerTalkList = ({
             gameTeams={game.gameTeams}
             scrollToBottom={scrollToBottomWithDelay}
             gameState={game.state}
-            onInputFocus={() => setIsNoticeVisible(true)}
+            onInputFocus={() => {
+              setIsNoticeVisible(true);
+              if (!hasFirstFocused.current) {
+                hasFirstFocused.current = true;
+                scrollToBottom();
+              }
+            }}
           />
         </div>
       </div>

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
@@ -98,7 +98,7 @@ export const CheerTalkList = ({
 
   return (
     <Fragment>
-      <div className="relative w-full px-4 py-4" style={{ paddingBottom: formHeight + 16 }}>
+      <div className="relative w-full px-4 py-4">
         <div ref={intersectionRef} className="h-1" />
         {isFetchingNextPage && (
           <div className="flex justify-center py-2">
@@ -111,6 +111,7 @@ export const CheerTalkList = ({
             <CheerTalkItem key={`talk-${talk.cheerTalkId}`} {...talk} />
           ))}
         </div>
+        <div style={{ height: formHeight }} />
       </div>
 
       <div

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
@@ -129,7 +129,7 @@ export const CheerTalkList = ({
             gameTeams={game.gameTeams}
             scrollToBottom={scrollToBottomWithDelay}
             gameState={game.state}
-            onInputFocus={() => {}}
+            onInputFocus={() => setIsNoticeVisible(true)}
           />
         </div>
       </div>

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
@@ -1,7 +1,15 @@
 'use client';
 import { CloseIcon } from '@hcc/icons';
 import { colors, Spinner, Typography } from '@hcc/ui';
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { type GameCheerTalkWithTeamInfo, useSuspenseGame } from '~/api';
 import useIntersectionObserver from '~/hooks/useIntersectionObserver';
@@ -33,13 +41,18 @@ export const CheerTalkList = ({
   const { data: game } = useSuspenseGame({ gameId });
   const [isNoticeVisible, setIsNoticeVisible] = useState(false);
 
-  const bottomRef = useRef<HTMLDivElement>(null);
   const formWrapperRef = useRef<HTMLDivElement>(null);
+  const hasScrolledToBottom = useRef(false);
 
-  const [formHeight, setFormHeight] = useState(88);
+  const [formHeight, setFormHeight] = useState(0);
+
+  const isNearBottom = useCallback(
+    () => window.innerHeight + window.scrollY >= document.body.scrollHeight - formHeight,
+    [formHeight],
+  );
 
   const scrollToBottom = useCallback(() => {
-    bottomRef.current?.scrollIntoView({ block: 'end' });
+    window.scrollTo({ top: document.body.scrollHeight, behavior: 'instant' });
   }, []);
 
   const [scrollToBottomWithDelay] = useTimeout(scrollToBottom, 100);
@@ -52,11 +65,11 @@ export const CheerTalkList = ({
     }
   });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!formWrapperRef.current) return;
 
     const updateHeight = () => {
-      setFormHeight(formWrapperRef.current?.offsetHeight ?? 88);
+      setFormHeight(formWrapperRef.current?.offsetHeight ?? 0);
     };
 
     updateHeight();
@@ -68,9 +81,15 @@ export const CheerTalkList = ({
   }, []);
 
   useEffect(() => {
-    if (socketTalkList.length === 0) return;
+    if (cheerTalkList.length === 0 || hasScrolledToBottom.current) return;
+    hasScrolledToBottom.current = true;
     scrollToBottom();
-  }, [socketTalkList, scrollToBottom]);
+  }, [cheerTalkList, scrollToBottom]);
+
+  useEffect(() => {
+    if (socketTalkList.length === 0) return;
+    if (isNearBottom()) scrollToBottom();
+  }, [socketTalkList, scrollToBottom, isNearBottom]);
 
   const allMessages = useMemo(() => {
     const messageMap = new Map<number, GameCheerTalkWithTeamInfo>();
@@ -98,8 +117,6 @@ export const CheerTalkList = ({
             <CheerTalkItem key={`talk-${talk.cheerTalkId}`} {...talk} />
           ))}
         </div>
-
-        <div ref={bottomRef} />
       </div>
 
       <div

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
@@ -116,9 +116,9 @@ export const CheerTalkList = ({
 
       <div
         ref={formWrapperRef}
-        className="pb-safe fixed right-0 bottom-0 left-0 z-20 border-t border-neutral-100 bg-white"
+        className="pb-safe fixed inset-x-0 bottom-0 z-20 mx-auto w-full max-w-(--app-max-width) border-t border-neutral-100 bg-white"
       >
-        <div className="max-w-screen-sm relative mx-auto w-full">
+        <div className="relative w-full">
           {isNoticeVisible && (
             <div className="absolute right-4 bottom-full left-4 z-20 mb-2">
               <div className="animate-in fade-in slide-in-from-bottom-2 flex items-center justify-between rounded-lg border border-neutral-100 bg-white p-3 shadow-lg">

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
@@ -33,12 +33,13 @@ export const CheerTalkList = ({
   const { data: game } = useSuspenseGame({ gameId });
   const [isNoticeVisible, setIsNoticeVisible] = useState(false);
 
-  const scrollRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const formWrapperRef = useRef<HTMLDivElement>(null);
+
+  const [formHeight, setFormHeight] = useState(88);
 
   const scrollToBottom = useCallback(() => {
-    if (!scrollRef.current) return;
-    scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    bottomRef.current?.scrollIntoView({ block: 'end' });
   }, []);
 
   const [scrollToBottomWithDelay] = useTimeout(scrollToBottom, 100);
@@ -51,32 +52,25 @@ export const CheerTalkList = ({
     }
   });
 
-  const handleNewMessages = useCallback(() => {
-    if (!scrollRef.current) return;
+  useEffect(() => {
+    if (!formWrapperRef.current) return;
 
-    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
-    const wasAtBottom = scrollHeight - scrollTop <= clientHeight + 10;
+    const updateHeight = () => {
+      setFormHeight(formWrapperRef.current?.offsetHeight ?? 88);
+    };
 
-    if (wasAtBottom) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
+    updateHeight();
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(formWrapperRef.current);
+
+    return () => observer.disconnect();
   }, []);
 
-  const handleInitialScroll = useCallback(() => {
-    if (cheerTalkList.length === 0 && socketTalkList.length === 0) return;
-
-    const timers = [100].map((delay) => setTimeout(scrollToBottom, delay));
-
-    return () => timers.forEach(clearTimeout);
-  }, [cheerTalkList.length, socketTalkList.length, scrollToBottom]);
-
   useEffect(() => {
-    handleNewMessages();
-  }, [cheerTalkList, socketTalkList, handleNewMessages]);
-
-  useEffect(() => {
-    return handleInitialScroll();
-  }, [handleInitialScroll]);
+    if (socketTalkList.length === 0) return;
+    scrollToBottom();
+  }, [socketTalkList, scrollToBottom]);
 
   const allMessages = useMemo(() => {
     const messageMap = new Map<number, GameCheerTalkWithTeamInfo>();
@@ -91,7 +85,7 @@ export const CheerTalkList = ({
 
   return (
     <Fragment>
-      <div ref={scrollRef} className="scrollbar-hide relative w-full flex-1 overflow-y-auto">
+      <div className="relative w-full px-4 py-4" style={{ paddingBottom: formHeight + 16 }}>
         <div ref={intersectionRef} className="h-1" />
         {isFetchingNextPage && (
           <div className="flex justify-center py-2">
@@ -99,7 +93,7 @@ export const CheerTalkList = ({
           </div>
         )}
 
-        <div className="column gap-2.5 px-4 py-4">
+        <div className="column gap-2.5">
           {allMessages.map((talk) => (
             <CheerTalkItem key={`talk-${talk.cheerTalkId}`} {...talk} />
           ))}
@@ -107,30 +101,37 @@ export const CheerTalkList = ({
 
         <div ref={bottomRef} />
       </div>
-      <div className="pb-safe relative flex-shrink-0 border-t border-neutral-100 bg-white">
-        {isNoticeVisible && (
-          <div className="absolute right-4 bottom-full left-4 z-20 mb-2">
-            <div className="animate-in fade-in slide-in-from-bottom-2 flex items-center justify-between rounded-lg border border-neutral-100 bg-white p-3 shadow-lg">
-              <Typography fontSize={12} color={colors.neutral700} className="leading-5">
-                타인에게 불쾌감을 주거나 법령을 위반하는 활동을 할 경우, 운영정책에 따라 메시지 삭제
-                및 서비스 이용이 제한 될 수 있습니다.
-              </Typography>
-              <button
-                type="button"
-                onClick={() => setIsNoticeVisible(false)}
-                className="text-neutral-400 hover:text-neutral-600"
-              >
-                <CloseIcon size={16} />
-              </button>
+
+      <div
+        ref={formWrapperRef}
+        className="pb-safe fixed right-0 bottom-0 left-0 z-20 border-t border-neutral-100 bg-white"
+      >
+        <div className="max-w-screen-sm relative mx-auto w-full">
+          {isNoticeVisible && (
+            <div className="absolute right-4 bottom-full left-4 z-20 mb-2">
+              <div className="animate-in fade-in slide-in-from-bottom-2 flex items-center justify-between rounded-lg border border-neutral-100 bg-white p-3 shadow-lg">
+                <Typography fontSize={12} color={colors.neutral700} className="leading-5">
+                  타인에게 불쾌감을 주거나 법령을 위반하는 활동을 할 경우, 운영정책에 따라 메시지
+                  삭제 및 서비스 이용이 제한 될 수 있습니다.
+                </Typography>
+                <button
+                  type="button"
+                  onClick={() => setIsNoticeVisible(false)}
+                  className="text-neutral-400 hover:text-neutral-600"
+                >
+                  <CloseIcon size={16} />
+                </button>
+              </div>
             </div>
-          </div>
-        )}
-        <CheerTalkForm
-          gameTeams={game.gameTeams}
-          scrollToBottom={scrollToBottomWithDelay}
-          gameState={game.state}
-          onInputFocus={() => setIsNoticeVisible(true)}
-        />
+          )}
+
+          <CheerTalkForm
+            gameTeams={game.gameTeams}
+            scrollToBottom={scrollToBottomWithDelay}
+            gameState={game.state}
+            onInputFocus={() => setIsNoticeVisible(true)}
+          />
+        </div>
       </div>
     </Fragment>
   );

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/cheer-talk-list.tsx
@@ -129,7 +129,7 @@ export const CheerTalkList = ({
             gameTeams={game.gameTeams}
             scrollToBottom={scrollToBottomWithDelay}
             gameState={game.state}
-            onInputFocus={() => setIsNoticeVisible(true)}
+            onInputFocus={() => {}}
           />
         </div>
       </div>

--- a/apps/spectator/src/app/games/[id]/_components/cheer-talk/index.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/cheer-talk/index.tsx
@@ -39,7 +39,7 @@ export const CheerTalk = ({ gameId }: Props) => {
   });
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
+    <div className="flex flex-col">
       <div className="flex-shrink-0">
         <CheerTalkTimeline gameId={gameId} />
       </div>

--- a/apps/spectator/src/app/games/[id]/page.tsx
+++ b/apps/spectator/src/app/games/[id]/page.tsx
@@ -36,23 +36,21 @@ const Page = async ({ searchParams, params }: Props) => {
   }
 
   return (
-    <div className="flex h-screen flex-col overflow-hidden bg-white">
+    <div className="flex min-h-dvh flex-col bg-white">
       <Header arrow />
 
-      <div className="flex-shrink-0">
-        <Suspense clientOnly>
-          <Banner gameId={id} />
-        </Suspense>
+      <Suspense clientOnly>
+        <Banner gameId={id} />
+      </Suspense>
 
-        <Suspense clientOnly>
-          <CheerVS gameId={id} />
-        </Suspense>
+      <Suspense clientOnly>
+        <CheerVS gameId={id} />
+      </Suspense>
 
-        <hr className="h-2 w-full border-none bg-neutral-50" />
-      </div>
+      <hr className="h-2 w-full border-none bg-neutral-50" />
 
-      <Tabs.Root className="flex min-h-0 flex-1 flex-col" defaultValue={tab}>
-        <Tabs.List className="center sticky top-0 z-10 flex h-12 flex-shrink-0 gap-5 border-b border-neutral-100 bg-white">
+      <Tabs.Root className="flex flex-col" defaultValue={tab}>
+        <Tabs.List className="sticky top-0 z-10 flex h-12 flex-shrink-0 gap-5 border-b border-neutral-100 bg-white">
           <TabTrigger className="size-full" value="cheer">
             응원
           </TabTrigger>
@@ -67,27 +65,25 @@ const Page = async ({ searchParams, params }: Props) => {
           </TabTrigger>
         </Tabs.List>
 
-        <Tabs.Content
-          value="cheer"
-          className="flex min-h-0 flex-1 flex-col overflow-hidden bg-[#EBEBEB] outline-none"
-        >
+        <Tabs.Content value="cheer" className="min-h-dvh bg-[#EBEBEB] outline-none">
           <Suspense clientOnly>
             <CheerTalk gameId={id} />
           </Suspense>
         </Tabs.Content>
-        <Tabs.Content value="lineup" className="min-h-0 flex-1 overflow-y-auto outline-none">
+
+        <Tabs.Content value="lineup" className="outline-none">
           <Suspense clientOnly>
             <LineupTab gameId={id} />
           </Suspense>
         </Tabs.Content>
 
-        <Tabs.Content value="timeline" className="min-h-0 flex-1 overflow-y-auto outline-none">
+        <Tabs.Content value="timeline" className="outline-none">
           <Suspense clientOnly>
             <TimelineTab gameId={id} />
           </Suspense>
         </Tabs.Content>
 
-        <Tabs.Content value="video" className="min-h-0 flex-1 overflow-y-auto outline-none">
+        <Tabs.Content value="video" className="outline-none">
           <Suspense clientOnly>
             <VideoTab gameId={id} />
           </Suspense>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 응원탭에서 채팅 입력시 채팅 영역이 줄어드는 문제를 발견했어요
  - 배너부분까지 전체 스크롤이 되도록 수정했어요
- 입력창에 focus되면서 화면이 zoom.. 되는 문제가 있었어요
  - 글씨 크기가 작으면 생기는 문제라고 해서 16px이상으로 키워서 해결했어요

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 사용자가 응원탭에 진입했을 때 배너부터 보여줘야할지, 최신 채팅을 보여줘야할지 중에 UX적으로 어떤게 좋을지 고민이네요
