### PR TITLE
fix: scheduled cta 정렬기준 수정

### DIFF
--- a/apps/spectator/src/app/[sport]/(home)/_components/tab.tsx
+++ b/apps/spectator/src/app/[sport]/(home)/_components/tab.tsx
@@ -61,6 +61,8 @@ const LeagueGameList = ({ leagueId, leagueName, games, sport }: LeagueGameListPr
     const bOrder = gameStateOrder[b.gameState];
 
     if (aOrder !== bOrder) return aOrder - bOrder;
+    if (a.gameState === 'SCHEDULED')
+      return new Date(a.startTime).getTime() - new Date(b.startTime).getTime();
     return new Date(b.startTime).getTime() - new Date(a.startTime).getTime();
   });
 


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- SCHEDULED만 있는 상태일 때 제일 빠른 경기가 cta로 보이도록 수정했어요

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
