### PR TITLE
feat: 축구/농구 탭 분리 및 SportType추가

### DIFF
--- a/apps/spectator/src/api/queries/useLeagueRecentGames.ts
+++ b/apps/spectator/src/api/queries/useLeagueRecentGames.ts
@@ -1,10 +1,14 @@
 import { getQueryClient, useQuery, useSuspenseQuery } from '@hcc/api-base';
 
+import type { SportType } from '~/api/types';
+
 import { queryKeys } from '../queryKey';
 
-export const useLeagueRecentGame = () => useQuery(queryKeys.leagues.recentGames());
+export const useLeagueRecentGame = (payload?: { sportType?: SportType }) =>
+  useQuery(queryKeys.leagues.recentGames(payload));
 
-export const useSuspenseLeagueRecentGames = () => useSuspenseQuery(queryKeys.leagues.recentGames());
+export const useSuspenseLeagueRecentGames = (payload?: { sportType?: SportType }) =>
+  useSuspenseQuery(queryKeys.leagues.recentGames(payload));
 
 export const fetchLeagueRecentGames = async () =>
   await getQueryClient().fetchQuery(queryKeys.leagues.recentGames());

--- a/apps/spectator/src/api/queries/useLeagueRecentGames.ts
+++ b/apps/spectator/src/api/queries/useLeagueRecentGames.ts
@@ -10,5 +10,5 @@ export const useLeagueRecentGame = (payload?: { sportType?: SportType }) =>
 export const useSuspenseLeagueRecentGames = (payload?: { sportType?: SportType }) =>
   useSuspenseQuery(queryKeys.leagues.recentGames(payload));
 
-export const fetchLeagueRecentGames = async () =>
-  await getQueryClient().fetchQuery(queryKeys.leagues.recentGames());
+export const fetchLeagueRecentGames = async (payload?: { sportType?: SportType }) =>
+  await getQueryClient().fetchQuery(queryKeys.leagues.recentGames(payload));

