### PR TITLE
fix: 축구 타임라인 교체 로직 수정

### DIFF
--- a/apps/manager/src/api/mutations/useCreateTimelinePK.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelinePK.ts
@@ -16,10 +16,10 @@ export const useCreateTimelinePK = ({ gameId }: { gameId: number }) => {
   return useMutation({
     mutationFn: postTimelinePK,
     onSuccess: async () => {
-      await qc.invalidateQueries({
-        queryKey: queryKeys.games.timeline({ gameId }).queryKey,
-        refetchType: 'all',
-      });
+      await Promise.all([
+        qc.refetchQueries({ queryKey: queryKeys.games.timeline({ gameId }).queryKey, type: 'all' }),
+        qc.refetchQueries({ queryKey: queryKeys.games.detail({ gameId }).queryKey, type: 'all' }),
+      ]);
     },
   });
 };

--- a/apps/manager/src/api/mutations/useCreateTimelinePK.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelinePK.ts
@@ -14,11 +14,11 @@ export const useCreateTimelinePK = ({ gameId }: { gameId: number }) => {
   const qc = useQueryClient();
 
   return useMutation({
-    mutationKey: queryKeys.games.timeline({ gameId }).queryKey,
     mutationFn: postTimelinePK,
     onSuccess: async () => {
       await qc.invalidateQueries({
         queryKey: queryKeys.games.timeline({ gameId }).queryKey,
+        refetchType: 'all',
       });
     },
   });

--- a/apps/manager/src/api/mutations/useCreateTimelineReplacement.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineReplacement.ts
@@ -17,14 +17,8 @@ export const useCreateTimelinesReplace = ({ gameId }: { gameId: number }) => {
     mutationFn: postTimelineReplace,
     onSuccess: async () => {
       await Promise.all([
-        qc.invalidateQueries({
-          queryKey: queryKeys.games.timeline({ gameId }).queryKey,
-          refetchType: 'all',
-        }),
-        qc.invalidateQueries({
-          queryKey: queryKeys.games.lineup({ gameId }).queryKey,
-          refetchType: 'all',
-        }),
+        qc.refetchQueries({ queryKey: queryKeys.games.timeline({ gameId }).queryKey, type: 'all' }),
+        qc.refetchQueries({ queryKey: queryKeys.games.lineup({ gameId }).queryKey, type: 'all' }),
       ]);
     },
   });

--- a/apps/manager/src/api/mutations/useCreateTimelineReplacement.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineReplacement.ts
@@ -14,12 +14,18 @@ export const useCreateTimelinesReplace = ({ gameId }: { gameId: number }) => {
   const qc = useQueryClient();
 
   return useMutation({
-    mutationKey: queryKeys.games.timeline({ gameId }).queryKey,
     mutationFn: postTimelineReplace,
     onSuccess: async () => {
-      await qc.invalidateQueries({
-        queryKey: queryKeys.games.timeline({ gameId }).queryKey,
-      });
+      await Promise.all([
+        qc.invalidateQueries({
+          queryKey: queryKeys.games.timeline({ gameId }).queryKey,
+          refetchType: 'all',
+        }),
+        qc.invalidateQueries({
+          queryKey: queryKeys.games.lineup({ gameId }).queryKey,
+          refetchType: 'all',
+        }),
+      ]);
     },
   });
 };

--- a/apps/manager/src/api/mutations/useCreateTimelineScore.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineScore.ts
@@ -14,12 +14,18 @@ export const useCreateTimelineScore = ({ gameId }: { gameId: number }) => {
   const qc = useQueryClient();
 
   return useMutation({
-    mutationKey: queryKeys.games.timeline({ gameId }).queryKey,
     mutationFn: postTimelineScore,
     onSuccess: async () => {
-      await qc.invalidateQueries({
-        queryKey: queryKeys.games.timeline({ gameId }).queryKey,
-      });
+      await Promise.all([
+        qc.invalidateQueries({
+          queryKey: queryKeys.games.timeline({ gameId }).queryKey,
+          refetchType: 'all',
+        }),
+        qc.invalidateQueries({
+          queryKey: queryKeys.games.detail({ gameId }).queryKey,
+          refetchType: 'all',
+        }),
+      ]);
     },
   });
 };

