### PR TITLE
feat: 차단된 채팅에 대한 문구추가

### DIFF
--- a/apps/spectator/src/app/[sport]/games/_components/cheer-talk/cheer-talk-item.tsx
+++ b/apps/spectator/src/app/[sport]/games/_components/cheer-talk/cheer-talk-item.tsx
@@ -12,6 +12,7 @@ type Props = {
   logoImageUrl: string;
   content: string;
   createdAt: string;
+  isBlocked: boolean;
 };
 
 export default function CheerTalkItem({
@@ -20,6 +21,7 @@ export default function CheerTalkItem({
   logoImageUrl,
   content,
   createdAt,
+  isBlocked,
 }: Props) {
   const [open, setOpen] = useState(false);
   const { mutate: report } = useCreateCheerTalkReport();
@@ -64,8 +66,8 @@ export default function CheerTalkItem({
             width={18}
             height={18}
           />
-          <Typography color={colors.neutral900} fontSize={14}>
-            {content}
+          <Typography color={isBlocked ? colors.neutral400 : colors.neutral900} fontSize={14}>
+            {isBlocked ? '관리자에 의해 차단된 톡입니다' : content}
           </Typography>
         </div>
       </div>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 차단된 채팅이 빈값으로 보이는 문제가 있어 문구 추가했어요
<img width="290" height="600" alt="image" src="https://github.com/user-attachments/assets/bafbd94f-1a52-4b40-ba09-f2a07b4ad704" />


## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
