### PR TITLE
fix: 연도 변경시에도 학교상태 유지되도록 수정

### DIFF
--- a/apps/spectator/src/app/[sport]/(home)/_components/school-select.tsx
+++ b/apps/spectator/src/app/[sport]/(home)/_components/school-select.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { startTransition, Suspense } from 'react';
+import { startTransition, Suspense, useEffect } from 'react';
 
 import { useSuspenseOrganizations } from '~/api/queries/useOrganizations';
 import { Select } from '~/components/ui/select';
@@ -11,7 +11,16 @@ const SchoolSelectContent = () => {
   const { organizationId, setOrganizationId } = useOrganizationId();
 
   const options = organizations.map((org) => ({ value: org.id, label: org.name }));
-  const selectedId = organizationId ?? organizations[0]?.id;
+  const isValidId = organizationId !== null && options.some((opt) => opt.value === organizationId);
+  const selectedId = isValidId ? organizationId : organizations[0]?.id;
+
+  useEffect(() => {
+    if (!isValidId && selectedId !== undefined) {
+      startTransition(() => {
+        setOrganizationId(selectedId, { scroll: false, history: 'replace' });
+      });
+    }
+  }, [isValidId, selectedId, setOrganizationId]);
 
   const handleChange = (id: number) => {
     startTransition(() => {

--- a/apps/spectator/src/app/[sport]/(home)/_components/school-select.tsx
+++ b/apps/spectator/src/app/[sport]/(home)/_components/school-select.tsx
@@ -11,7 +11,7 @@ const SchoolSelectContent = () => {
   const { organizationId, setOrganizationId } = useOrganizationId();
 
   const options = organizations.map((org) => ({ value: org.id, label: org.name }));
-  const isValidId = organizationId !== null && options.some((opt) => opt.value === organizationId);
+  const isValidId = options.some((opt) => opt.value === organizationId);
   const selectedId = isValidId ? organizationId : organizations[0]?.id;
 
   useEffect(() => {

--- a/apps/spectator/src/app/[sport]/(home)/previous/_components/year-filter.tsx
+++ b/apps/spectator/src/app/[sport]/(home)/previous/_components/year-filter.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 
 import { FilterBadge } from '~/components/ui';
+import { useOrganizationId } from '~/hooks/useOrganizationId';
 
 const SERVICE_START_YEAR = 2024;
 
@@ -15,7 +16,7 @@ export const YearFilter = ({ selectedYear }: Props) => {
   const currentYear = new Date().getFullYear();
   const searchParams = useSearchParams();
   const sport = searchParams.get('sport');
-  const organizationId = searchParams.get('organizationId');
+  const { organizationId } = useOrganizationId();
 
   const years = Array.from(
     { length: currentYear - SERVICE_START_YEAR + 1 },

--- a/apps/spectator/src/app/[sport]/(home)/previous/_components/year-filter.tsx
+++ b/apps/spectator/src/app/[sport]/(home)/previous/_components/year-filter.tsx
@@ -15,6 +15,7 @@ export const YearFilter = ({ selectedYear }: Props) => {
   const currentYear = new Date().getFullYear();
   const searchParams = useSearchParams();
   const sport = searchParams.get('sport');
+  const organizationId = searchParams.get('organizationId');
 
   const years = Array.from(
     { length: currentYear - SERVICE_START_YEAR + 1 },
@@ -28,7 +29,17 @@ export const YearFilter = ({ selectedYear }: Props) => {
           return (
             <div key={_year} className="flex shrink-0 items-center gap-2">
               <FilterBadge
-                render={<Link href={{ query: { year: _year, ...(sport && { sport }) } }} />}
+                render={
+                  <Link
+                    href={{
+                      query: {
+                        year: _year,
+                        ...(sport && { sport }),
+                        ...(organizationId && { organizationId }),
+                      },
+                    }}
+                  />
+                }
                 isActive={selectedYear === _year}
               >
                 {_year}

--- a/apps/spectator/src/hooks/useOrganizationId.ts
+++ b/apps/spectator/src/hooks/useOrganizationId.ts
@@ -5,7 +5,7 @@ import { parseAsInteger, useQueryState } from 'nuqs';
 export const useOrganizationId = () => {
   const [organizationId, setOrganizationId] = useQueryState(
     'organizationId',
-    parseAsInteger.withDefault(1).withOptions({ clearOnDefault: false }),
+    parseAsInteger.withOptions({ clearOnDefault: false }),
   );
 
   return { organizationId, setOrganizationId };

--- a/apps/spectator/src/hooks/useOrganizationId.ts
+++ b/apps/spectator/src/hooks/useOrganizationId.ts
@@ -5,7 +5,7 @@ import { parseAsInteger, useQueryState } from 'nuqs';
 export const useOrganizationId = () => {
   const [organizationId, setOrganizationId] = useQueryState(
     'organizationId',
-    parseAsInteger.withOptions({ clearOnDefault: false }),
+    parseAsInteger.withDefault(1).withOptions({ clearOnDefault: false }),
   );
 
   return { organizationId, setOrganizationId };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 대회 탭에서 연도가 바뀌어도 학교 상태 유지되도록 수정했어요
(이것도 저번에 브랜치 통합하면서 날라간듯...)

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