--- a/apps/manager/src/api/mutations/useCreateTimelineScore.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineScore.ts
@@ -17,14 +17,8 @@ export const useCreateTimelineScore = ({ gameId }: { gameId: number }) => {
     mutationFn: postTimelineScore,
     onSuccess: async () => {
       await Promise.all([
-        qc.invalidateQueries({
-          queryKey: queryKeys.games.timeline({ gameId }).queryKey,
-          refetchType: 'all',
-        }),
-        qc.invalidateQueries({
-          queryKey: queryKeys.games.detail({ gameId }).queryKey,
-          refetchType: 'all',
-        }),
+        qc.refetchQueries({ queryKey: queryKeys.games.timeline({ gameId }).queryKey, type: 'all' }),
+        qc.refetchQueries({ queryKey: queryKeys.games.detail({ gameId }).queryKey, type: 'all' }),
       ]);
     },
   });

--- a/apps/manager/src/api/mutations/useCreateTimelineStatus.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineStatus.ts
@@ -17,18 +17,12 @@ export const useCreateTimelinesProgress = ({ gameId }: { gameId: number }) => {
     mutationFn: postTimelineProgress,
     onSuccess: async () => {
       await Promise.all([
-        qc.invalidateQueries({
-          queryKey: queryKeys.games.timeline({ gameId }).queryKey,
-          refetchType: 'all',
-        }),
-        qc.invalidateQueries({
+        qc.refetchQueries({ queryKey: queryKeys.games.timeline({ gameId }).queryKey, type: 'all' }),
+        qc.refetchQueries({
           queryKey: queryKeys.games.progressAvailable({ gameId }).queryKey,
-          refetchType: 'all',
+          type: 'all',
         }),
-        qc.invalidateQueries({
-          queryKey: queryKeys.games.detail({ gameId }).queryKey,
-          refetchType: 'all',
-        }),
+        qc.refetchQueries({ queryKey: queryKeys.games.detail({ gameId }).queryKey, type: 'all' }),
       ]);
     },
   });

--- a/apps/manager/src/api/mutations/useCreateTimelineStatus.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineStatus.ts
@@ -14,16 +14,22 @@ export const useCreateTimelinesProgress = ({ gameId }: { gameId: number }) => {
   const qc = useQueryClient();
 
   return useMutation({
-    mutationKey: queryKeys.games.timeline({ gameId }).queryKey,
     mutationFn: postTimelineProgress,
     onSuccess: async () => {
-      await qc.invalidateQueries({
-        queryKey: queryKeys.games.timeline({ gameId }).queryKey,
-      });
-
-      await qc.invalidateQueries({
-        queryKey: queryKeys.games.progressAvailable({ gameId }).queryKey,
-      });
+      await Promise.all([
+        qc.invalidateQueries({
+          queryKey: queryKeys.games.timeline({ gameId }).queryKey,
+          refetchType: 'all',
+        }),
+        qc.invalidateQueries({
+          queryKey: queryKeys.games.progressAvailable({ gameId }).queryKey,
+          refetchType: 'all',
+        }),
+        qc.invalidateQueries({
+          queryKey: queryKeys.games.detail({ gameId }).queryKey,
+          refetchType: 'all',
+        }),
+      ]);
     },
   });
 };

--- a/apps/manager/src/api/mutations/useCreateTimelineWarning.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineWarning.ts
@@ -16,9 +16,9 @@ export const useCreateTimelinesWarning = ({ gameId }: { gameId: number }) => {
   return useMutation({
     mutationFn: postTimelineWarning,
     onSuccess: async () => {
-      await qc.invalidateQueries({
+      await qc.refetchQueries({
         queryKey: queryKeys.games.timeline({ gameId }).queryKey,
-        refetchType: 'all',
+        type: 'all',
       });
     },
   });

--- a/apps/manager/src/api/mutations/useCreateTimelineWarning.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineWarning.ts
@@ -14,11 +14,11 @@ export const useCreateTimelinesWarning = ({ gameId }: { gameId: number }) => {
   const qc = useQueryClient();
 
   return useMutation({
-    mutationKey: queryKeys.games.timeline({ gameId }).queryKey,
     mutationFn: postTimelineWarning,
     onSuccess: async () => {
       await qc.invalidateQueries({
         queryKey: queryKeys.games.timeline({ gameId }).queryKey,
+        refetchType: 'all',
       });
     },
   });

--- a/apps/manager/src/api/mutations/useDeleteTimeline.ts
+++ b/apps/manager/src/api/mutations/useDeleteTimeline.ts
@@ -20,14 +20,9 @@ export const useDeleteTimeline = ({ gameId }: { gameId: number }) => {
     mutationFn: deleteTimeline,
     onSuccess: async () => {
       await Promise.all([
-        qc.refetchQueries({
-          queryKey: queryKeys.games.timeline({ gameId }).queryKey,
-          type: 'all',
-        }),
-        qc.refetchQueries({
-          queryKey: queryKeys.games.lineup({ gameId }).queryKey,
-          type: 'all',
-        }),
+        qc.refetchQueries({ queryKey: queryKeys.games.timeline({ gameId }).queryKey, type: 'all' }),
+        qc.refetchQueries({ queryKey: queryKeys.games.lineup({ gameId }).queryKey, type: 'all' }),
+        qc.refetchQueries({ queryKey: queryKeys.games.detail({ gameId }).queryKey, type: 'all' }),
       ]);
     },
   });

--- a/apps/manager/src/api/mutations/useDeleteTimeline.ts
+++ b/apps/manager/src/api/mutations/useDeleteTimeline.ts
@@ -17,12 +17,18 @@ export const useDeleteTimeline = ({ gameId }: { gameId: number }) => {
   const qc = useQueryClient();
 
   return useMutation({
-    mutationKey: queryKeys.games.timeline({ gameId }).queryKey,
     mutationFn: deleteTimeline,
     onSuccess: async () => {
-      await qc.invalidateQueries({
-        queryKey: queryKeys.games.timeline({ gameId }).queryKey,
-      });
+      await Promise.all([
+        qc.refetchQueries({
+          queryKey: queryKeys.games.timeline({ gameId }).queryKey,
+          type: 'all',
+        }),
+        qc.refetchQueries({
+          queryKey: queryKeys.games.lineup({ gameId }).queryKey,
+          type: 'all',
+        }),
+      ]);
     },
   });
 };

--- a/apps/manager/src/api/types/timelines.ts
+++ b/apps/manager/src/api/types/timelines.ts
@@ -154,64 +154,64 @@ export type WarningCardRecordType = {
 type ScoreTimelineRecord = CommonTimelineRecordFields & {
   type: typeof RecordType.SCORE;
   scoreRecord: ScoreRecordType;
-  replacementRecord: undefined;
-  progressRecord: undefined;
-  pkRecord: undefined;
-  warningCardRecord?: WarningCardRecordType;
+  replacementRecord: ReplacementRecordType | null;
+  progressRecord: ProgressRecordType | null;
+  pkRecord: PkRecordType | null;
+  warningCardRecord: WarningCardRecordType | null;
 };
 
 type SoccerReplacementTimelineRecord = CommonTimelineRecordFields & {
   type: typeof RecordType.SOCCER_REPLACEMENT;
-  scoreRecord: undefined;
+  scoreRecord: ScoreRecordType | null;
   replacementRecord: ReplacementRecordType;
-  progressRecord: undefined;
-  pkRecord: undefined;
-  warningCardRecord?: WarningCardRecordType;
+  progressRecord: ProgressRecordType | null;
+  pkRecord: PkRecordType | null;
+  warningCardRecord: WarningCardRecordType | null;
 };
 
 type BasketballReplacementTimelineRecord = CommonTimelineRecordFields & {
   type: typeof RecordType.BASKETBALL_REPLACEMENT;
-  scoreRecord: undefined;
+  scoreRecord: ScoreRecordType | null;
   replacementRecord: ReplacementRecordType;
-  progressRecord: undefined;
-  pkRecord: undefined;
-  warningCardRecord?: WarningCardRecordType;
+  progressRecord: ProgressRecordType | null;
+  pkRecord: PkRecordType | null;
+  warningCardRecord: WarningCardRecordType | null;
 };
 
 type ProgressTimelineRecord = CommonTimelineRecordFields & {
   type: typeof RecordType.PROGRESS;
-  scoreRecord: undefined;
-  replacementRecord: undefined;
+  scoreRecord: ScoreRecordType | null;
+  replacementRecord: ReplacementRecordType | null;
   progressRecord: ProgressRecordType;
-  pkRecord: undefined;
-  warningCardRecord?: WarningCardRecordType;
+  pkRecord: PkRecordType | null;
+  warningCardRecord: WarningCardRecordType | null;
 };
 
 type PkTimelineRecord = CommonTimelineRecordFields & {
   type: typeof RecordType.PK;
-  scoreRecord: undefined;
-  replacementRecord: undefined;
-  progressRecord: undefined;
+  scoreRecord: ScoreRecordType | null;
+  replacementRecord: ReplacementRecordType | null;
+  progressRecord: ProgressRecordType | null;
   pkRecord: PkRecordType;
-  warningCardRecord?: WarningCardRecordType;
+  warningCardRecord: WarningCardRecordType | null;
 };
 
 type WarningCardTimelineRecord = CommonTimelineRecordFields & {
   type: typeof RecordType.WARNING_CARD;
-  scoreRecord: undefined;
-  replacementRecord: undefined;
-  progressRecord: undefined;
-  pkRecord: undefined;
+  scoreRecord: ScoreRecordType | null;
+  replacementRecord: ReplacementRecordType | null;
+  progressRecord: ProgressRecordType | null;
+  pkRecord: PkRecordType | null;
   warningCardRecord: WarningCardRecordType;
 };
 
 type FoulTimelineRecord = CommonTimelineRecordFields & {
   type: typeof RecordType.FOUL;
-  scoreRecord: undefined;
-  replacementRecord: undefined;
-  progressRecord: undefined;
-  pkRecord: undefined;
-  warningCardRecord: undefined;
+  scoreRecord: ScoreRecordType | null;
+  replacementRecord: ReplacementRecordType | null;
+  progressRecord: ProgressRecordType | null;
+  pkRecord: PkRecordType | null;
+  warningCardRecord: WarningCardRecordType | null;
 };
 
 type AnyTimelineRecord =

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/SubstituteSheet.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/sheets/SubstituteSheet.tsx
@@ -55,22 +55,18 @@ export default function SubstituteSheet({
 
   const playerInOptions: SelectOption[] = useMemo(() => {
     if (!selectedTeam) return [];
-    return selectedTeam.candidatePlayers
-      .filter((p) => p.state === 'CANDIDATE')
-      .map((p) => ({
-        label: `${p.jerseyNumber} ${p.playerName}`,
-        value: String(p.lineupPlayerId),
-      }));
+    return selectedTeam.candidatePlayers.map((p) => ({
+      label: `${p.jerseyNumber} ${p.playerName}`,
+      value: String(p.lineupPlayerId),
+    }));
   }, [selectedTeam]);
 
   const playerOutOptions: SelectOption[] = useMemo(() => {
     if (!selectedTeam) return [];
-    return selectedTeam.starterPlayers
-      .filter((p) => p.state === 'STARTER')
-      .map((p) => ({
-        label: `${p.jerseyNumber} ${p.playerName}`,
-        value: String(p.lineupPlayerId),
-      }));
+    return selectedTeam.starterPlayers.map((p) => ({
+      label: `${p.jerseyNumber} ${p.playerName}`,
+      value: String(p.lineupPlayerId),
+    }));
   }, [selectedTeam]);
 
   const isFormValid = !!quarter && selectedTeamId !== null && !!playerIn && !!playerOut && !!minute;

--- a/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/timeline-delete.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/timeline-tab/timeline-delete.tsx
@@ -74,12 +74,12 @@ export const TimelineDeleteMenu = ({ gameId }: Props) => {
 
   const handleDelete = () => {
     if (!latestRecordId) {
-      toast.error('삭제할 기록이 없습니다.');
+      toast.error('삭제할 기록이 없어요');
       return;
     }
     deleteTimeline(
       { gameId, timelineId: latestRecordId },
-      { onSuccess: () => toast.success('최근 기록이 삭제되었습니다.') },
+      { onSuccess: () => toast.success('최근 기록이 삭제되었어요') },
     );
   };
   const extraNode = (


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 축구 경기 진행시 교체한 선수를 재투입이 불가한 문제 발생
  - 교체 로직 오류로 수정
  - 쿼리상태가 변하지 않는 문제가 있어 mutation 수정

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
