### PR TITLE
feat: `gameQuarter` 필드 타입 변경

### DIFF
--- a/apps/manager/src/api/mutations/useUpdateGames.ts
+++ b/apps/manager/src/api/mutations/useUpdateGames.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import type { GameStateType } from '~/api';
+import type { GameQuarterType, GameStateType } from '~/api';
 
 import { fetcher, queryKeys } from '~/api/queryKey';
 
@@ -9,7 +9,7 @@ export type GameUpdateFormType = {
   gameId: number;
   name: string;
   round: number;
-  quarter: string;
+  quarter: GameQuarterType['key'];
   state: GameStateType;
   startTime: string;
   videoId: string;

--- a/apps/manager/src/api/types/games.ts
+++ b/apps/manager/src/api/types/games.ts
@@ -2,13 +2,24 @@ import type { GameTeamType } from '~/api';
 
 export type GameStateType = 'SCHEDULED' | 'PLAYING' | 'FINISHED';
 
+const quarters = [
+  { key: 'PRE_GAME', label: '경기전' },
+  { key: 'FIRST_HALF', label: '전반전' },
+  { key: 'SECOND_HALF', label: '후반전' },
+  { key: 'EXTRA_TIME', label: '연장전' },
+  { key: 'PENALTY_SHOOTOUT', label: '승부차기' },
+  { key: 'POST_GAME', label: '경기후' },
+] as const;
+
+export type GameQuarterType = (typeof quarters)[number];
+
 export type GameType = {
   id: number;
   isPkTaken: boolean;
   startTime: string;
   state: GameStateType;
   gameName: string;
-  gameQuarter: string;
+  gameQuarter: GameQuarterType;
   round: number;
   videoId: string;
   gameTeams: GameTeamType[];
@@ -16,7 +27,7 @@ export type GameType = {
 
 export type GameData = {
   startTime: string;
-  gameQuarter: string;
+  gameQuarter: GameQuarterType;
   gameName: string;
   round: number;
   videoId: string;

--- a/apps/manager/src/api/types/timelines.ts
+++ b/apps/manager/src/api/types/timelines.ts
@@ -1,3 +1,5 @@
+import type { GameQuarterType } from './games';
+
 export const PROGRESS_TYPE = {
   GAME_START: 'GAME_START',
   QUARTER_START: 'QUARTER_START',
@@ -158,6 +160,6 @@ export type TimelinePayload = {
 };
 
 export type TimelineType = {
-  gameQuarter: string;
+  gameQuarter: GameQuarterType;
   records: TimelineRecordType[];
 };

--- a/apps/manager/src/app/(private)/_components/game-card.tsx
+++ b/apps/manager/src/app/(private)/_components/game-card.tsx
@@ -6,7 +6,7 @@ import { Badge, Button, Typography } from '@hcc/ui';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import type { GameTeamType, GameType } from '~/api';
+import type { GameQuarterType, GameTeamType, GameType } from '~/api';
 
 import { routes } from '~/constants/routes';
 
@@ -16,14 +16,14 @@ export const GameCardRoot = ({ children }: PropsWithChildren) => {
 
 type GameHeaderProps = {
   leagueId: number;
-  gameQuarter?: string;
+  gameQuarter?: GameQuarterType;
 } & Pick<GameType, 'id' | 'state' | 'startTime'>;
 
 const GameHeader = ({ leagueId, id: gameId, gameQuarter, state, startTime }: GameHeaderProps) => {
   return (
     <div className="row-between">
       <Badge size="sm" variant={state === 'PLAYING' ? 'danger' : 'default'}>
-        {state ?? gameQuarter}
+        {state ?? gameQuarter?.label}
       </Badge>
       <Typography className="center-y" color="var(--color-neutral-500)" fontSize={14} asChild>
         <Link href={`/${routes.game(leagueId, gameId)}`}>

--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/form-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/form-section.tsx
@@ -189,7 +189,7 @@ const FormSectionInner = ({ leagueId, gameId }: Props) => {
     defaultValues: {
       name: data.gameName,
       round: data.round,
-      quarter: data.gameQuarter,
+      quarter: data.gameQuarter.key,
       state: data.state,
       startTime: data.startTime,
       videoId: data.videoId,

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/index.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/index.tsx
@@ -44,16 +44,15 @@ export const TimelineTab = ({ gameId }: Props) => {
       )}
 
       {data.map((timeline) => (
-        <div key={timeline.gameQuarter}>
-          <Fragment key={timeline.gameQuarter}>
+        <div key={timeline.gameQuarter.key}>
+          <Fragment key={timeline.gameQuarter.key}>
             {timeline.records.map((record) => {
               if (record.progressRecord?.gameProgressType) {
-                if (timeline.gameQuarter === '경기 종료' || timeline.gameQuarter === '경기후')
-                  return null;
+                if (timeline.gameQuarter.key === 'POST_GAME') return null;
 
                 return (
                   <TextRecord key={record.recordId} showDividerLine>
-                    {timeline.gameQuarter}이(가)&nbsp;
+                    {timeline.gameQuarter.label}이(가)&nbsp;
                     {getProgressSemantics(record.progressRecord.gameProgressType)}
                     되었습니다.
                   </TextRecord>

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/timeline-delete.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/timeline-delete.tsx
@@ -32,7 +32,7 @@ export const TimelineDeleteMenu = ({ gameId }: Props) => {
 
   const { latestRecord, latestRecordId } = useMemo(() => {
     const all = (timelineData ?? []).flatMap((q) =>
-      (q.records ?? []).map((r) => ({ ...r, __quarter: q.gameQuarter })),
+      (q.records ?? []).map((r) => ({ ...r, __quarter: q.gameQuarter.label })),
     );
 
     const toNum = (v: unknown) => Number(v);

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline.tsx
@@ -43,16 +43,15 @@ export const Timeline = ({ gameId }: Props) => {
       )}
 
       {data.map((timeline) => (
-        <div key={timeline.gameQuarter}>
-          <Fragment key={timeline.gameQuarter}>
+        <div key={timeline.gameQuarter.key}>
+          <Fragment key={timeline.gameQuarter.key}>
             {timeline.records.map((record) => {
               if (record.progressRecord?.gameProgressType) {
-                if (timeline.gameQuarter === '경기 종료' || timeline.gameQuarter === '경기후')
-                  return null;
+                if (timeline.gameQuarter.key === 'POST_GAME') return null;
 
                 return (
                   <TextRecord key={record.recordId} showDividerLine>
-                    {timeline.gameQuarter}이(가)&nbsp;
+                    {timeline.gameQuarter.label}이(가)&nbsp;
                     {getProgressSemantics(record.progressRecord.gameProgressType)}
                     되었습니다.
                   </TextRecord>

--- a/apps/spectator/src/api/types/games.ts
+++ b/apps/spectator/src/api/types/games.ts
@@ -1,8 +1,19 @@
 import type { GameTeamType } from '~/api';
 
+const quarters = [
+  { key: 'PRE_GAME', label: '경기전' },
+  { key: 'FIRST_HALF', label: '전반전' },
+  { key: 'SECOND_HALF', label: '후반전' },
+  { key: 'EXTRA_TIME', label: '연장전' },
+  { key: 'PENALTY_SHOOTOUT', label: '승부차기' },
+  { key: 'POST_GAME', label: '경기후' },
+] as const;
+
+export type GameQuarterType = (typeof quarters)[number];
+
 type GameData = {
   startTime: string;
-  gameQuarter: string;
+  gameQuarter: GameQuarterType;
   gameName: string;
   round: number;
   videoId: string;

--- a/apps/spectator/src/api/types/timelines.ts
+++ b/apps/spectator/src/api/types/timelines.ts
@@ -1,3 +1,5 @@
+import type { GameQuarterType } from './games';
+
 export const PROGRESS_TYPE = {
   GAME_START: 'GAME_START',
   QUARTER_START: 'QUARTER_START',
@@ -84,6 +86,6 @@ export type TimelinePayload = {
 };
 
 export type TimelineType = {
-  gameQuarter: string;
+  gameQuarter: GameQuarterType;
   records: TimelineRecordType[];
 };

--- a/apps/spectator/src/app/games/[id]/_components/banner.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/banner.tsx
@@ -26,7 +26,7 @@ export const Banner = ({ gameId }: Props) => {
       </div>
 
       <div className="column-center-x gap-2">
-        <Badge size="sm">{data.gameQuarter}</Badge>
+        <Badge size="sm">{data.gameQuarter.label}</Badge>
         <div className="center h-9 gap-4">
           <span
             className={twMerge(

--- a/apps/spectator/src/app/games/[id]/_components/timeline-tab/index.tsx
+++ b/apps/spectator/src/app/games/[id]/_components/timeline-tab/index.tsx
@@ -44,16 +44,15 @@ export const TimelineTab = ({ gameId }: Props) => {
       )}
 
       {data.map((timeline) => (
-        <div key={timeline.gameQuarter}>
-          <Fragment key={timeline.gameQuarter}>
+        <div key={timeline.gameQuarter.key}>
+          <Fragment key={timeline.gameQuarter.key}>
             {timeline.records.map((record) => {
               if (record.progressRecord?.gameProgressType) {
-                if (timeline.gameQuarter === '경기 종료' || timeline.gameQuarter === '경기후')
-                  return null;
+                if (timeline.gameQuarter.key === 'POST_GAME') return null;
 
                 return (
                   <TextRecord key={record.recordId} showDividerLine>
-                    {timeline.gameQuarter}이(가)&nbsp;
+                    {timeline.gameQuarter.label}이(가)&nbsp;
                     {getProgressSemantics(record.progressRecord.gameProgressType)}
                     되었습니다.
                   </TextRecord>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 쿼터 필드가 객체 타입으로 변경되어서 수정했습니다.

```ts
  { key: 'PRE_GAME', label: '경기전' },
  { key: 'FIRST_HALF', label: '전반전' },
  { key: 'SECOND_HALF', label: '후반전' },
  { key: 'EXTRA_TIME', label: '연장전' },
  { key: 'PENALTY_SHOOTOUT', label: '승부차기' },
  { key: 'POST_GAME', label: '경기후' },
```

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
