### PR TITLE
feat: 농구 경기 생성 및 수정

### DIFF
--- a/apps/manager/src/api/types/games.ts
+++ b/apps/manager/src/api/types/games.ts
@@ -9,6 +9,11 @@ const quarters = [
   { key: 'EXTRA_TIME', label: '연장전' },
   { key: 'PENALTY_SHOOTOUT', label: '승부차기' },
   { key: 'POST_GAME', label: '경기후' },
+  { key: 'FIRST_QUARTER', label: '1쿼터' },
+  { key: 'SECOND_QUARTER', label: '2쿼터' },
+  { key: 'THIRD_QUARTER', label: '3쿼터' },
+  { key: 'FOURTH_QUARTER', label: '4쿼터' },
+  { key: 'OVERTIME', label: '연장전' },
 ] as const;
 
 export type GameQuarterType = (typeof quarters)[number];

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/form-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/form-section.tsx
@@ -158,10 +158,6 @@ const FormSectionInner = ({ leagueId, gameId }: Props) => {
       toast.warning('모든 단계를 완료해야 경기 수정이 가능해요');
       return;
     }
-    if (!form.formState.isValid) {
-      toast.error('입력값을 확인해주세요 모든 단계의 입력값이 유효해야 해요');
-      return;
-    }
 
     mutate(
       { ...formData, leagueId, gameId },

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/form-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/form-section.tsx
@@ -9,7 +9,7 @@ import { twMerge } from 'tailwind-merge';
 
 import { type GameUpdateFormType, useSuspenseGame, useSuspenseLeague, useUpdateGames } from '~/api';
 import { InputSelect } from '~/components/ui/input-select';
-import { getRoundOptions, quarterOptions, stateOptions } from '~/constants/leagues';
+import { getRoundOptions } from '~/constants/leagues';
 import { handleFormError } from '~/utils/form-util';
 
 import { StepProgress } from '../game-form/step-progress';
@@ -35,29 +35,13 @@ const GameEditBasicStep = ({ leagueId, onNext }: BasicStepProps) => {
   const { register, watch, control } = useFormContext<GameUpdateFormType>();
   const { data: league } = useSuspenseLeague({ leagueId });
 
-  const [name, round, quarter, state, startTime] = watch([
-    'name',
-    'round',
-    'quarter',
-    'state',
-    'startTime',
-  ]);
+  const [name, round, startTime] = watch(['name', 'round', 'startTime']);
 
-  const isValid = Boolean(name?.trim() && round && quarter && state && startTime);
+  const isValid = Boolean(name?.trim() && round && startTime);
 
   const roundOptions_ = getRoundOptions(league.sportType)
     .filter((item) => league.maxRound >= item.round)
     .map((item) => ({ value: item.value.toString(), label: item.label }));
-
-  const quarterListOptions = Object.entries(quarterOptions).map(([key, value]) => ({
-    value: key,
-    label: value,
-  }));
-
-  const stateListOptions = Object.entries(stateOptions).map(([key, value]) => ({
-    value: key,
-    label: value,
-  }));
 
   return (
     <div className="flex h-full flex-col">
@@ -80,32 +64,6 @@ const GameEditBasicStep = ({ leagueId, onNext }: BasicStepProps) => {
                 label="라운드"
                 options={roundOptions_}
                 value={field.value?.toString()}
-                onValueChange={field.onChange}
-              />
-            )}
-          />
-
-          <Controller
-            name="quarter"
-            control={control}
-            render={({ field }) => (
-              <InputSelect
-                label="쿼터"
-                options={quarterListOptions}
-                value={field.value}
-                onValueChange={field.onChange}
-              />
-            )}
-          />
-
-          <Controller
-            name="state"
-            control={control}
-            render={({ field }) => (
-              <InputSelect
-                label="상황"
-                options={stateListOptions}
-                value={field.value}
                 onValueChange={field.onChange}
               />
             )}

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/form-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/form-section.tsx
@@ -9,7 +9,7 @@ import { twMerge } from 'tailwind-merge';
 
 import { type GameUpdateFormType, useSuspenseGame, useSuspenseLeague, useUpdateGames } from '~/api';
 import { InputSelect } from '~/components/ui/input-select';
-import { quarterOptions, roundOptions, stateOptions } from '~/constants/leagues';
+import { getRoundOptions, quarterOptions, stateOptions } from '~/constants/leagues';
 import { handleFormError } from '~/utils/form-util';
 
 import { StepProgress } from '../game-form/step-progress';
@@ -45,7 +45,7 @@ const GameEditBasicStep = ({ leagueId, onNext }: BasicStepProps) => {
 
   const isValid = Boolean(name?.trim() && round && quarter && state && startTime);
 
-  const roundOptions_ = roundOptions
+  const roundOptions_ = getRoundOptions(league.sportType)
     .filter((item) => league.maxRound >= item.round)
     .map((item) => ({ value: item.value.toString(), label: item.label }));
 

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/form-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/form-section.tsx
@@ -189,7 +189,7 @@ const FormSectionInner = ({ leagueId, gameId }: Props) => {
       quarter: data.gameQuarter.key,
       state: data.state,
       startTime: data.startTime,
-      videoId: data.videoId,
+      //videoId: data.videoId,
     },
   });
 
@@ -201,7 +201,7 @@ const FormSectionInner = ({ leagueId, gameId }: Props) => {
       return;
     }
     if (!form.formState.isValid) {
-      toast.error('입력값을 확인해주세요. 모든 단계의 입력값이 유효해야 해요.');
+      toast.error('입력값을 확인해주세요 모든 단계의 입력값이 유효해야 해요');
       return;
     }
 

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/game-lineup-edit-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/game-lineup-edit-section.tsx
@@ -134,7 +134,7 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
       const isAlreadyStarter =
         currentSelection.find((p) => p.teamPlayerId === teamPlayerId)?.state === 'STARTER';
       if (!isAlreadyStarter && currentStarters.length >= 5) {
-        toast.warning('선발 인원이 다 찼어요');
+        toast.error('선발 인원이 다 찼어요');
         return;
       }
     }
