### PR TITLE
feat: 상태 코드에 따른 에러 문구 추가

### DIFF
--- a/apps/spectator/package.json
+++ b/apps/spectator/package.json
@@ -29,6 +29,7 @@
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "clsx": "^2.1.1",
+    "ky": "^1.11.0",
     "next": "^16.1.0",
     "nuqs": "^2.6.0",
     "react": "^19.1.1",

--- a/apps/spectator/src/api/http-error.ts
+++ b/apps/spectator/src/api/http-error.ts
@@ -1,0 +1,26 @@
+import { toast } from '@hcc/ui';
+import { HTTPError } from 'ky';
+
+const DEFAULT_MESSAGE = '요청에 실패했어요. 다시 시도해 주세요';
+
+type ErrorMessageFn = (status: number) => string | undefined;
+type FallbackMessage = string | ErrorMessageFn;
+
+const resolveMessage = (fallback: FallbackMessage, status: number) => {
+  if (typeof fallback === 'function') return fallback(status);
+
+  return fallback;
+};
+
+export const handleHTTPError = (error: Error, message: FallbackMessage) => {
+  if (error instanceof HTTPError) {
+    const status = error.response.status;
+    const msg = resolveMessage(message, status);
+
+    error.response
+      .json<{ message?: string }>()
+      .then((body) => toast.error(msg ?? body.message ?? DEFAULT_MESSAGE))
+      .catch(() => toast.error(msg ?? DEFAULT_MESSAGE));
+    return;
+  }
+};

--- a/apps/spectator/src/api/mutations/useCreateCheerTalk.ts
+++ b/apps/spectator/src/api/mutations/useCreateCheerTalk.ts
@@ -1,8 +1,8 @@
 import { useMutation } from '@hcc/api-base';
-import { toast } from '@hcc/ui'; // 토스트 메시지를 위한 import
 
 import type { CheerTalkType } from '~/api';
 
+import { handleHTTPError } from '../http-error';
 import { fetcher } from '../queryKey';
 
 type Request = Pick<CheerTalkType, 'gameTeamId' | 'content'>;
@@ -14,12 +14,13 @@ const postCreateCheerTalk = (request: Request) => {
 export const useCreateCheerTalk = () =>
   useMutation({
     mutationFn: postCreateCheerTalk,
-    onError: (error: { status?: number; response?: { status: number } }) => {
-      const status = error.status || error.response?.status;
-      if (status === 400) {
-        toast.error('부적절한 단어가 포함되어 있어 전송할 수 없어요');
-      } else {
-        toast.error('메시지 전송에 실패했어요 다시 시도해 주세요');
-      }
-    },
+    onError: (error) =>
+      handleHTTPError(error, (status) => {
+        let msg = '메시지 전송에 실패했어요 다시 시도해 주세요';
+
+        if (status === 400) msg = '부적절한 단어가 포함되어 있어 전송할 수 없어요';
+        if (status === 429) msg = '요청이 너무 많습니다. 잠시 후 다시 시도해 주세요';
+
+        return msg;
+      }),
   });

--- a/apps/spectator/src/api/mutations/useCreateCheerTalk.ts
+++ b/apps/spectator/src/api/mutations/useCreateCheerTalk.ts
@@ -19,7 +19,7 @@ export const useCreateCheerTalk = () =>
         let msg = '메시지 전송에 실패했어요 다시 시도해 주세요';
 
         if (status === 400) msg = '부적절한 단어가 포함되어 있어 전송할 수 없어요';
-        if (status === 429) msg = '요청이 너무 많습니다. 잠시 후 다시 시도해 주세요';
+        if (status === 429) msg = '메시지를 너무 많이 보내고 있어요. 잠시 후 다시 시도해 주세요.';
 
         return msg;
       }),

--- a/apps/spectator/src/api/mutations/useUpdateGameCheer.ts
+++ b/apps/spectator/src/api/mutations/useUpdateGameCheer.ts
@@ -24,7 +24,7 @@ export const useUpdateGameCheer = () => {
         let msg = '응원에 실패했어요. 다시 시도해 주세요';
 
         if (status === 400) msg = '잘못된 응원 요청이에요';
-        if (status === 429) msg = '요청이 너무 많습니다. 잠시 후 다시 시도해 주세요';
+        if (status === 429) msg = '메시지를 너무 많이 보내고 있어요. 잠시 후 다시 시도해 주세요.';
 
         return msg;
       }),

--- a/apps/spectator/src/api/mutations/useUpdateGameCheer.ts
+++ b/apps/spectator/src/api/mutations/useUpdateGameCheer.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
+import { handleHTTPError } from '../http-error';
 import { fetcher, queryKeys } from '../queryKey';
 
 export type Request = {
@@ -18,5 +19,14 @@ export const useUpdateGameCheer = () => {
     mutationFn: postGameCheer,
     onSuccess: async (_, { gameId }) =>
       await qc.invalidateQueries({ queryKey: queryKeys.games.cheer({ gameId }).queryKey }),
+    onError: (error) =>
+      handleHTTPError(error, (status) => {
+        let msg = '응원에 실패했어요. 다시 시도해 주세요';
+
+        if (status === 400) msg = '잘못된 응원 요청이에요';
+        if (status === 429) msg = '요청이 너무 많습니다. 잠시 후 다시 시도해 주세요';
+
+        return msg;
+      }),
   });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      ky:
+        specifier: ^1.11.0
+        version: 1.11.0
       next:
         specifier: ^16.1.0
         version: 16.1.0(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)


### PR DESCRIPTION
## ✅ 작업 내용

- `handleHTTPError` 유틸리티를 이용해서 API 호출부에서 상태 코드에 따른 에러 문구를 쉽게 조작할 수 있도록 했습니다.
- 응원톡 입력 시 발생할 수 있는 에러에 대한 문구를 추가해두었습니다.

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
