### PR TITLE
feat: 학교 선택 기능추가

### DIFF
--- a/apps/spectator/src/api/queries/index.ts
+++ b/apps/spectator/src/api/queries/index.ts
@@ -1,5 +1,6 @@
 export * from './useGame';
 export * from './useGameCheer';
+export * from './useOrganizations';
 export * from './useGameLineup';
 export * from './useGameLineupPlaying';
 export * from './useGames';

--- a/apps/spectator/src/api/queries/useOrganizations.ts
+++ b/apps/spectator/src/api/queries/useOrganizations.ts
@@ -1,0 +1,5 @@
+import { useSuspenseQuery } from '@hcc/api-base';
+
+import { queryKeys } from '../queryKey';
+
+export const useSuspenseOrganizations = () => useSuspenseQuery(queryKeys.organizations.list);

--- a/apps/spectator/src/api/queryKey.ts
+++ b/apps/spectator/src/api/queryKey.ts
@@ -149,7 +149,7 @@ const leagueQueryKeys = createQueryKeys('leagues', {
     queryKey: [payload],
     queryFn: () => fetcher.get<LeagueDetailType>(`leagues/${payload.leagueId}`),
   }),
-  recentGames: (payload?: { sportType?: SportType }) => ({
+  recentGames: (payload?: { sportType?: SportType; organizationId?: number }) => ({
     queryKey: ['recent-games', payload],
     queryFn: () =>
       fetcher.get<GameListResponse[]>(`leagues/recent/games`, { searchParams: payload }),

--- a/apps/spectator/src/api/queryKey.ts
+++ b/apps/spectator/src/api/queryKey.ts
@@ -1,9 +1,10 @@
 import { getFetcher } from '@hcc/api-base';
 import { createQueryKeys, mergeQueryKeys } from '@lukemorales/query-key-factory';
 
-import type { TimelinePayload, TimelineType } from '~/api/types/timelines';
-
 import type {
+  OrganizationType,
+  TimelinePayload,
+  TimelineType,
   CheerTalkPayload,
   CheerTalkType,
   GameCheerPayload,
@@ -179,4 +180,16 @@ const leagueQueryKeys = createQueryKeys('leagues', {
   }),
 });
 
-export const queryKeys = mergeQueryKeys(gameQueryKeys, teamQueryKeys, leagueQueryKeys);
+const organizationQueryKeys = createQueryKeys('organizations', {
+  list: {
+    queryKey: null,
+    queryFn: () => fetcher.get<OrganizationType[]>('organizations'),
+  },
+});
+
+export const queryKeys = mergeQueryKeys(
+  gameQueryKeys,
+  teamQueryKeys,
+  leagueQueryKeys,
+  organizationQueryKeys,
+);

--- a/apps/spectator/src/api/types/index.ts
+++ b/apps/spectator/src/api/types/index.ts
@@ -1,5 +1,6 @@
 export * from './cheer-talk';
 export * from './games';
 export * from './leagues';
+export * from './organizations';
 export * from './teams';
 export * from './timelines';

--- a/apps/spectator/src/api/types/leagues.ts
+++ b/apps/spectator/src/api/types/leagues.ts
@@ -16,6 +16,7 @@ export type LeagueListPayload = {
   cursor?: number;
   size?: number;
   sportType?: SportType;
+  organizationId?: number;
 };
 
 export type LeagueDetailPayload = {

--- a/apps/spectator/src/api/types/organizations.ts
+++ b/apps/spectator/src/api/types/organizations.ts
@@ -1,0 +1,4 @@
+export type OrganizationType = {
+  id: number;
+  name: string;
+};

--- a/apps/spectator/src/app/(home)/_components/navigation-bar.tsx
+++ b/apps/spectator/src/app/(home)/_components/navigation-bar.tsx
@@ -22,12 +22,17 @@ const NavItems = () => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const sport = searchParams.get('sport');
+  const organizationId = searchParams.get('organizationId');
 
   return (
     <>
       {NAVBAR_ITEMS.map(({ label, href, icon: Icon }) => {
         const isCurrentPath = href === '/' ? pathname === '/' : pathname.startsWith(href);
-        const hrefWithSport = sport ? { pathname: href, query: { sport } } : href;
+        const query = {
+          ...(sport && { sport }),
+          ...(organizationId && { organizationId }),
+        };
+        const hrefWithSport = Object.keys(query).length > 0 ? { pathname: href, query } : href;
 
         return (
           <Link

--- a/apps/spectator/src/app/(home)/_components/school-select.tsx
+++ b/apps/spectator/src/app/(home)/_components/school-select.tsx
@@ -2,6 +2,7 @@
 
 import { CheckSmallIcon, KeyboardArrowDownIcon } from '@hcc/icons';
 import { startTransition, Suspense, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { useSuspenseOrganizations } from '~/api/queries/useOrganizations';
 import { useOrganizationId } from '~/hooks/useOrganizationId';
@@ -11,7 +12,8 @@ const SchoolSelectContent = () => {
   const { data: organizations } = useSuspenseOrganizations();
   const { organizationId, setOrganizationId } = useOrganizationId();
   const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [dropdownStyle, setDropdownStyle] = useState({ top: 0, left: 0, width: 0 });
 
   useEffect(() => {
     if (organizationId === null && organizations.length > 0) {
@@ -21,6 +23,14 @@ const SchoolSelectContent = () => {
 
   const selectedOrg = organizations.find((org) => org.id === organizationId) ?? organizations[0];
 
+  const handleOpen = () => {
+    if (buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setDropdownStyle({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+    }
+    setOpen((prev) => !prev);
+  };
+
   const handleSelect = (id: number) => {
     startTransition(() => {
       setOrganizationId(id, { scroll: false, history: 'replace' });
@@ -29,10 +39,11 @@ const SchoolSelectContent = () => {
   };
 
   return (
-    <div ref={containerRef} className="relative">
+    <div className="relative">
       <button
+        ref={buttonRef}
         type="button"
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={handleOpen}
         className="center-y cursor-pointer gap-4 rounded-xl bg-(--color-talk) px-2 py-1 text-sm font-medium text-neutral-800"
       >
         {selectedOrg?.name ?? '학교 선택'}
@@ -42,32 +53,41 @@ const SchoolSelectContent = () => {
         />
       </button>
 
-      {open && (
-        <>
-          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
-          <ul className="absolute top-full left-0 z-20 mt-1 w-full overflow-hidden rounded-xl border border-neutral-100 bg-white py-1 shadow-lg">
-            {organizations.map((org) => (
-              <li key={org.id}>
-                <button
-                  type="button"
-                  onClick={() => handleSelect(org.id)}
-                  className={cn(
-                    'row-between w-full cursor-pointer px-2 py-2.5 text-sm hover:bg-neutral-50',
-                    org.id === organizationId
-                      ? 'font-semibold text-(--color-primary-600)'
-                      : 'text-neutral-700',
-                  )}
-                >
-                  {org.name}
-                  {org.id === organizationId && (
-                    <CheckSmallIcon size={16} className="text-(--color-primary-600)" />
-                  )}
-                </button>
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
+      {open &&
+        createPortal(
+          <>
+            <div className="fixed inset-0 z-50" onClick={() => setOpen(false)} />
+            <ul
+              className="fixed z-50 overflow-hidden rounded-xl border border-neutral-100 bg-white py-1 shadow-lg"
+              style={{
+                top: dropdownStyle.top,
+                left: dropdownStyle.left,
+                width: dropdownStyle.width,
+              }}
+            >
+              {organizations.map((org) => (
+                <li key={org.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelect(org.id)}
+                    className={cn(
+                      'row-between w-full cursor-pointer px-2 py-2.5 text-sm hover:bg-neutral-50',
+                      org.id === organizationId
+                        ? 'font-semibold text-(--color-primary-600)'
+                        : 'text-neutral-700',
+                    )}
+                  >
+                    {org.name}
+                    {org.id === organizationId && (
+                      <CheckSmallIcon size={16} className="text-(--color-primary-600)" />
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>,
+          document.body,
+        )}
     </div>
   );
 };

--- a/apps/spectator/src/app/(home)/_components/school-select.tsx
+++ b/apps/spectator/src/app/(home)/_components/school-select.tsx
@@ -1,98 +1,27 @@
 'use client';
 
-import { CheckSmallIcon, KeyboardArrowDownIcon } from '@hcc/icons';
-import { startTransition, Suspense, useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { startTransition, Suspense } from 'react';
 
 import { useSuspenseOrganizations } from '~/api/queries/useOrganizations';
+import { Select } from '~/components/ui/select';
 import { useOrganizationId } from '~/hooks/useOrganizationId';
-import { cn } from '~/utils/cn';
 
 const SchoolSelectContent = () => {
   const { data: organizations } = useSuspenseOrganizations();
   const { organizationId, setOrganizationId } = useOrganizationId();
-  const [open, setOpen] = useState(false);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const [dropdownStyle, setDropdownStyle] = useState({ top: 0, left: 0, width: 0 });
 
-  useEffect(() => {
-    if (!organizations.some((org) => org.id === organizationId) && organizations.length > 0) {
-      setOrganizationId(organizations[0].id, { scroll: false, history: 'replace' });
-    }
-  }, [organizationId, organizations, setOrganizationId]);
+  const options = organizations.map((org) => ({ value: org.id, label: org.name }));
+  const selectedId = organizationId ?? organizations[0]?.id;
 
-  const selectedOrg = organizations.find((org) => org.id === organizationId) ?? organizations[0];
-
-  const handleOpen = () => {
-    if (buttonRef.current) {
-      const rect = buttonRef.current.getBoundingClientRect();
-      setDropdownStyle({ top: rect.bottom + 4, left: rect.left, width: rect.width });
-    }
-    setOpen((prev) => !prev);
-  };
-
-  const handleSelect = (id: number) => {
+  const handleChange = (id: number) => {
     startTransition(() => {
       setOrganizationId(id, { scroll: false, history: 'replace' });
     });
-    setOpen(false);
   };
 
-  return (
-    <div className="relative">
-      <button
-        ref={buttonRef}
-        type="button"
-        onClick={handleOpen}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        className="center-y cursor-pointer gap-4 rounded-xl bg-(--color-talk) px-2 py-1 text-sm font-medium text-neutral-800"
-      >
-        {selectedOrg?.name ?? '학교 선택'}
-        <KeyboardArrowDownIcon
-          size={16}
-          className={cn('text-neutral-500 transition-transform duration-150', open && 'rotate-180')}
-        />
-      </button>
+  if (selectedId === undefined) return null;
 
-      {open &&
-        createPortal(
-          <>
-            <div className="fixed inset-0 z-50" onClick={() => setOpen(false)} />
-            <ul
-              role="listbox"
-              className="fixed z-50 overflow-hidden rounded-xl border border-neutral-100 bg-white py-1 shadow-lg"
-              style={{
-                top: dropdownStyle.top,
-                left: dropdownStyle.left,
-                width: dropdownStyle.width,
-              }}
-            >
-              {organizations.map((org) => (
-                <li key={org.id} role="option" aria-selected={org.id === organizationId}>
-                  <button
-                    type="button"
-                    onClick={() => handleSelect(org.id)}
-                    className={cn(
-                      'row-between w-full cursor-pointer px-2 py-2.5 text-sm hover:bg-neutral-50',
-                      org.id === organizationId
-                        ? 'font-semibold text-(--color-primary-600)'
-                        : 'text-neutral-700',
-                    )}
-                  >
-                    {org.name}
-                    {org.id === organizationId && (
-                      <CheckSmallIcon size={16} className="text-(--color-primary-600)" />
-                    )}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </>,
-          document.body,
-        )}
-    </div>
-  );
+  return <Select value={selectedId} onChange={handleChange} options={options} />;
 };
 
 export const SchoolSelect = () => (

--- a/apps/spectator/src/app/(home)/_components/school-select.tsx
+++ b/apps/spectator/src/app/(home)/_components/school-select.tsx
@@ -16,7 +16,7 @@ const SchoolSelectContent = () => {
   const [dropdownStyle, setDropdownStyle] = useState({ top: 0, left: 0, width: 0 });
 
   useEffect(() => {
-    if (organizationId === null && organizations.length > 0) {
+    if (!organizations.some((org) => org.id === organizationId) && organizations.length > 0) {
       setOrganizationId(organizations[0].id, { scroll: false, history: 'replace' });
     }
   }, [organizationId, organizations, setOrganizationId]);
@@ -44,6 +44,8 @@ const SchoolSelectContent = () => {
         ref={buttonRef}
         type="button"
         onClick={handleOpen}
+        aria-haspopup="listbox"
+        aria-expanded={open}
         className="center-y cursor-pointer gap-4 rounded-xl bg-(--color-talk) px-2 py-1 text-sm font-medium text-neutral-800"
       >
         {selectedOrg?.name ?? '학교 선택'}
@@ -58,6 +60,7 @@ const SchoolSelectContent = () => {
           <>
             <div className="fixed inset-0 z-50" onClick={() => setOpen(false)} />
             <ul
+              role="listbox"
               className="fixed z-50 overflow-hidden rounded-xl border border-neutral-100 bg-white py-1 shadow-lg"
               style={{
                 top: dropdownStyle.top,
@@ -66,7 +69,7 @@ const SchoolSelectContent = () => {
               }}
             >
               {organizations.map((org) => (
-                <li key={org.id}>
+                <li key={org.id} role="option" aria-selected={org.id === organizationId}>
                   <button
                     type="button"
                     onClick={() => handleSelect(org.id)}
@@ -93,7 +96,7 @@ const SchoolSelectContent = () => {
 };
 
 export const SchoolSelect = () => (
-  <Suspense fallback={<div className="h-7 w-24 animate-pulse rounded-md bg-neutral-100" />}>
+  <Suspense fallback={<div className="animate-pulse rounded-xl bg-neutral-100" />}>
     <SchoolSelectContent />
   </Suspense>
 );

--- a/apps/spectator/src/app/(home)/_components/school-select.tsx
+++ b/apps/spectator/src/app/(home)/_components/school-select.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { CheckSmallIcon, KeyboardArrowDownIcon } from '@hcc/icons';
+import { startTransition, Suspense, useEffect, useRef, useState } from 'react';
+
+import { useSuspenseOrganizations } from '~/api/queries/useOrganizations';
+import { useOrganizationId } from '~/hooks/useOrganizationId';
+import { cn } from '~/utils/cn';
+
+const SchoolSelectContent = () => {
+  const { data: organizations } = useSuspenseOrganizations();
+  const { organizationId, setOrganizationId } = useOrganizationId();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (organizationId === null && organizations.length > 0) {
+      setOrganizationId(organizations[0].id, { scroll: false, history: 'replace' });
+    }
+  }, [organizationId, organizations, setOrganizationId]);
+
+  const selectedOrg = organizations.find((org) => org.id === organizationId) ?? organizations[0];
+
+  const handleSelect = (id: number) => {
+    startTransition(() => {
+      setOrganizationId(id, { scroll: false, history: 'replace' });
+    });
+    setOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="center-y cursor-pointer gap-4 rounded-xl bg-(--color-talk) px-2 py-1 text-sm font-medium text-neutral-800"
+      >
+        {selectedOrg?.name ?? '학교 선택'}
+        <KeyboardArrowDownIcon
+          size={16}
+          className={cn('text-neutral-500 transition-transform duration-150', open && 'rotate-180')}
+        />
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <ul className="absolute top-full left-0 z-20 mt-1 w-full overflow-hidden rounded-xl border border-neutral-100 bg-white py-1 shadow-lg">
+            {organizations.map((org) => (
+              <li key={org.id}>
+                <button
+                  type="button"
+                  onClick={() => handleSelect(org.id)}
+                  className={cn(
+                    'row-between w-full cursor-pointer px-2 py-2.5 text-sm hover:bg-neutral-50',
+                    org.id === organizationId
+                      ? 'font-semibold text-(--color-primary-600)'
+                      : 'text-neutral-700',
+                  )}
+                >
+                  {org.name}
+                  {org.id === organizationId && (
+                    <CheckSmallIcon size={16} className="text-(--color-primary-600)" />
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+};
+
+export const SchoolSelect = () => (
+  <Suspense fallback={<div className="h-7 w-24 animate-pulse rounded-md bg-neutral-100" />}>
+    <SchoolSelectContent />
+  </Suspense>
+);

--- a/apps/spectator/src/app/(home)/_components/tab.tsx
+++ b/apps/spectator/src/app/(home)/_components/tab.tsx
@@ -13,12 +13,17 @@ import { useSuspenseLeagueCheerCount } from '~/api/queries/useLeagueCheerCount';
 import { useSuspenseLeagueRecentGames } from '~/api/queries/useLeagueRecentGames';
 import { GameCard } from '~/components/ui';
 import { routes } from '~/constants/routes';
+import { useOrganizationId } from '~/hooks/useOrganizationId';
 import { useSportType } from '~/hooks/useSportType';
 import { useTracker } from '~/hooks/useTracker';
 
 export const RecentTab = () => {
   const { sport } = useSportType();
-  const { data: recentGames } = useSuspenseLeagueRecentGames({ sportType: sport });
+  const { organizationId } = useOrganizationId();
+  const { data: recentGames } = useSuspenseLeagueRecentGames({
+    sportType: sport,
+    ...(organizationId !== null && { organizationId }),
+  });
   const displayedGame = recentGames.find((league) => league.sportType === sport);
 
   if (!displayedGame) return null;

--- a/apps/spectator/src/app/(home)/layout.tsx
+++ b/apps/spectator/src/app/(home)/layout.tsx
@@ -6,11 +6,12 @@ import { Header } from '~/components/layout';
 
 import { CalendarMenu } from './_components/calendar-menu';
 import { NavigationBar } from './_components/navigation-bar';
+import { SchoolSelect } from './_components/school-select';
 
 const RootLayout = ({ children }: PropsWithChildren) => {
   return (
     <div className="relative">
-      <Header menu={<CalendarMenu />} />
+      <Header center={<SchoolSelect />} menu={<CalendarMenu />} />
 
       <div className="pb-navbar-height">{children}</div>
 

--- a/apps/spectator/src/app/(home)/previous/_components/league-card-list.tsx
+++ b/apps/spectator/src/app/(home)/previous/_components/league-card-list.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary, Suspense } from '@suspensive/react';
 
 import { useSuspenseLeagues } from '~/api';
 import { Skeleton } from '~/components/skeleton';
+import { useOrganizationId } from '~/hooks/useOrganizationId';
 import { useSportType } from '~/hooks/useSportType';
 
 import * as LeagueCard from './league-card';
@@ -16,7 +17,13 @@ interface Props {
 
 export const LeagueCardList = ({ year }: Props) => {
   const { sport } = useSportType();
-  const { data } = useSuspenseLeagues({ year, size: 50, sportType: sport });
+  const { organizationId } = useOrganizationId();
+  const { data } = useSuspenseLeagues({
+    year,
+    size: 50,
+    sportType: sport,
+    ...(organizationId !== null && { organizationId }),
+  });
 
   return (
     <div className="column gap-3 px-5 pb-5">

--- a/apps/spectator/src/components/layout/header.tsx
+++ b/apps/spectator/src/components/layout/header.tsx
@@ -10,10 +10,11 @@ import { routes } from '~/constants/routes';
 
 type Props = {
   arrow?: boolean;
+  center?: ReactNode;
   menu?: ReactNode;
 };
 
-export const Header = ({ arrow, menu }: Props) => {
+export const Header = ({ arrow, center, menu }: Props) => {
   const router = useRouter();
 
   return (
@@ -39,9 +40,12 @@ export const Header = ({ arrow, menu }: Props) => {
           </>
         ) : (
           <>
-            <Link className="flex items-end gap-2 select-none" href={`/${routes.home}`}>
-              <HCCLogo width="71.5" height="21" className="text-[var(--color-primary-600)]" />
-            </Link>
+            <div className="center-y gap-4">
+              <Link className="flex items-end select-none" href={`/${routes.home}`}>
+                <HCCLogo width="71.5" height="21" className="text-[var(--color-primary-600)]" />
+              </Link>
+              {center}
+            </div>
             <div className="center-y">{menu ?? null}</div>
           </>
         )}

--- a/apps/spectator/src/components/ui/select.tsx
+++ b/apps/spectator/src/components/ui/select.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from 'react';
+
+import { Select as BaseSelect } from '@base-ui/react';
+import { CheckSmallIcon, KeyboardArrowDownIcon } from '@hcc/icons';
+import { twMerge } from 'tailwind-merge';
+
+export interface SelectOption<T extends string | number> {
+  value: T;
+  label: string;
+}
+
+interface SelectProps<T extends string | number> {
+  value: T;
+  onChange: (value: T) => void;
+  options: SelectOption<T>[];
+  placeholder?: string;
+  className?: string;
+  renderValue?: (option: SelectOption<T> | undefined) => ReactNode;
+}
+
+export const Select = <T extends string | number>({
+  value,
+  onChange,
+  options,
+  placeholder = '선택',
+  className,
+  renderValue,
+}: SelectProps<T>) => {
+  const selectedOption = options.find((opt) => opt.value === value);
+
+  return (
+    <BaseSelect.Root value={value} onValueChange={onChange}>
+      <BaseSelect.Trigger
+        className={twMerge(
+          'center-y cursor-pointer gap-4 rounded-xl bg-(--color-talk) px-2 py-1 text-sm font-medium text-neutral-800',
+          '[&[data-open]>span]:rotate-180',
+          className,
+        )}
+        aria-label={placeholder}
+      >
+        <BaseSelect.Value>
+          {renderValue ? renderValue(selectedOption) : (selectedOption?.label ?? placeholder)}
+        </BaseSelect.Value>
+        <BaseSelect.Icon
+          render={<span className="text-neutral-500 transition-transform duration-150" />}
+        >
+          <KeyboardArrowDownIcon size={16} />
+        </BaseSelect.Icon>
+      </BaseSelect.Trigger>
+
+      <BaseSelect.Portal>
+        <BaseSelect.Backdrop className="fixed inset-0 z-50" />
+        <BaseSelect.Positioner className="z-50" sideOffset={4} align="start">
+          <BaseSelect.Popup className="overflow-hidden rounded-xl border border-neutral-100 bg-white py-1 shadow-lg">
+            <BaseSelect.List>
+              {options.map((option) => (
+                <BaseSelect.Item
+                  key={option.value}
+                  value={option.value}
+                  className="row-between w-full cursor-pointer px-2 py-2.5 text-sm text-neutral-700 hover:bg-neutral-50 data-[selected]:font-semibold data-[selected]:text-(--color-primary-600)"
+                >
+                  <BaseSelect.ItemText>{option.label}</BaseSelect.ItemText>
+                  <BaseSelect.ItemIndicator>
+                    <CheckSmallIcon size={16} className="text-(--color-primary-600)" />
+                  </BaseSelect.ItemIndicator>
+                </BaseSelect.Item>
+              ))}
+            </BaseSelect.List>
+          </BaseSelect.Popup>
+        </BaseSelect.Positioner>
+      </BaseSelect.Portal>
+    </BaseSelect.Root>
+  );
+};

--- a/apps/spectator/src/components/ui/select.tsx
+++ b/apps/spectator/src/components/ui/select.tsx
@@ -29,7 +29,14 @@ export const Select = <T extends string | number>({
   const selectedOption = options.find((opt) => opt.value === value);
 
   return (
-    <BaseSelect.Root value={value} onValueChange={onChange}>
+    <BaseSelect.Root
+      value={value}
+      onValueChange={(nextValue) => {
+        if (nextValue !== null) {
+          onChange(nextValue);
+        }
+      }}
+    >
       <BaseSelect.Trigger
         className={twMerge(
           'center-y cursor-pointer gap-4 rounded-xl bg-(--color-talk) px-2 py-1 text-sm font-medium text-neutral-800',

--- a/apps/spectator/src/hooks/useOrganizationId.ts
+++ b/apps/spectator/src/hooks/useOrganizationId.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import { parseAsInteger, useQueryState } from 'nuqs';
+
+export const useOrganizationId = () => {
+  const [organizationId, setOrganizationId] = useQueryState(
+    'organizationId',
+    parseAsInteger.withOptions({ clearOnDefault: false }),
+  );
+
+  return { organizationId, setOrganizationId };
+};

--- a/packages/style/css/theme.css
+++ b/packages/style/css/theme.css
@@ -62,6 +62,7 @@
 
   --color-toast: #374553;
 
+  --color-talk: #F2F2F7;
   --z-index-above: 1;
   --z-index-header: 10;
   --z-index-overlay: 1000;


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 학교 선택 기능을 추가했어요
  - 헤더 로고 옆에 학교 선택 드롭다운 배치 `SchoolSelect`
  - 앱 진입 시 첫 번째 학교가 기본값으로 설정됨
  - 드롭다운이 SportTab 등 하위 요소에 가려지는 문제를 createPortal로 해결
- `GET /organizations` 연동하여 학교 목록 조회
- `GET /leagues/recent/games`, `GET /leagues`에 organizationId 파라미터 추가
- 다른 탭을 이동해도 학교 선택 상태가 유지되도록 했어요
  - useOrganizationId 훅으로 organizationId를 URL 쿼리 파라미터로 관리



## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