--- a/apps/spectator/src/api/queryKey.ts
+++ b/apps/spectator/src/api/queryKey.ts
@@ -32,6 +32,7 @@ import type {
   LeagueTopScorersPayload,
   LeagueTopScorersType,
   LeagueType,
+  SportType,
   TeamDetailPayload,
   TeamDetailType,
   TeamGamesPayload,
@@ -143,9 +144,10 @@ const leagueQueryKeys = createQueryKeys('leagues', {
     queryKey: [payload],
     queryFn: () => fetcher.get<LeagueDetailType>(`leagues/${payload.leagueId}`),
   }),
-  recentGames: () => ({
-    queryKey: ['recent-games'],
-    queryFn: () => fetcher.get<GameListResponse[]>(`leagues/recent/games`),
+  recentGames: (payload?: { sportType?: SportType }) => ({
+    queryKey: ['recent-games', payload],
+    queryFn: () =>
+      fetcher.get<GameListResponse[]>(`leagues/recent/games`, { searchParams: payload }),
   }),
   recentSummary: (payload?: LeagueRecentSummaryPayload) => ({
     queryKey: [payload],

--- a/apps/spectator/src/api/queryKey.ts
+++ b/apps/spectator/src/api/queryKey.ts
@@ -103,6 +103,8 @@ const teamQueryKeys = createQueryKeys('teams', {
         units.forEach((u) => params.append('units', u));
       }
 
+      if (payload.sportType) params.append('sportType', payload.sportType);
+
       return fetcher.get<TeamType[]>('teams', { searchParams: params });
     },
   }),
@@ -127,6 +129,8 @@ const teamQueryKeys = createQueryKeys('teams', {
         const units = Array.isArray(payload.units) ? payload.units : [payload.units];
         units.forEach((u) => params.append('units', u));
       }
+
+      if (payload.sportType) params.append('sportType', payload.sportType);
 
       return fetcher.get<TeamSummaryType[]>('teams/summary', {
         searchParams: params,

--- a/apps/spectator/src/api/types/games.ts
+++ b/apps/spectator/src/api/types/games.ts
@@ -1,5 +1,7 @@
 import type { GameTeamType } from '~/api';
 
+import type { SportType } from './leagues';
+
 const quarters = [
   { key: 'PRE_GAME', label: '경기전' },
   { key: 'FIRST_HALF', label: '전반전' },
@@ -53,6 +55,7 @@ export type GameListResponse = {
   leagueId: number;
   leagueName: string;
   leagueProgress: 'BEFORE_START' | 'IN_PROGRESS' | 'FINISHED';
+  sportType: SportType;
   games: GameListType[];
 };
 

--- a/apps/spectator/src/api/types/leagues.ts
+++ b/apps/spectator/src/api/types/leagues.ts
@@ -1,5 +1,7 @@
 import type { TeamUnitType, TopScorerType } from './teams';
 
+export type SportType = 'SOCCER' | 'BASKETBALL';
+
 export type LeagueType = {
   leagueId: number;
   name: string;
@@ -13,6 +15,7 @@ export type LeagueListPayload = {
   leagueProgress?: 'BEFORE_START' | 'IN_PROGRESS' | 'FINISHED';
   cursor?: number;
   size?: number;
+  sportType?: SportType;
 };
 
 export type LeagueDetailPayload = {

--- a/apps/spectator/src/api/types/teams.ts
+++ b/apps/spectator/src/api/types/teams.ts
@@ -1,5 +1,7 @@
 import type { GameType } from '~/api';
 
+import type { SportType } from './leagues';
+
 export type TeamType = {
   id: number;
   name: string;
@@ -93,4 +95,4 @@ export type TeamSummaryType = {
   recentGames: GameType[];
 };
 
-export type SportType = 'SOCCER' | 'BASKETBALL';
+export type { SportType } from './leagues';

--- a/apps/spectator/src/api/types/teams.ts
+++ b/apps/spectator/src/api/types/teams.ts
@@ -30,6 +30,7 @@ export type TeamUnitType = (typeof TEAM_UNIT_LIST)[number];
 
 export type TeamListPayload = {
   units?: TeamUnitType | TeamUnitType[];
+  sportType?: SportType;
 };
 
 export type GameTeamType = {
@@ -91,3 +92,5 @@ export type TeamSummaryType = {
   teamDetail: TeamDetailType;
   recentGames: GameType[];
 };
+
+export type SportType = 'SOCCER' | 'BASKETBALL';

--- a/apps/spectator/src/api/types/teams.ts
+++ b/apps/spectator/src/api/types/teams.ts
@@ -8,6 +8,7 @@ export type TeamType = {
   logoImageUrl: string;
   unit: string;
   teamColor: string;
+  sportType: SportType;
 };
 
 export const TEAM_UNIT_LIST = [
@@ -78,6 +79,7 @@ export type TeamDetailType = {
   logoImageUrl: string;
   unit: string;
   teamColor: string;
+  sportType: SportType;
   teamPlayers: TeamPlayerType[];
   winCount: number;
   drawCount: number;

--- a/apps/spectator/src/app/(home)/_components/navigation-bar.tsx
+++ b/apps/spectator/src/app/(home)/_components/navigation-bar.tsx
@@ -4,6 +4,7 @@ import { HomeIcon, TrophyIcon, UsersIcon } from '@hcc/icons';
 import { Typography } from '@hcc/ui';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
 
 import { useTracker } from '~/hooks/useTracker';
 import { cn } from '~/utils/cn';
@@ -16,24 +17,16 @@ const NAVBAR_ITEMS = [
 
 interface Props extends React.ComponentProps<'nav'> {}
 
-export const NavigationBar = ({ 'aria-label': ariaLabel = 'Main', className, ...props }: Props) => {
+const NavItems = () => {
   const sendEvent = useTracker({ category: 'NavigationBar' });
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const sport = searchParams.get('sport');
 
   return (
-    <nav
-      aria-label={ariaLabel}
-      className={cn(
-        'fixed bottom-0 flex h-navbar-height w-full max-w-(--app-max-width) items-center justify-around gap-4 border-t border-t-greyscale-100 bg-white px-5',
-        className,
-      )}
-      {...props}
-    >
+    <>
       {NAVBAR_ITEMS.map(({ label, href, icon: Icon }) => {
         const isCurrentPath = href === '/' ? pathname === '/' : pathname.startsWith(href);
-
         const hrefWithSport = sport ? { pathname: href, query: { sport } } : href;
 
         return (
@@ -52,6 +45,23 @@ export const NavigationBar = ({ 'aria-label': ariaLabel = 'Main', className, ...
           </Link>
         );
       })}
+    </>
+  );
+};
+
+export const NavigationBar = ({ 'aria-label': ariaLabel = 'Main', className, ...props }: Props) => {
+  return (
+    <nav
+      aria-label={ariaLabel}
+      className={cn(
+        'fixed bottom-0 flex h-navbar-height w-full max-w-(--app-max-width) items-center justify-around gap-4 border-t border-t-greyscale-100 bg-white px-5',
+        className,
+      )}
+      {...props}
+    >
+      <Suspense>
+        <NavItems />
+      </Suspense>
     </nav>
   );
 };

--- a/apps/spectator/src/app/(home)/_components/navigation-bar.tsx
+++ b/apps/spectator/src/app/(home)/_components/navigation-bar.tsx
@@ -3,7 +3,7 @@
 import { HomeIcon, TrophyIcon, UsersIcon } from '@hcc/icons';
 import { Typography } from '@hcc/ui';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 
 import { useTracker } from '~/hooks/useTracker';
 import { cn } from '~/utils/cn';
@@ -19,6 +19,8 @@ interface Props extends React.ComponentProps<'nav'> {}
 export const NavigationBar = ({ 'aria-label': ariaLabel = 'Main', className, ...props }: Props) => {
   const sendEvent = useTracker({ category: 'NavigationBar' });
   const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const sport = searchParams.get('sport');
 
   return (
     <nav
@@ -32,10 +34,12 @@ export const NavigationBar = ({ 'aria-label': ariaLabel = 'Main', className, ...
       {NAVBAR_ITEMS.map(({ label, href, icon: Icon }) => {
         const isCurrentPath = href === '/' ? pathname === '/' : pathname.startsWith(href);
 
+        const hrefWithSport = sport ? { pathname: href, query: { sport } } : href;
+
         return (
           <Link
             key={href}
-            href={href}
+            href={hrefWithSport}
             aria-current={isCurrentPath ? 'page' : undefined}
             className={cn(
               'center-y flex flex-col gap-1',

--- a/apps/spectator/src/app/(home)/_components/sport-tab.tsx
+++ b/apps/spectator/src/app/(home)/_components/sport-tab.tsx
@@ -23,12 +23,12 @@ export const SportTab = () => {
 
   return (
     <Tabs.Root value={sport} onValueChange={handleChange}>
-      <Tabs.List className="flex gap-1 border-b border-neutral-100 px-8">
+      <Tabs.List className="flex items-center justify-center gap-1 border-b border-neutral-100 px-8">
         {SPORT_TABS.map(({ value, label, emoji }) => (
           <Tabs.Trigger
             key={value}
             value={value}
-            className="flex cursor-pointer items-center gap-1.5 border-b-1 px-4 py-3 text-sm font-semibold transition-colors duration-150 data-[state=active]:border-(--color-primary-600) data-[state=active]:text-(--color-primary-600) data-[state=inactive]:border-transparent data-[state=inactive]:text-(--color-greyscale-300)"
+            className="flex w-100 cursor-pointer justify-center gap-1.5 border-b-1 px-4 py-3 text-sm font-semibold transition-colors duration-150 data-[state=active]:border-(--color-primary-600) data-[state=active]:text-(--color-primary-600) data-[state=inactive]:border-transparent data-[state=inactive]:text-(--color-greyscale-300)"
           >
             <span>{emoji}</span>
             {label}

--- a/apps/spectator/src/app/(home)/_components/sport-tab.tsx
+++ b/apps/spectator/src/app/(home)/_components/sport-tab.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import * as Tabs from '@radix-ui/react-tabs';
-import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import { startTransition, useEffect } from 'react';
 
 import type { SportType } from '~/api/types';
+
+import { useSportType } from '~/hooks/useSportType';
 
 const SPORT_TABS: { value: SportType; label: string; emoji: string }[] = [
   { value: 'SOCCER', label: '축구', emoji: '⚽' },
@@ -12,10 +13,7 @@ const SPORT_TABS: { value: SportType; label: string; emoji: string }[] = [
 ];
 
 export const SportTab = () => {
-  const [sport, setSport] = useQueryState(
-    'sport',
-    parseAsStringLiteral(['SOCCER', 'BASKETBALL'] as const).withDefault('SOCCER'),
-  );
+  const { sport, setSport } = useSportType();
 
   useEffect(() => {
     setSport(sport, { scroll: false, history: 'replace', clearOnDefault: false });

--- a/apps/spectator/src/app/(home)/_components/sport-tab.tsx
+++ b/apps/spectator/src/app/(home)/_components/sport-tab.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import * as Tabs from '@radix-ui/react-tabs';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
+import { startTransition, useEffect } from 'react';
+
+import type { SportType } from '~/api/types';
+
+const SPORT_TABS: { value: SportType; label: string; emoji: string }[] = [
+  { value: 'SOCCER', label: '축구', emoji: '⚽' },
+  { value: 'BASKETBALL', label: '농구', emoji: '🏀' },
+];
+
+export const SportTab = () => {
+  const [sport, setSport] = useQueryState(
+    'sport',
+    parseAsStringLiteral(['SOCCER', 'BASKETBALL'] as const).withDefault('SOCCER'),
+  );
+
+  useEffect(() => {
+    setSport(sport, { scroll: false, history: 'replace', clearOnDefault: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleChange = (value: string) => {
+    startTransition(() => {
+      setSport(value as SportType, { scroll: false, history: 'replace', clearOnDefault: false });
+    });
+  };
+
+  return (
+    <Tabs.Root value={sport} onValueChange={handleChange}>
+      <Tabs.List className="flex gap-1 border-b border-neutral-100 px-8">
+        {SPORT_TABS.map(({ value, label, emoji }) => (
+          <Tabs.Trigger
+            key={value}
+            value={value}
+            className="flex cursor-pointer items-center gap-1.5 border-b-1 px-4 py-3 text-sm font-semibold transition-colors duration-150 data-[state=active]:border-(--color-primary-600) data-[state=active]:text-(--color-primary-600) data-[state=inactive]:border-transparent data-[state=inactive]:text-(--color-greyscale-300)"
+          >
+            <span>{emoji}</span>
+            {label}
+          </Tabs.Trigger>
+        ))}
+      </Tabs.List>
+    </Tabs.Root>
+  );
+};

--- a/apps/spectator/src/app/(home)/_components/sport-tab.tsx
+++ b/apps/spectator/src/app/(home)/_components/sport-tab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as Tabs from '@radix-ui/react-tabs';
-import { startTransition, useEffect } from 'react';
+import { startTransition } from 'react';
 
 import type { SportType } from '~/api/types';
 
@@ -15,14 +15,9 @@ const SPORT_TABS: { value: SportType; label: string; emoji: string }[] = [
 export const SportTab = () => {
   const { sport, setSport } = useSportType();
 
-  useEffect(() => {
-    setSport(sport, { scroll: false, history: 'replace', clearOnDefault: false });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const handleChange = (value: string) => {
     startTransition(() => {
-      setSport(value as SportType, { scroll: false, history: 'replace', clearOnDefault: false });
+      setSport(value as SportType, { scroll: false, history: 'replace' });
     });
   };
 

--- a/apps/spectator/src/app/(home)/_components/tab.tsx
+++ b/apps/spectator/src/app/(home)/_components/tab.tsx
@@ -13,16 +13,32 @@ import { useSuspenseLeagueCheerCount } from '~/api/queries/useLeagueCheerCount';
 import { useSuspenseLeagueRecentGames } from '~/api/queries/useLeagueRecentGames';
 import { GameCard } from '~/components/ui';
 import { routes } from '~/constants/routes';
+import { useSportType } from '~/hooks/useSportType';
 import { useTracker } from '~/hooks/useTracker';
 
 export const RecentTab = () => {
-  const { data: recentGames } = useSuspenseLeagueRecentGames();
-  const displayedGame = recentGames.at(0);
+  const { sport } = useSportType();
+  const { data: recentGames } = useSuspenseLeagueRecentGames({ sportType: sport });
+  const displayedGame = recentGames.find((league) => league.sportType === sport);
 
   if (!displayedGame) return null;
 
-  const { games, leagueId, leagueName } = displayedGame;
+  return (
+    <LeagueGameList
+      leagueId={displayedGame.leagueId}
+      leagueName={displayedGame.leagueName}
+      games={displayedGame.games}
+    />
+  );
+};
 
+interface LeagueGameListProps {
+  leagueId: number;
+  leagueName: string;
+  games: GameListType[];
+}
+
+const LeagueGameList = ({ leagueId, leagueName, games }: LeagueGameListProps) => {
   const hasPlayingGames = !games.every(({ gameState }) => gameState === 'FINISHED');
   const buttonLabel = hasPlayingGames ? '응원하러 가기' : '지난 경기 보러가기';
 
@@ -38,7 +54,7 @@ export const RecentTab = () => {
   });
 
   const { data: cheerCount } = useSuspenseLeagueCheerCount(
-    { leagueId: displayedGame?.leagueId },
+    { leagueId },
     { refetchInterval: hasPlayingGames ? 10000 : false },
   );
 

--- a/apps/spectator/src/app/(home)/page.tsx
+++ b/apps/spectator/src/app/(home)/page.tsx
@@ -2,23 +2,27 @@ import { Spinner } from '@hcc/ui';
 import { ErrorBoundary, Suspense } from '@suspensive/react';
 
 import { ErrorMessage } from './_components/error-message';
+import { SportTab } from './_components/sport-tab';
 import { RecentTab } from './_components/tab';
 
 export default function Page() {
   return (
-    <div className="flex flex-col justify-between gap-3 p-5">
-      <ErrorBoundary fallback={<ErrorMessage />}>
-        <Suspense
-          clientOnly
-          fallback={
-            <div className="flex justify-center py-12">
-              <Spinner />
-            </div>
-          }
-        >
-          <RecentTab />
-        </Suspense>
-      </ErrorBoundary>
+    <div className="flex flex-col justify-between gap-3">
+      <SportTab />
+      <div className="px-5">
+        <ErrorBoundary fallback={<ErrorMessage />}>
+          <Suspense
+            clientOnly
+            fallback={
+              <div className="flex justify-center py-12">
+                <Spinner />
+              </div>
+            }
+          >
+            <RecentTab />
+          </Suspense>
+        </ErrorBoundary>
+      </div>
     </div>
   );
 }

--- a/apps/spectator/src/app/(home)/page.tsx
+++ b/apps/spectator/src/app/(home)/page.tsx
@@ -8,21 +8,21 @@ import { RecentTab } from './_components/tab';
 export default function Page() {
   return (
     <div className="flex flex-col justify-between gap-3">
-      <SportTab />
-      <div className="px-5">
-        <ErrorBoundary fallback={<ErrorMessage />}>
-          <Suspense
-            clientOnly
-            fallback={
-              <div className="flex justify-center py-12">
-                <Spinner />
-              </div>
-            }
-          >
+      <ErrorBoundary fallback={<ErrorMessage />}>
+        <Suspense
+          clientOnly
+          fallback={
+            <div className="flex justify-center py-12">
+              <Spinner />
+            </div>
+          }
+        >
+          <SportTab />
+          <div className="px-5">
             <RecentTab />
-          </Suspense>
-        </ErrorBoundary>
-      </div>
+          </div>
+        </Suspense>
+      </ErrorBoundary>
     </div>
   );
 }

--- a/apps/spectator/src/app/(home)/previous/_components/league-card-list.tsx
+++ b/apps/spectator/src/app/(home)/previous/_components/league-card-list.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary, Suspense } from '@suspensive/react';
 
 import { useSuspenseLeagues } from '~/api';
 import { Skeleton } from '~/components/skeleton';
+import { useSportType } from '~/hooks/useSportType';
 
 import * as LeagueCard from './league-card';
 
@@ -14,7 +15,8 @@ interface Props {
 }
 
 export const LeagueCardList = ({ year }: Props) => {
-  const { data } = useSuspenseLeagues({ year, size: 50 });
+  const { sport } = useSportType();
+  const { data } = useSuspenseLeagues({ year, size: 50, sportType: sport });
 
   return (
     <div className="column gap-3 px-5 pb-5">

--- a/apps/spectator/src/app/(home)/previous/_components/year-filter.tsx
+++ b/apps/spectator/src/app/(home)/previous/_components/year-filter.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 
 import { FilterBadge } from '~/components/ui';
 
@@ -10,6 +13,8 @@ interface Props {
 
 export const YearFilter = ({ selectedYear }: Props) => {
   const currentYear = new Date().getFullYear();
+  const searchParams = useSearchParams();
+  const sport = searchParams.get('sport');
 
   const years = Array.from(
     { length: currentYear - SERVICE_START_YEAR + 1 },
@@ -23,7 +28,7 @@ export const YearFilter = ({ selectedYear }: Props) => {
           return (
             <div key={_year} className="flex shrink-0 items-center gap-2">
               <FilterBadge
-                render={<Link href={{ query: { year: _year } }} />}
+                render={<Link href={{ query: { year: _year, ...(sport && { sport }) } }} />}
                 isActive={selectedYear === _year}
               >
                 {_year}

--- a/apps/spectator/src/app/(home)/previous/page.tsx
+++ b/apps/spectator/src/app/(home)/previous/page.tsx
@@ -1,6 +1,7 @@
 import { ErrorBoundary, Suspense } from '@suspensive/react';
 
 import { ErrorMessage } from '../_components/error-message';
+import { SportTab } from '../_components/sport-tab';
 import { LeagueCardList } from './_components/league-card-list';
 import { YearFilter } from './_components/year-filter';
 
@@ -14,6 +15,7 @@ export default async function Page({ searchParams }: PageProps) {
 
   return (
     <div className="flex-1">
+      <SportTab />
       <YearFilter selectedYear={selectedYear} />
 
       <div className="column">

--- a/apps/spectator/src/app/(home)/previous/page.tsx
+++ b/apps/spectator/src/app/(home)/previous/page.tsx
@@ -15,12 +15,12 @@ export default async function Page({ searchParams }: PageProps) {
 
   return (
     <div className="flex-1">
-      <SportTab />
       <YearFilter selectedYear={selectedYear} />
 
       <div className="column">
         <ErrorBoundary fallback={<ErrorMessage />}>
           <Suspense clientOnly>
+            <SportTab />
             <LeagueCardList year={selectedYear} />
           </Suspense>
         </ErrorBoundary>

--- a/apps/spectator/src/app/(home)/previous/page.tsx
+++ b/apps/spectator/src/app/(home)/previous/page.tsx
@@ -15,16 +15,15 @@ export default async function Page({ searchParams }: PageProps) {
 
   return (
     <div className="flex-1">
-      <YearFilter selectedYear={selectedYear} />
-
-      <div className="column">
-        <ErrorBoundary fallback={<ErrorMessage />}>
-          <Suspense clientOnly>
-            <SportTab />
+      <ErrorBoundary fallback={<ErrorMessage />}>
+        <Suspense clientOnly>
+          <SportTab />
+          <YearFilter selectedYear={selectedYear} />
+          <div className="column">
             <LeagueCardList year={selectedYear} />
-          </Suspense>
-        </ErrorBoundary>
-      </div>
+          </div>
+        </Suspense>
+      </ErrorBoundary>
     </div>
   );
 }

--- a/apps/spectator/src/app/(home)/teams/_components/tab.tsx
+++ b/apps/spectator/src/app/(home)/teams/_components/tab.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary, Suspense } from '@suspensive/react';
 import { useState } from 'react';
 
 import { useSuspenseTeamsSummary } from '~/api';
+import { useSportType } from '~/hooks/useSportType';
 
 import { MatchHistory } from './match-history';
 import { ScoreList } from './score-list';
@@ -18,7 +19,8 @@ type ModalPayload = {
 
 export const TeamTab = () => {
   const { selected } = useTeamUnits();
-  const { data } = useSuspenseTeamsSummary({ units: selected });
+  const { sport } = useSportType();
+  const { data } = useSuspenseTeamsSummary({ units: selected, sportType: sport });
 
   const [modal, setModal] = useState<ModalPayload>(null);
   const open = modal !== null;

--- a/apps/spectator/src/app/(home)/teams/_components/tab.tsx
+++ b/apps/spectator/src/app/(home)/teams/_components/tab.tsx
@@ -21,6 +21,7 @@ export const TeamTab = () => {
   const { selected } = useTeamUnits();
   const { sport } = useSportType();
   const { data } = useSuspenseTeamsSummary({ units: selected, sportType: sport });
+  const filteredData = data.filter((team) => team.teamDetail.sportType === sport);
 
   const [modal, setModal] = useState<ModalPayload>(null);
   const open = modal !== null;
@@ -30,7 +31,7 @@ export const TeamTab = () => {
         <TeamFilter />
 
         <div className="column mb-5 gap-3 px-5">
-          {data.map((team) => (
+          {filteredData.map((team) => (
             <TeamCard key={team.teamDetail.teamId}>
               <TeamCard.Header team={team.teamDetail} />
               <TeamCard.Divider />

--- a/apps/spectator/src/app/(home)/teams/page.tsx
+++ b/apps/spectator/src/app/(home)/teams/page.tsx
@@ -7,9 +7,9 @@ import { TeamTab } from './_components/tab';
 export default function Page() {
   return (
     <div className="flex-1">
-      <SportTab />
       <ErrorBoundary fallback={<ErrorMessage />}>
         <Suspense clientOnly>
+          <SportTab />
           <TeamTab />
         </Suspense>
       </ErrorBoundary>

--- a/apps/spectator/src/app/(home)/teams/page.tsx
+++ b/apps/spectator/src/app/(home)/teams/page.tsx
@@ -1,11 +1,13 @@
 import { ErrorBoundary, Suspense } from '@suspensive/react';
 
 import { ErrorMessage } from '../_components/error-message';
+import { SportTab } from '../_components/sport-tab';
 import { TeamTab } from './_components/tab';
 
 export default function Page() {
   return (
     <div className="flex-1">
+      <SportTab />
       <ErrorBoundary fallback={<ErrorMessage />}>
         <Suspense clientOnly>
           <TeamTab />

--- a/apps/spectator/src/hooks/useSportType.ts
+++ b/apps/spectator/src/hooks/useSportType.ts
@@ -9,7 +9,9 @@ const SPORT_TYPES = ['SOCCER', 'BASKETBALL'] as const satisfies readonly SportTy
 export const useSportType = () => {
   const [sport, setSport] = useQueryState(
     'sport',
-    parseAsStringLiteral([...SPORT_TYPES]).withDefault('SOCCER'),
+    parseAsStringLiteral([...SPORT_TYPES])
+      .withDefault('SOCCER')
+      .withOptions({ clearOnDefault: false }),
   );
 
   return { sport: sport as SportType, setSport };

--- a/apps/spectator/src/hooks/useSportType.ts
+++ b/apps/spectator/src/hooks/useSportType.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
+
+import type { SportType } from '~/api/types';
+
+const SPORT_TYPES = ['SOCCER', 'BASKETBALL'] as const satisfies readonly SportType[];
+
+export const useSportType = () => {
+  const [sport, setSport] = useQueryState(
+    'sport',
+    parseAsStringLiteral([...SPORT_TYPES]).withDefault('SOCCER'),
+  );
+
+  return { sport: sport as SportType, setSport };
+};


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 관객화면(홈·대회·팀 탭)에 축구/농구 탭을 분리했어요
  - 선택한 종목은 URL query param(`?sport=SOCCER`)으로 관리하여 새로고침·공유 시에도 유지
  - `useSportType` 훅 추출 — 4곳에서 중복되던 `useQueryState('sport', ...)` 코드 공통화
  - `RecentTab`을 `RecentTab` + `LeagueGameList`로 분리 — 조건부 hook 호출로 인한 Rules of Hooks 위반 해결
  - `NavigationBar`에서 `useSearchParams`로 현재 `sport` 값을 읽어 이동 링크에 포함

- sportType을 추가했어요
  - `SportType` 타입 추가 (`SOCCER` | `BASKETBALL`)
  - `GET /leagues/recent/games`, `GET /leagues`, `GET /teams/summary` 요청에 `sportType` 파라미터 전달
  - `GameListResponse`에 `sportType` 필드 추가 (응답값으로 종목 필터링) 
  - `TeamType`, `TeamDetailType`에 `sportType` 필드 추가 (GET /teams, GET /teams/{teamId} 응답 반영)

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 해당 내용이 dev 서버에 반영되어있어 wip-v2가 아닌 dev로 브랜치 바꿈(머지했다가 revert했어요)