@@ -320,35 +320,33 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
 
   return (
     <div className={twMerge('flex h-full flex-col')}>
-      <div className={twMerge('mb-4 flex border-gray-200 border-b')}>
-        {([1, 2] as const).map((tab) => {
-          const name = tab === 1 ? team1Name : team2Name;
-          const starters_ = tab === 1 ? team1Starters : team2Starters;
-          const captain_ = tab === 1 ? team1Captain : team2Captain;
-          return (
-            <button
-              key={tab}
-              type="button"
-              className={twMerge(
-                'flex-1 border-b-2 px-4 py-3 text-center font-medium transition-colors',
-                activeTab === tab
-                  ? 'border-black text-black'
-                  : 'border-transparent text-gray-500 hover:text-gray-700',
-              )}
-              onClick={() => {
-                setActiveTab(tab);
-                setSearchQuery('');
-              }}
-            >
-              <div className="flex flex-col items-center gap-1">
+      <div className="mb-4 rounded-xl bg-neutral-100 p-1">
+        <div className="flex">
+          {([1, 2] as const).map((tab) => {
+            const name = tab === 1 ? team1Name : team2Name;
+            const starters_ = tab === 1 ? team1Starters : team2Starters;
+            const captain_ = tab === 1 ? team1Captain : team2Captain;
+            return (
+              <button
+                key={tab}
+                type="button"
+                className={twMerge(
+                  'flex flex-1 flex-col items-center gap-0.5 rounded-lg px-4 py-2 text-sm font-medium transition-all',
+                  activeTab === tab ? 'bg-white text-black shadow-sm' : 'text-gray-500',
+                )}
+                onClick={() => {
+                  setActiveTab(tab);
+                  setSearchQuery('');
+                }}
+              >
                 <span>{name}</span>
-                <span className="text-xs text-gray-500">
+                <span className="text-xs text-gray-400">
                   선발 {starters_.length}명 · 주장 {captain_ ? '✓' : '✗'}
                 </span>
-              </div>
-            </button>
-          );
-        })}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
       <div className="mb-4">

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/game-lineup-edit-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/game-lineup-edit-section.tsx
@@ -14,6 +14,7 @@ import {
   useUpdateGamesStarter,
   useSuspenseGame,
   useSuspenseGameLineup,
+  useSuspenseLeague,
   useSuspenseLeagueTeams,
   useSuspenseLeagueTeamsPlayers,
   type GameLineupType,
@@ -55,6 +56,7 @@ const initializeSelection = (
 };
 
 const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
+  const { data: league } = useSuspenseLeague({ leagueId });
   const { data: game } = useSuspenseGame({ gameId });
   const { data: lineup } = useSuspenseGameLineup({ gameId });
   const { data: leagueTeams } = useSuspenseLeagueTeams({ leagueId });
@@ -125,6 +127,18 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
     newState: 'STARTER' | 'CANDIDATE',
   ) => {
     const setSelection = teamNumber === 1 ? setTeam1Selection : setTeam2Selection;
+    const currentSelection = teamNumber === 1 ? team1Selection : team2Selection;
+
+    if (league.sportType === 'BASKETBALL' && newState === 'STARTER') {
+      const currentStarters = currentSelection.filter((p) => p.state === 'STARTER');
+      const isAlreadyStarter =
+        currentSelection.find((p) => p.teamPlayerId === teamPlayerId)?.state === 'STARTER';
+      if (!isAlreadyStarter && currentStarters.length >= 5) {
+        toast.warning('선발 인원이 다 찼어요');
+        return;
+      }
+    }
+
     setSelection((prev) => {
       const existing = prev.find((p) => p.teamPlayerId === teamPlayerId);
       if (existing) {

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/game-lineup-edit-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/game-lineup-edit-section.tsx
@@ -20,6 +20,7 @@ import {
   type GameLineupType,
   type LeagueTeamsPlayerType,
 } from '~/api';
+import { getStarterLimit } from '~/constants/leagues';
 
 type PlayerSelectionState = {
   teamPlayerId: number;
@@ -129,11 +130,12 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
     const setSelection = teamNumber === 1 ? setTeam1Selection : setTeam2Selection;
     const currentSelection = teamNumber === 1 ? team1Selection : team2Selection;
 
-    if (league.sportType === 'BASKETBALL' && newState === 'STARTER') {
+    if (newState === 'STARTER') {
+      const starterLimit = getStarterLimit(league.sportType);
       const currentStarters = currentSelection.filter((p) => p.state === 'STARTER');
       const isAlreadyStarter =
         currentSelection.find((p) => p.teamPlayerId === teamPlayerId)?.state === 'STARTER';
-      if (!isAlreadyStarter && currentStarters.length >= 5) {
+      if (!isAlreadyStarter && currentStarters.length >= starterLimit) {
         toast.error('선발 인원이 다 찼어요');
         return;
       }

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/game-lineup-edit-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/game-lineup-edit-section.tsx
@@ -232,10 +232,10 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
       await applyTeamChanges(gameTeam1.gameTeamId, originalTeam1Selection, team1Selection);
       await applyTeamChanges(gameTeam2.gameTeamId, originalTeam2Selection, team2Selection);
 
-      toast.success('라인업이 수정되었습니다.');
+      toast.success('라인업을 수정했어요');
       onNext();
     } catch (error) {
-      toast.error('라인업 수정에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      toast.error('라인업 수정에 실패했어요 잠시 후 다시 시도해주세요');
     } finally {
       setSaving(false);
     }

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-basic-info-step.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-basic-info-step.tsx
@@ -4,7 +4,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 
 import { type GameFormType, useSuspenseLeague, useSuspenseLeagueTeams } from '~/api';
 import { InputSelect } from '~/components/ui/input-select';
-import { quarterOptions, roundOptions, stateOptions } from '~/constants/leagues';
+import { getRoundOptions, quarterOptions, stateOptions } from '~/constants/leagues';
 
 type Props = {
   leagueId: number;
@@ -39,10 +39,10 @@ export const GameBasicInfoStep = ({ leagueId, onNext }: Props) => {
   );
   const roundFilteredOptions = useMemo(
     () =>
-      roundOptions
+      getRoundOptions(league.sportType)
         .filter((item) => league.maxRound >= item.round)
         .map((item) => ({ value: item.value.toString(), label: item.label })),
-    [league.maxRound],
+    [league.maxRound, league.sportType],
   );
   const quarterListOptions = Object.entries(quarterOptions).map(([key, value]) => ({
     value: key,

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-basic-info-step.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-basic-info-step.tsx
@@ -4,7 +4,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 
 import { type GameFormType, useSuspenseLeague, useSuspenseLeagueTeams } from '~/api';
 import { InputSelect } from '~/components/ui/input-select';
-import { getRoundOptions, quarterOptions, stateOptions } from '~/constants/leagues';
+import { getRoundOptions } from '~/constants/leagues';
 
 type Props = {
   leagueId: number;
@@ -19,24 +19,16 @@ export const GameBasicInfoStep = ({ leagueId, onNext }: Props) => {
   const watchedFields = watch([
     'name',
     'round',
-    'quarter',
-    'state',
     'startTime',
     'team1.leagueTeamId',
     'team2.leagueTeamId',
   ]);
-  const [name, round, quarter, state, startTime, team1Id, team2Id] = watchedFields;
+  const [name, round, startTime, team1Id, team2Id] = watchedFields;
 
   const isValid = Boolean(
-    name?.trim() &&
-    round &&
-    quarter &&
-    state &&
-    startTime &&
-    team1Id &&
-    team2Id &&
-    team1Id !== team2Id,
+    name?.trim() && round && startTime && team1Id && team2Id && team1Id !== team2Id,
   );
+
   const roundFilteredOptions = useMemo(
     () =>
       getRoundOptions(league.sportType)
@@ -44,15 +36,6 @@ export const GameBasicInfoStep = ({ leagueId, onNext }: Props) => {
         .map((item) => ({ value: item.value.toString(), label: item.label })),
     [league.maxRound, league.sportType],
   );
-  const quarterListOptions = Object.entries(quarterOptions).map(([key, value]) => ({
-    value: key,
-    label: value,
-  }));
-
-  const stateListOptions = Object.entries(stateOptions).map(([key, value]) => ({
-    value: key,
-    label: value,
-  }));
 
   const teamOptions = teams.map((team) => ({
     value: team.leagueTeamId.toString(),
@@ -89,32 +72,6 @@ export const GameBasicInfoStep = ({ leagueId, onNext }: Props) => {
                 label="라운드"
                 options={roundFilteredOptions}
                 value={field.value?.toString()}
-                onValueChange={field.onChange}
-              />
-            )}
-          />
-
-          <Controller
-            name="quarter"
-            control={control}
-            render={({ field }) => (
-              <InputSelect
-                label="쿼터"
-                options={quarterListOptions}
-                value={field.value}
-                onValueChange={field.onChange}
-              />
-            )}
-          />
-
-          <Controller
-            name="state"
-            control={control}
-            render={({ field }) => (
-              <InputSelect
-                label="상황"
-                options={stateListOptions}
-                value={field.value}
                 onValueChange={field.onChange}
               />
             )}

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
@@ -100,7 +100,7 @@ export const GameLineupStep = ({ leagueId, onNext, onPrevious }: Props) => {
       const isAlreadyStarter =
         currentSelection.find((p) => p.teamPlayerId === teamPlayerId)?.state === 'STARTER';
       if (!isAlreadyStarter && currentStarters.length >= 5) {
-        toast.warning('선발인원이 모두 찼어요');
+        toast.error('선발인원이 모두 찼어요');
         return;
       }
     }
@@ -232,49 +232,33 @@ export const GameLineupStep = ({ leagueId, onNext, onPrevious }: Props) => {
   };
 
   return (
-    <div className={twMerge('w-full')}>
-      <div className={twMerge('mb-4')}>
-        <div className={twMerge('flex border-gray-200 border-b')}>
-          <button
-            type="button"
-            className={twMerge(
-              'flex-1 border-b-2 px-4 py-3 text-center font-medium transition-colors',
-              activeTab === 1
-                ? 'border-black text-black'
-                : 'border-transparent text-gray-500 hover:text-gray-700',
-            )}
-            onClick={() => {
-              setActiveTab(1);
-              setSearchQuery('');
-            }}
-          >
-            <div className="flex flex-col items-center gap-1">
-              <span>{team1?.teamName}</span>
-              <span className={twMerge('text-gray-500 text-xs')}>
-                선발: {team1Starters.length}명, 주장: {team1Captain ? '✓' : '✗'}
-              </span>
-            </div>
-          </button>
-          <button
-            type="button"
-            className={twMerge(
-              'flex-1 border-b-2 px-4 py-3 text-center font-medium transition-colors',
-              activeTab === 2
-                ? 'border-black text-black'
-                : 'border-transparent text-gray-500 hover:text-gray-700',
-            )}
-            onClick={() => {
-              setActiveTab(2);
-              setSearchQuery('');
-            }}
-          >
-            <div className="flex flex-col items-center gap-1">
-              <span>{team2?.teamName}</span>
-              <span className={twMerge('text-gray-500 text-xs')}>
-                선발: {team2Starters.length}명, 주장: {team2Captain ? '✓' : '✗'}
-              </span>
-            </div>
-          </button>
+    <div className={twMerge('flex h-full flex-col')}>
+      <div className="mb-4 rounded-xl bg-neutral-100 p-1">
+        <div className="flex">
+          {([1, 2] as const).map((tab) => {
+            const team = tab === 1 ? team1 : team2;
+            const starters = tab === 1 ? team1Starters : team2Starters;
+            const captain = tab === 1 ? team1Captain : team2Captain;
+            return (
+              <button
+                key={tab}
+                type="button"
+                className={twMerge(
+                  'flex flex-1 flex-col items-center gap-0.5 rounded-lg px-4 py-2 text-sm font-medium transition-all',
+                  activeTab === tab ? 'bg-white text-black shadow-sm' : 'text-gray-500',
+                )}
+                onClick={() => {
+                  setActiveTab(tab);
+                  setSearchQuery('');
+                }}
+              >
+                <span>{team?.teamName}</span>
+                <span className="text-xs text-gray-400">
+                  선발 {starters.length}명 · 주장 {captain ? '✓' : '✗'}
+                </span>
+              </button>
+            );
+          })}
         </div>
       </div>
       <div className={twMerge('mb-4')}>
@@ -287,10 +271,8 @@ export const GameLineupStep = ({ leagueId, onNext, onPrevious }: Props) => {
         />
       </div>
 
-      <div className={twMerge('mb-6')} style={{ maxHeight: '500px', overflowY: 'auto' }}>
-        {renderPlayerList(activeTab)}
-      </div>
-      <div className={twMerge('sticky bottom-0 border-gray-200 border-t bg-white pt-4')}>
+      <div className={twMerge('mb-6 flex-1 overflow-y-auto')}>{renderPlayerList(activeTab)}</div>
+      <div className={twMerge('flex-shrink-0 border-gray-200 border-t bg-white pt-4')}>
         <div className={twMerge('flex gap-3')}>
           <Button
             type="button"

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
@@ -9,6 +9,7 @@ import {
   useSuspenseLeagueTeams,
   useSuspenseLeagueTeamsPlayers,
 } from '~/api';
+import { getStarterLimit } from '~/constants/leagues';
 
 type Props = {
   leagueId: number;
@@ -95,11 +96,12 @@ export const GameLineupStep = ({ leagueId, onNext, onPrevious }: Props) => {
     const setSelection = teamNumber === 1 ? setTeam1Selection : setTeam2Selection;
     const currentSelection = teamNumber === 1 ? team1Selection : team2Selection;
 
-    if (league.sportType === 'BASKETBALL' && state === 'STARTER') {
+    if (state === 'STARTER') {
+      const starterLimit = getStarterLimit(league.sportType);
       const currentStarters = currentSelection.filter((p) => p.state === 'STARTER');
       const isAlreadyStarter =
         currentSelection.find((p) => p.teamPlayerId === teamPlayerId)?.state === 'STARTER';
-      if (!isAlreadyStarter && currentStarters.length >= 5) {
+      if (!isAlreadyStarter && currentStarters.length >= starterLimit) {
         toast.error('선발인원이 모두 찼어요');
         return;
       }

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-form/game-lineup-step.tsx
@@ -1,9 +1,14 @@
-import { Button, Input } from '@hcc/ui';
+import { Button, Input, toast } from '@hcc/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
 
-import { type GameFormType, useSuspenseLeagueTeams, useSuspenseLeagueTeamsPlayers } from '~/api';
+import {
+  type GameFormType,
+  useSuspenseLeague,
+  useSuspenseLeagueTeams,
+  useSuspenseLeagueTeamsPlayers,
+} from '~/api';
 
 type Props = {
   leagueId: number;
@@ -19,6 +24,7 @@ type PlayerSelectionState = {
 
 export const GameLineupStep = ({ leagueId, onNext, onPrevious }: Props) => {
   const { watch, setValue, getValues } = useFormContext<GameFormType>();
+  const { data: league } = useSuspenseLeague({ leagueId });
   const [team1Id, team2Id] = watch(['team1.leagueTeamId', 'team2.leagueTeamId']);
 
   const { data: leagueTeams } = useSuspenseLeagueTeams({ leagueId });
@@ -87,6 +93,17 @@ export const GameLineupStep = ({ leagueId, onNext, onPrevious }: Props) => {
     state: 'STARTER' | 'CANDIDATE',
   ) => {
     const setSelection = teamNumber === 1 ? setTeam1Selection : setTeam2Selection;
+    const currentSelection = teamNumber === 1 ? team1Selection : team2Selection;
+
+    if (league.sportType === 'BASKETBALL' && state === 'STARTER') {
+      const currentStarters = currentSelection.filter((p) => p.state === 'STARTER');
+      const isAlreadyStarter =
+        currentSelection.find((p) => p.teamPlayerId === teamPlayerId)?.state === 'STARTER';
+      if (!isAlreadyStarter && currentStarters.length >= 5) {
+        toast.warning('선발인원이 모두 찼어요');
+        return;
+      }
+    }
 
     setSelection((prev) => {
       const existing = prev.find((p) => p.teamPlayerId === teamPlayerId);

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/league-overview.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/league-overview.tsx
@@ -5,6 +5,7 @@ import { colors, Typography } from '@hcc/ui';
 import Link from 'next/link';
 
 import { useSuspenseLeague } from '~/api';
+import { getRoundLabel } from '~/constants/leagues';
 import { routes } from '~/constants/routes';
 
 type Props = {
@@ -44,7 +45,7 @@ export const LeagueOverview = ({ id }: Props) => {
           lineHeight="none"
         >
           <strong>라운드</strong>
-          {data.maxRound}강
+          {getRoundLabel(data.maxRound, data.sportType)}
         </Typography>
         <Typography
           className="center-y gap-2"

--- a/apps/manager/src/app/(private)/leagues/[id]/create-game/form-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/create-game/form-section.tsx
@@ -17,7 +17,7 @@ export const FormSection = ({ leagueId }: Props) => {
 
   const handleSubmit = async (data: GameFormType) => {
     mutate(
-      { ...data, leagueId },
+      { ...data, leagueId, quarter: 'PRE_GAME', state: 'SCHEDULED' },
       {
         onSuccess: () => {
           toast.success('경기가 생성되었습니다.');

--- a/apps/manager/src/app/(private)/leagues/_components/league-overview.tsx
+++ b/apps/manager/src/app/(private)/leagues/_components/league-overview.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 import { Fragment } from 'react';
 
 import { useSuspenseLeaguesLeague } from '~/api';
+import { getRoundLabel } from '~/constants/leagues';
 import { routes } from '~/constants/routes';
 
 export const LeagueOverview = () => {
@@ -50,7 +51,7 @@ export const LeagueOverview = () => {
                 weight="medium"
                 lineHeight="none"
               >
-                <strong>라운드</strong> {league.maxRound}강
+                <strong>라운드</strong> {getRoundLabel(league.maxRound, league.sportType)}
               </Typography>
               <Typography
                 color="var(--color-neutral-500)"

--- a/apps/manager/src/app/(private)/leagues/create/LeagueInfo.tsx
+++ b/apps/manager/src/app/(private)/leagues/create/LeagueInfo.tsx
@@ -7,6 +7,7 @@ import type { SportType } from '~/api/types';
 
 import { InputDate } from '~/components/ui/input-date';
 import { InputSelect } from '~/components/ui/input-select';
+import { getRoundOptions } from '~/constants/leagues';
 
 const SPORT_OPTIONS: { value: SportType; label: string; emoji: string }[] = [
   { value: 'SOCCER', label: '축구', emoji: '⚽' },
@@ -20,12 +21,6 @@ export type LeagueInfoForm = {
   maxRound?: number | undefined;
   sportType: SportType;
 };
-
-const ROUND_SIZES = [32, 16, 8, 4, 2];
-const ROUND_OPTIONS = ROUND_SIZES.map((n) => ({
-  value: String(n),
-  label: n === 2 ? '결승' : `${n}강`,
-}));
 
 type LeagueInfoProps = {
   form: LeagueInfoForm;
@@ -78,7 +73,10 @@ const LeagueInfo = ({ form, onChange, onNext, isFormValid }: LeagueInfoProps) =>
           />
 
           <InputSelect
-            options={ROUND_OPTIONS}
+            options={getRoundOptions(form.sportType).map((o) => ({
+              value: o.value,
+              label: o.label,
+            }))}
             label="라운드"
             value={form.maxRound ? String(form.maxRound) : undefined}
             onValueChange={(v) => onChange({ maxRound: Number(v) })}

--- a/apps/manager/src/constants/leagues.ts
+++ b/apps/manager/src/constants/leagues.ts
@@ -1,3 +1,26 @@
+export const soccerQuarterOptions = {
+  PRE_GAME: '경기 전',
+  FIRST_HALF: '전반전',
+  SECOND_HALF: '후반전',
+  EXTRA_TIME: '연장전',
+  PENALTY_SHOOTOUT: '승부차기',
+  POST_GAME: '경기 후',
+} as const;
+
+export const basketballQuarterOptions = {
+  PRE_GAME: '경기 전',
+  FIRST_QUARTER: '1쿼터',
+  SECOND_QUARTER: '2쿼터',
+  THIRD_QUARTER: '3쿼터',
+  FOURTH_QUARTER: '4쿼터',
+  OVERTIME: '연장전',
+  POST_GAME: '경기 후',
+} as const;
+
+export const getQuarterOptions = (sportType: 'SOCCER' | 'BASKETBALL') =>
+  sportType === 'BASKETBALL' ? basketballQuarterOptions : soccerQuarterOptions;
+
+/** @deprecated Use getQuarterOptions(sportType) instead */
 export const quarterOptions = {
   경기전: '경기전',
   전반전: '전반전',

--- a/apps/manager/src/constants/leagues.ts
+++ b/apps/manager/src/constants/leagues.ts
@@ -53,6 +53,13 @@ export const getRoundLabel = (round: number, sportType: 'SOCCER' | 'BASKETBALL')
   return sportType === 'BASKETBALL' ? option.basketballLabel : option.label;
 };
 
+export const STARTER_LIMITS = {
+  SOCCER: 11,
+  BASKETBALL: 5,
+} as const;
+
+export const getStarterLimit = (sportType: 'SOCCER' | 'BASKETBALL') => STARTER_LIMITS[sportType];
+
 export const stateOptions = {
   PLAYING: '진행 중',
   SCHEDULED: '시작 전',

--- a/apps/manager/src/constants/leagues.ts
+++ b/apps/manager/src/constants/leagues.ts
@@ -33,7 +33,7 @@ export const quarterOptions = {
 export type QuarterType = keyof typeof quarterOptions;
 
 export const roundOptions = [
-  { value: '32', label: '32강', basketballLabel: '예선', round: 32 },
+  { value: '32', label: '예선', basketballLabel: '예선', round: 32 },
   { value: '16', label: '16강', basketballLabel: '16강', round: 16 },
   { value: '8', label: '8강', basketballLabel: '8강', round: 8 },
   { value: '4', label: '4강', basketballLabel: '4강', round: 4 },

--- a/apps/manager/src/constants/leagues.ts
+++ b/apps/manager/src/constants/leagues.ts
@@ -10,12 +10,25 @@ export const quarterOptions = {
 export type QuarterType = keyof typeof quarterOptions;
 
 export const roundOptions = [
-  { value: '32', label: '32강', round: 32 },
-  { value: '16', label: '16강', round: 16 },
-  { value: '8', label: '8강', round: 8 },
-  { value: '4', label: '4강', round: 4 },
-  { value: '2', label: '결승', round: 2 },
+  { value: '32', label: '32강', basketballLabel: '예선', round: 32 },
+  { value: '16', label: '16강', basketballLabel: '16강', round: 16 },
+  { value: '8', label: '8강', basketballLabel: '8강', round: 8 },
+  { value: '4', label: '4강', basketballLabel: '4강', round: 4 },
+  { value: '2', label: '결승', basketballLabel: '결승', round: 2 },
 ] as const;
+
+export const getRoundOptions = (sportType: 'SOCCER' | 'BASKETBALL') =>
+  roundOptions.map((item) => ({
+    value: item.value,
+    label: sportType === 'BASKETBALL' ? item.basketballLabel : item.label,
+    round: item.round,
+  }));
+
+export const getRoundLabel = (round: number, sportType: 'SOCCER' | 'BASKETBALL') => {
+  const option = roundOptions.find((item) => item.round === round);
+  if (!option) return `${round}강`;
+  return sportType === 'BASKETBALL' ? option.basketballLabel : option.label;
+};
 
 export const stateOptions = {
   PLAYING: '진행 중',


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 라운드 명칭을 수정했어요(32강 -> 예선)
- 농구 라인업 인원수 제한 로직을 추가했어요
- 경기 라인업 화면에서 팀 선택 ui를 수정했어요
- 경기 생성/수정 시 상태와 쿼터 필드를 제거했어요
- 경기 수정시 폼 유효성검사에서 경기영상은 제외되도록 수정했어요

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
