### PR TITLE
feat: Add SportType & 리그생성 UI

### DIFF
--- a/apps/manager/src/api/mutations/useCreateLeagues.ts
+++ b/apps/manager/src/api/mutations/useCreateLeagues.ts
@@ -6,7 +6,7 @@ import { fetcher, queryKeys } from '~/api/queryKey';
 
 export type LeagueFormType = Pick<
   LeagueDetailType,
-  'name' | 'maxRound' | 'startAt' | 'endAt' | 'teamIds'
+  'name' | 'maxRound' | 'startAt' | 'endAt' | 'teamIds' | 'sportType'
 >;
 
 export const postLeagues = (request: LeagueFormType) => {

--- a/apps/manager/src/api/mutations/useCreateTeams.ts
+++ b/apps/manager/src/api/mutations/useCreateTeams.ts
@@ -4,7 +4,10 @@ import type { TeamType } from '~/api';
 
 import { fetcher, queryKeys } from '~/api/queryKey';
 
-export type TeamFormType = Pick<TeamType, 'name' | 'unit' | 'teamColor' | 'teamPlayers'> & {
+export type TeamFormType = Pick<
+  TeamType,
+  'name' | 'unit' | 'teamColor' | 'teamPlayers' | 'sportType'
+> & {
   logoImageUrl: string | File;
 };
 

--- a/apps/manager/src/api/types/leagues.ts
+++ b/apps/manager/src/api/types/leagues.ts
@@ -8,10 +8,13 @@ export const LEAGUE_STATE = {
 
 export type LeagueStateType = (typeof LEAGUE_STATE)[keyof typeof LEAGUE_STATE];
 
+export type SportType = 'SOCCER' | 'BASKETBALL';
+
 export type LeagueType = {
   id: number;
   name: string;
   state: LeagueStateType;
+  sportType: SportType;
   inProgressGames: GameType[];
 };
 
@@ -29,6 +32,7 @@ export type LeagueDetailType = {
   startAt: string;
   endAt: string;
   teamIds: number[];
+  sportType: SportType;
 };
 
 export type LeagueTeamsPayload = { leagueId: number };

--- a/apps/manager/src/api/types/teams.ts
+++ b/apps/manager/src/api/types/teams.ts
@@ -1,3 +1,5 @@
+import type { SportType } from './leagues';
+
 export type TeamPlayerType = {
   playerId: number;
   name?: string;
@@ -11,6 +13,7 @@ export type TeamType = {
   logoImageUrl: string;
   unit: string;
   teamColor: string;
+  sportType: SportType;
   teamPlayers?: TeamPlayerType[];
 };
 

--- a/apps/manager/src/api/types/timelines.ts
+++ b/apps/manager/src/api/types/timelines.ts
@@ -70,6 +70,7 @@ export type WarningType = {
   gameTeamId: number;
   warnedLineupPlayerId: number;
   cardType: CardType;
+  sportType: SportType;
 };
 
 type ScoreSnapshotType = {

--- a/apps/manager/src/api/types/timelines.ts
+++ b/apps/manager/src/api/types/timelines.ts
@@ -1,4 +1,5 @@
 import type { GameQuarterType } from './games';
+import type { SportType } from './leagues';
 
 export const PROGRESS_TYPE = {
   GAME_START: 'GAME_START',
@@ -26,10 +27,12 @@ export type ScoreType = {
   recordedAt: number;
   gameTeamId: number;
   scoreLineupPlayerId: number;
+  sportType: SportType;
 };
 
 export type ReplacementType = {
   gameId?: number;
+  sportType: SportType;
   recordedQuarter: QuarterType;
   recordedAt: number;
   gameTeamId: number;
@@ -39,6 +42,7 @@ export type ReplacementType = {
 
 export type ProgressStateType = {
   gameId?: number;
+  sportType: SportType;
   recordedQuarter: QuarterType;
   recordedAt: number;
   gameProgressType: ProgressType;
@@ -46,6 +50,7 @@ export type ProgressStateType = {
 
 export type PkType = {
   gameId: number;
+  sportType: SportType;
   recordedQuarter: QuarterType;
   recordedAt: number;
   gameTeamId: number;

--- a/apps/manager/src/app/(private)/leagues/[id]/[gameId]/timeline/timelineClient.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/[gameId]/timeline/timelineClient.tsx
@@ -21,19 +21,19 @@ export default function TimelineClient({ leagueId, gameId }: { leagueId: number;
     () => ({
       addScore: {
         title: '득점 추가',
-        node: <AddScoreSheet gameId={gameId} onClose={close} />,
+        node: <AddScoreSheet leagueId={leagueId} gameId={gameId} onClose={close} />,
       },
       changeStatus: {
         title: '상태 변경',
-        node: <StatusChangeSheet gameId={gameId} onClose={close} />,
+        node: <StatusChangeSheet leagueId={leagueId} gameId={gameId} onClose={close} />,
       },
       substitute: {
         title: '교체 추가',
-        node: <SubstituteSheet gameId={gameId} onClose={close} />,
+        node: <SubstituteSheet leagueId={leagueId} gameId={gameId} onClose={close} />,
       },
       warning: {
         title: '경고 추가',
-        node: <WarningSheet gameId={gameId} onClose={close} />,
+        node: <WarningSheet leagueId={leagueId} gameId={gameId} onClose={close} />,
       },
     }),
     [gameId, close],

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/league-form/index.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/league-form/index.tsx
@@ -49,7 +49,7 @@ export const LeagueForm = ({ initialData, initialTeams, onSubmit }: Props) => {
       startAt: formData.startAt.toISOString(),
       endAt: formData.endAt.toISOString(),
       teamIds,
-      sportType: initialData?.sportType ?? 'SOCCER',
+      sportType: formData.sportType ?? 'SOCCER',
     };
 
     onSubmit(payload);
@@ -81,7 +81,7 @@ export const LeagueForm = ({ initialData, initialTeams, onSubmit }: Props) => {
                   maxRound: formData.maxRound ?? 0,
                   startAt: formData.startAt?.toISOString() ?? '',
                   endAt: formData.endAt?.toISOString() ?? '',
-                  sportType: initialData?.sportType ?? 'SOCCER',
+                  sportType: formData?.sportType ?? 'SOCCER',
                 }}
                 initialTeams={initialTeams}
                 onSubmit={handleUpdate}

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/league-form/index.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/league-form/index.tsx
@@ -30,6 +30,7 @@ export const LeagueForm = ({ initialData, initialTeams, onSubmit }: Props) => {
     startAt: initialData?.startAt ? new Date(initialData.startAt) : undefined,
     endAt: initialData?.endAt ? new Date(initialData.endAt) : undefined,
     maxRound: initialData?.maxRound,
+    sportType: initialData?.sportType ?? 'SOCCER',
   });
   const handleFormChange = (patch: Partial<LeagueInfoForm>) => {
     setFormData((prev) => ({
@@ -48,6 +49,7 @@ export const LeagueForm = ({ initialData, initialTeams, onSubmit }: Props) => {
       startAt: formData.startAt.toISOString(),
       endAt: formData.endAt.toISOString(),
       teamIds,
+      sportType: initialData?.sportType ?? 'SOCCER',
     };
 
     onSubmit(payload);
@@ -79,6 +81,7 @@ export const LeagueForm = ({ initialData, initialTeams, onSubmit }: Props) => {
                   maxRound: formData.maxRound ?? 0,
                   startAt: formData.startAt?.toISOString() ?? '',
                   endAt: formData.endAt?.toISOString() ?? '',
+                  sportType: initialData?.sportType ?? 'SOCCER',
                 }}
                 initialTeams={initialTeams}
                 onSubmit={handleUpdate}

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/AddScoreSheet.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/AddScoreSheet.tsx
@@ -8,6 +8,7 @@ import type { ScoreType } from '~/api/types';
 import { useCreateTimelinePK } from '~/api/mutations/useCreateTimelinePK';
 import { useCreateTimelineScore } from '~/api/mutations/useCreateTimelineScore';
 import { useSuspenseGameLineupPlaying } from '~/api/queries/useGameLineupPlaying';
+import { useSuspenseLeague } from '~/api/queries/useLeague';
 import { QUARTER_TYPE } from '~/api/types';
 import { InputSelect } from '~/components/ui/input-select';
 
@@ -30,12 +31,16 @@ const SUCCESS_OPTIONS: SelectOption[] = [
 ];
 
 export default function AddScoreSheet({
+  leagueId,
   gameId,
   onClose,
 }: {
+  leagueId: number;
   gameId: number;
   onClose: () => void;
 }) {
+  const { data: league } = useSuspenseLeague({ leagueId });
+  const sportType = league.sportType;
   const { mutate: createScore, isPending: isScorePending } = useCreateTimelineScore({
     gameId,
   });
@@ -100,6 +105,7 @@ export default function AddScoreSheet({
         recordedAt: 0,
         scorerId: Number(player.value),
         isSuccess: isSuccess.value === 'true',
+        sportType,
       };
 
       createPK(pkRequest, {
@@ -117,6 +123,7 @@ export default function AddScoreSheet({
         ...commonData,
         recordedAt: Number(minute),
         scoreLineupPlayerId: Number(player.value),
+        sportType,
       };
 
       createScore(scoreRequest, {

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/StatusChangeSheet.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/StatusChangeSheet.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import type { ProgressStateType } from '~/api/types';
 
 import { useCreateTimelinesProgress } from '~/api/mutations/useCreateTimelineStatus';
+import { useSuspenseLeague } from '~/api/queries/useLeague';
 import { PROGRESS_TYPE, QUARTER_TYPE } from '~/api/types';
 import { InputSelect } from '~/components/ui/input-select';
 
@@ -66,12 +67,16 @@ const progressOptions: SelectOption[] = (
 }));
 
 export default function StatusChangeSheet({
+  leagueId,
   gameId,
   onClose,
 }: {
+  leagueId: number;
   gameId: number;
   onClose: () => void;
 }) {
+  const { data: league } = useSuspenseLeague({ leagueId });
+  const sportType = league.sportType;
   const { mutate: createProgress, isPending } = useCreateTimelinesProgress({
     gameId,
   });
@@ -92,6 +97,7 @@ export default function StatusChangeSheet({
       recordedQuarter: quarter.value,
       gameProgressType: progress.value as keyof typeof PROGRESS_TYPE,
       recordedAt: Number(minute),
+      sportType,
     };
 
     createProgress(request, {

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/SubstituteSheet.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/SubstituteSheet.tsx
@@ -7,6 +7,7 @@ import type { ReplacementType } from '~/api/types';
 
 import { useCreateTimelinesReplace } from '~/api/mutations/useCreateTimelineReplacement';
 import { useSuspenseGameLineup } from '~/api/queries/useGameLineup';
+import { useSuspenseLeague } from '~/api/queries/useLeague';
 import { QUARTER_TYPE } from '~/api/types';
 import { InputSelect } from '~/components/ui/input-select';
 
@@ -25,12 +26,16 @@ const quarterOptions: SelectOption[] = (
 }));
 
 export default function SubstituteSheet({
+  leagueId,
   gameId,
   onClose,
 }: {
+  leagueId: number;
   gameId: number;
   onClose: () => void;
 }) {
+  const { data: league } = useSuspenseLeague({ leagueId });
+  const sportType = league.sportType;
   const { mutate: createReplacement, isPending } = useCreateTimelinesReplace({
     gameId,
   });
@@ -88,6 +93,7 @@ export default function SubstituteSheet({
       recordedAt: Number(minute),
       originLineupPlayerId: Number(playerOut?.value),
       replacementLineupPlayerId: Number(playerIn?.value),
+      sportType,
     };
 
     createReplacement(request, {

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/WarningSheet.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/WarningSheet.tsx
@@ -7,6 +7,7 @@ import type { WarningType } from '~/api/types';
 
 import { useCreateTimelinesWarning } from '~/api/mutations/useCreateTimelineWarning';
 import { useSuspenseGameLineupPlaying } from '~/api/queries/useGameLineupPlaying';
+import { useSuspenseLeague } from '~/api/queries/useLeague';
 import { CARD_TYPE, QUARTER_TYPE } from '~/api/types';
 import { InputSelect } from '~/components/ui/input-select';
 
@@ -34,7 +35,17 @@ const cardOptions: SelectOption[] = (Object.keys(CARD_TYPE) as Array<keyof typeo
     value: CARD_TYPE[key],
   }),
 );
-export default function WarningSheet({ gameId, onClose }: { gameId: number; onClose: () => void }) {
+export default function WarningSheet({
+  leagueId,
+  gameId,
+  onClose,
+}: {
+  leagueId: number;
+  gameId: number;
+  onClose: () => void;
+}) {
+  const { data: league } = useSuspenseLeague({ leagueId });
+  const sportType = league.sportType;
   const { mutate: createWarning, isPending } = useCreateTimelinesWarning({
     gameId,
   });
@@ -80,6 +91,7 @@ export default function WarningSheet({ gameId, onClose }: { gameId: number; onCl
       recordedQuarter: quarter.value,
       recordedAt: Number(minute),
       cardType: card.value,
+      sportType,
     };
 
     createWarning(request, {

--- a/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
+++ b/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
@@ -4,7 +4,7 @@ import { Button } from '@hcc/ui';
 import clsx from 'clsx';
 import { useMemo, useState } from 'react';
 
-import type { TeamType } from '~/api';
+import type { SportType, TeamType } from '~/api';
 
 import { useTeams } from '~/api/queries/useTeams';
 
@@ -38,13 +38,20 @@ type TeamCreationFormProps = {
   onClose: () => void;
   onRegister: (teams: RegisteredTeam[]) => void;
   maxSelectCount: number;
+  sportType: SportType;
 };
 
-export const SelectTeam = ({ onClose, onRegister, maxSelectCount }: TeamCreationFormProps) => {
+export const SelectTeam = ({
+  onClose,
+  onRegister,
+  maxSelectCount,
+  sportType,
+}: TeamCreationFormProps) => {
   const { data: teams = [], isLoading } = useTeams();
 
   const affiliations = useMemo(() => {
-    const units = teams.reduce<Record<string, TeamType[]>>((acc, team) => {
+    const filtered = teams.filter((team) => team.sportType === sportType);
+    const units = filtered.reduce<Record<string, TeamType[]>>((acc, team) => {
       if (!acc[team.unit]) {
         acc[team.unit] = [];
       }

--- a/apps/manager/src/app/(private)/leagues/create/LeagueInfo.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/LeagueInfo.tsx
@@ -3,6 +3,8 @@
 import { Button, Input } from '@hcc/ui';
 import { Suspense } from '@suspensive/react';
 
+import type { SportType } from '~/api/types';
+
 import { InputDate } from '~/components/ui/input-date';
 import { InputSelect } from '~/components/ui/input-select';
 
@@ -11,6 +13,7 @@ export type LeagueInfoForm = {
   startAt?: Date;
   endAt?: Date;
   maxRound?: number | undefined;
+  sportType: SportType;
 };
 
 const ROUND_SIZES = [32, 16, 8, 4, 2];
@@ -32,6 +35,16 @@ const LeagueInfo = ({ form, onChange, onNext, isFormValid }: LeagueInfoProps) =>
     <div className="column h-full gap-1.5 bg-white p-5">
       <Suspense clientOnly>
         <div className="flex flex-col gap-4">
+          <div className="text-lg font-semibold text-black">대회 구분</div>
+          <InputSelect
+            options={[
+              { value: 'SOCCER', label: '축구' },
+              { value: 'BASKETBALL', label: '농구' },
+            ]}
+            label="대회 구분"
+            value={form.sportType}
+            onValueChange={(v) => onChange({ sportType: v as SportType })}
+          />
           <div className="text-lg font-semibold text-black">대회 정보</div>
           <Input
             name="name"

--- a/apps/manager/src/app/(private)/leagues/create/LeagueInfo.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/LeagueInfo.tsx
@@ -8,6 +8,11 @@ import type { SportType } from '~/api/types';
 import { InputDate } from '~/components/ui/input-date';
 import { InputSelect } from '~/components/ui/input-select';
 
+const SPORT_OPTIONS: { value: SportType; label: string; emoji: string }[] = [
+  { value: 'SOCCER', label: '축구', emoji: '⚽' },
+  { value: 'BASKETBALL', label: '농구', emoji: '🏀' },
+];
+
 export type LeagueInfoForm = {
   name: string;
   startAt?: Date;
@@ -36,15 +41,19 @@ const LeagueInfo = ({ form, onChange, onNext, isFormValid }: LeagueInfoProps) =>
       <Suspense clientOnly>
         <div className="flex flex-col gap-4">
           <div className="text-lg font-semibold text-black">대회 구분</div>
-          <InputSelect
-            options={[
-              { value: 'SOCCER', label: '축구' },
-              { value: 'BASKETBALL', label: '농구' },
-            ]}
-            label="대회 구분"
-            value={form.sportType}
-            onValueChange={(v) => onChange({ sportType: v as SportType })}
-          />
+          <div className="grid grid-cols-2 gap-2">
+            {SPORT_OPTIONS.map((opt) => (
+              <Button
+                key={opt.value}
+                size="md"
+                color={form.sportType === opt.value ? 'primary' : 'black'}
+                variant={form.sportType === opt.value ? 'solid' : 'subtle'}
+                onClick={() => onChange({ sportType: opt.value })}
+              >
+                {opt.emoji} {opt.label}
+              </Button>
+            ))}
+          </div>
           <div className="text-lg font-semibold text-black">대회 정보</div>
           <Input
             name="name"

--- a/apps/manager/src/app/(private)/leagues/create/LeagueRegister.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/LeagueRegister.tsx
@@ -149,6 +149,7 @@ const LeagueRegister = ({ onPrev, round, leagueInfoForm, initialTeams = [], onSu
               onClose={() => setIsOpen(false)}
               onRegister={handleRegisterTeam}
               maxSelectCount={maxTeams - registeredTeams.length}
+              sportType={leagueInfoForm.sportType}
             />
           </div>
         </Drawer.Content>

--- a/apps/manager/src/app/(private)/leagues/create/page.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/page.tsx
@@ -17,6 +17,7 @@ const Page = () => {
     startAt: undefined,
     endAt: undefined,
     maxRound: undefined,
+    sportType: 'SOCCER',
   });
 
   const isFormValid = useMemo(() => {
@@ -38,6 +39,7 @@ const Page = () => {
       maxRound: form.maxRound ?? 0,
       startAt: form.startAt?.toISOString() ?? '',
       endAt: form.endAt?.toISOString() ?? '',
+      sportType: form.sportType,
     }),
     [form],
   );

--- a/apps/manager/src/app/(private)/leagues/page.tsx
+++ b/apps/manager/src/app/(private)/leagues/page.tsx
@@ -18,7 +18,7 @@ const Page = () => {
     <>
       <Header title="대회 관리" menu={<LeagueCreateMenu />} arrow />
 
-      <div className="column mt-1.5 h-full gap-1.5">
+      <div className="column-between h-full w-full gap-1.5 overflow-y-auto">
         <Suspense clientOnly>
           <LeagueOverview />
         </Suspense>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- API 변경에 따른 sportType 필드를 추가했어요
- 대회 생성에 종목 구분 UI를 추가했어요
- 기본 정보>참가팀 등록 에서는 해당 종목의 팀만 보이도록 했어요
<img width="328" height="703" alt="image" src="https://github.com/user-attachments/assets/6ab77408-5726-4508-a1a5-85cc23ee7e1c" />


## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
