### PR TITLE
feat: 팀 생성시 단과대 리스트 & 계정별 팀 목록 api추가

### DIFF
--- a/apps/manager/src/api/queries/index.ts
+++ b/apps/manager/src/api/queries/index.ts
@@ -20,4 +20,5 @@ export * from './usePlayers';
 export * from './useTeam';
 export * from './useTeams';
 export * from './useTeamUnits';
+export * from './useManagerTeams';
 export * from './useGameTimelineProgressAvailable';

--- a/apps/manager/src/api/queries/index.ts
+++ b/apps/manager/src/api/queries/index.ts
@@ -19,4 +19,5 @@ export * from './usePlayer';
 export * from './usePlayers';
 export * from './useTeam';
 export * from './useTeams';
+export * from './useTeamUnits';
 export * from './useGameTimelineProgressAvailable';

--- a/apps/manager/src/api/queries/useManagerTeams.ts
+++ b/apps/manager/src/api/queries/useManagerTeams.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@hcc/api-base';
+
+import { queryKeys } from '../queryKey';
+
+export const useManagerTeams = (units: string[], sportType: string) =>
+  useQuery({
+    ...queryKeys.teams.managerList({ units, sportType }),
+    enabled: units.length > 0,
+  });

--- a/apps/manager/src/api/queries/useTeamUnits.ts
+++ b/apps/manager/src/api/queries/useTeamUnits.ts
@@ -1,0 +1,5 @@
+import { useQuery } from '@hcc/api-base';
+
+import { queryKeys } from '../queryKey';
+
+export const useTeamUnits = (sportType: string) => useQuery(queryKeys.teams.units({ sportType }));

--- a/apps/manager/src/api/queryKey.ts
+++ b/apps/manager/src/api/queryKey.ts
@@ -93,6 +93,14 @@ const teamQueryKeys = createQueryKeys('teams', {
     queryKey: [payload],
     queryFn: () => fetcher.get<TeamUnitType[]>('manager/teams/units', { searchParams: payload }),
   }),
+  managerList: (payload: { units: string[]; sportType: string }) => ({
+    queryKey: [payload],
+    queryFn: () => {
+      const params = new URLSearchParams({ sportType: payload.sportType });
+      payload.units.forEach((unit) => params.append('units', unit));
+      return fetcher.get<TeamType[]>('manager/teams', { searchParams: params });
+    },
+  }),
 });
 
 const gameQueryKeys = createQueryKeys('games', {

--- a/apps/manager/src/api/queryKey.ts
+++ b/apps/manager/src/api/queryKey.ts
@@ -24,6 +24,7 @@ import type {
   PlayerType,
   ProgressAvailableActionsResponse,
   TeamType,
+  TeamUnitType,
   TimelinePayload,
   TimelineResponseType,
 } from './types';
@@ -87,6 +88,10 @@ const teamQueryKeys = createQueryKeys('teams', {
   teamplayers: (payload: { id: number }) => ({
     queryKey: [payload],
     queryFn: () => fetcher.get<PlayerType[]>(`teams/${payload.id}/players`),
+  }),
+  units: (payload: { sportType: string }) => ({
+    queryKey: [payload],
+    queryFn: () => fetcher.get<TeamUnitType[]>('manager/teams/units', { searchParams: payload }),
   }),
 });
 

--- a/apps/manager/src/api/types/teams.ts
+++ b/apps/manager/src/api/types/teams.ts
@@ -28,3 +28,9 @@ export type GameTeamType = {
 export type TeamDetailPayload = {
   id: number;
 };
+
+export type TeamUnitType = {
+  id: number;
+  unitName: string;
+  hasTeam: boolean;
+};

--- a/apps/manager/src/app/(private)/teams/_components/team-basic-info-step.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/team-basic-info-step.tsx
@@ -6,8 +6,9 @@ import { twMerge } from 'tailwind-merge';
 
 import type { TeamFormType } from '~/api';
 
+import { useTeamUnits } from '~/api/queries/useTeamUnits';
 import { ImageUploader } from '~/components/ui';
-import { categories, colorPalette } from '~/constants/teams';
+import { colorPalette } from '~/constants/teams';
 
 type Props = {
   onNext: () => void;
@@ -16,6 +17,7 @@ type Props = {
 export const TeamBasicInfoStep = ({ onNext }: Props) => {
   const { register, control, watch } = useFormContext<TeamFormType>();
   const colorInputRef = useRef<HTMLInputElement>(null);
+  const { data: units = [] } = useTeamUnits(watch('sportType'));
 
   const isValid = Boolean(watch('name').trim() && watch('unit').trim() && watch('teamColor'));
   const defaultPalette = [...colorPalette];
@@ -74,9 +76,9 @@ export const TeamBasicInfoStep = ({ onNext }: Props) => {
           placeholder="소속"
           required
         >
-          {categories.map((category) => (
-            <option key={category} value={category}>
-              {category}
+          {units.map((unit) => (
+            <option key={unit.id} value={unit.unitName}>
+              {unit.unitName}
             </option>
           ))}
         </Select>

--- a/apps/manager/src/app/(private)/teams/_components/team-list.tsx
+++ b/apps/manager/src/app/(private)/teams/_components/team-list.tsx
@@ -7,7 +7,8 @@ import Link from 'next/link';
 
 import type { SportType } from '~/api/types';
 
-import { useSuspenseTeams } from '~/api';
+import { useManagerTeams } from '~/api/queries/useManagerTeams';
+import { useTeamUnits } from '~/api/queries/useTeamUnits';
 import { routes } from '~/constants/routes';
 
 import { TeamDeleteDialog } from './team-delete-dialog';
@@ -18,8 +19,11 @@ type Props = {
 };
 
 export const TeamList = ({ edit, sportType }: Props) => {
-  const { data: allTeams } = useSuspenseTeams();
-  const data = allTeams.filter((team) => team.sportType === sportType);
+  const { data: units = [] } = useTeamUnits(sportType);
+  const { data = [] } = useManagerTeams(
+    units.map((u) => u.unitName),
+    sportType,
+  );
 
   return (
     <div className="column h-full gap-3 overflow-y-auto px-5 pt-5 pb-[92px]">


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- qa리스트: 팀 생성시 해당 단과대 리스트 불러오기, 매니저 계정별 팀 목록 분리 api 추가

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
