### PR TITLE
fix: 생성된 리그가 없을때 UI 깨짐 문제 해결 및 응원탭 버그 해결

### DIFF
--- a/apps/spectator/src/app/[sport]/(home)/layout.tsx
+++ b/apps/spectator/src/app/[sport]/(home)/layout.tsx
@@ -11,7 +11,7 @@ type Props = PropsWithChildren;
 
 const RootLayout = ({ children }: Props) => {
   return (
-    <div className="relative">
+    <div className="relative flex min-h-dvh flex-col">
       <Header center={<SchoolSelect />} />
 
       <div className="flex flex-1 flex-col pb-navbar-height">{children}</div>

--- a/apps/spectator/src/app/[sport]/(home)/previous/_components/league-card-list.tsx
+++ b/apps/spectator/src/app/[sport]/(home)/previous/_components/league-card-list.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from '~/components/skeleton';
 import { useOrganizationId } from '~/hooks/useOrganizationId';
 import { DEFAULT_SPORT, normalizeSportParam } from '~/utils/sport-route';
 
+import { EmptyLeague } from '../../_components/empty-league';
 import * as LeagueCard from './league-card';
 
 interface Props {
@@ -28,6 +29,8 @@ export const LeagueCardList = ({ year }: Props) => {
     sportType: sport,
     ...(organizationId !== null && { organizationId }),
   });
+
+  if (data.length === 0) return <EmptyLeague sport={sport} />;
 
   return (
     <div className="column gap-3 pb-5">

--- a/apps/spectator/src/app/[sport]/games/_components/cheer-talk/cheer-talk-list.tsx
+++ b/apps/spectator/src/app/[sport]/games/_components/cheer-talk/cheer-talk-list.tsx
@@ -41,7 +41,6 @@ export const CheerTalkList = ({
   const showNotice = () => {
     if (sessionStorage.getItem(NOTICE_DISMISSED_KEY)) return;
     setIsNoticeVisible(true);
-    sessionStorage.setItem(NOTICE_DISMISSED_KEY, 'true');
   };
 
   const scrollRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 생성된 리그가 없을때 UI 깨짐 문제 해결 -> 예전에 브랜치 병합하면서 누락된듯함 
- 응원탭 버그 해결

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
