### PR TITLE
fix: 어시스턴트로 선수 등록 후 선수 관리에서 수정 안되는 문제 해결

### DIFF
--- a/apps/manager/src/api/mutations/index.ts
+++ b/apps/manager/src/api/mutations/index.ts
@@ -25,3 +25,4 @@ export * from './useUpdateGamesStarter';
 export * from './useUpdateGamesCaptainRegister';
 export * from './useUpdateGamesCaptainRevoke';
 export * from './useCheckDuplicateNL';
+export * from './useRegisterNL';

--- a/apps/manager/src/api/mutations/useRegisterNL.ts
+++ b/apps/manager/src/api/mutations/useRegisterNL.ts
@@ -14,7 +14,10 @@ export const useRegisterNL = () => {
   return useMutation({
     mutationFn: postRegisterNL,
     onSuccess: async () => {
-      await qc.invalidateQueries({ queryKey: queryKeys.teams._def });
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: queryKeys.teams._def }),
+        qc.invalidateQueries({ queryKey: queryKeys.players._def }),
+      ]);
     },
   });
 };

--- a/apps/manager/src/api/queries/usePlayers.ts
+++ b/apps/manager/src/api/queries/usePlayers.ts
@@ -1,7 +1,25 @@
-import { useQuery, useSuspenseQuery } from '@hcc/api-base';
+import { useSuspenseInfiniteQuery, useQuery, useSuspenseQuery } from '@hcc/api-base';
 
-import { queryKeys } from '../queryKey';
+import type { PlayerType } from '~/api';
+
+import { fetcher, queryKeys } from '../queryKey';
+
+const PLAYERS_PAGE_SIZE = 20;
 
 export const usePlayers = () => useQuery(queryKeys.players.list);
 
 export const useSuspensePlayers = () => useSuspenseQuery(queryKeys.players.list);
+
+export const useSuspenseInfinitePlayers = () =>
+  useSuspenseInfiniteQuery({
+    queryKey: ['players', 'infinite'] as const,
+    queryFn: ({ pageParam }: { pageParam: number }) =>
+      fetcher.get<PlayerType[]>('players', {
+        searchParams: { cursor: pageParam || '', size: PLAYERS_PAGE_SIZE },
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage: PlayerType[]) =>
+      lastPage.length === PLAYERS_PAGE_SIZE
+        ? (lastPage[lastPage.length - 1]?.playerId ?? null)
+        : null,
+  });

--- a/apps/manager/src/api/queries/usePlayers.ts
+++ b/apps/manager/src/api/queries/usePlayers.ts
@@ -15,7 +15,7 @@ export const useSuspenseInfinitePlayers = () =>
     queryKey: ['players', 'infinite'] as const,
     queryFn: ({ pageParam }: { pageParam: number }) =>
       fetcher.get<PlayerType[]>('players', {
-        searchParams: { cursor: pageParam || '', size: PLAYERS_PAGE_SIZE },
+        searchParams: { cursor: pageParam, size: PLAYERS_PAGE_SIZE },
       }),
     initialPageParam: 0,
     getNextPageParam: (lastPage: PlayerType[]) =>

--- a/apps/manager/src/app/(private)/players/[id]/form-section.tsx
+++ b/apps/manager/src/app/(private)/players/[id]/form-section.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { toast } from '@hcc/ui';
-import { HTTPError } from 'ky';
 import { useRouter } from 'next/navigation';
 
 import { type PlayerFormType, useSuspensePlayer, useUpdatePlayers } from '~/api';
+import { parseHTTPError } from '~/utils/form-util';
 
 import { PlayerForm } from '../_components/player-form';
 
@@ -22,14 +22,7 @@ export const FormSection = ({ id }: Props) => {
       toast.success('선수가 수정되었어요');
       router.back();
     } catch (error) {
-      if (error instanceof HTTPError) {
-        const body = await error.response
-          .json<{ message?: string }>()
-          .catch((): { message?: string } => ({}));
-        toast.error(body.message ?? '선수 수정에 실패했어요');
-      } else {
-        toast.error('선수 수정에 실패했어요');
-      }
+      toast.error(await parseHTTPError(error, '선수 수정에 실패했어요'));
     }
   };
 

--- a/apps/manager/src/app/(private)/players/[id]/form-section.tsx
+++ b/apps/manager/src/app/(private)/players/[id]/form-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { toast } from '@hcc/ui';
+import { HTTPError } from 'ky';
 import { useRouter } from 'next/navigation';
 
 import { type PlayerFormType, useSuspensePlayer, useUpdatePlayers } from '~/api';
@@ -18,11 +19,17 @@ export const FormSection = ({ id }: Props) => {
   const handleSubmit = async (data: PlayerFormType) => {
     try {
       await mutateAsync({ id, ...data });
-      toast.success('선수가 수정되었어요.');
+      toast.success('선수가 수정되었어요');
       router.back();
     } catch (error) {
-      console.error(error);
-      toast.error('선수 수정에 실패했어요.');
+      if (error instanceof HTTPError) {
+        const body = await error.response
+          .json<{ message?: string }>()
+          .catch((): { message?: string } => ({}));
+        toast.error(body.message ?? '선수 수정에 실패했어요');
+      } else {
+        toast.error('선수 수정에 실패했어요');
+      }
     }
   };
 

--- a/apps/manager/src/app/(private)/players/_components/player-form.tsx
+++ b/apps/manager/src/app/(private)/players/_components/player-form.tsx
@@ -61,11 +61,11 @@ export const PlayerForm = ({ className, onSubmit, initialData, ...props }: Props
           maxLength={10}
           {...register('studentNumber', {
             required: '학번을 입력해주세요.',
-            minLength: { value: 9, message: '학번은 9자리에서 10자리 사이여야 합니다.' },
-            maxLength: { value: 10, message: '학번은 9자리에서 10자리 사이여야 합니다.' },
+            minLength: { value: 9, message: '학번은 9자리에서 10자리 사이여야 해요' },
+            maxLength: { value: 10, message: '학번은 9자리에서 10자리 사이여야 해요' },
             pattern: {
               value: /^\d+$/,
-              message: '학번은 숫자만 입력해주세요.',
+              message: '학번은 숫자만 입력해주세요',
             },
           })}
         />

--- a/apps/manager/src/app/(private)/players/_components/player-list.tsx
+++ b/apps/manager/src/app/(private)/players/_components/player-list.tsx
@@ -7,6 +7,7 @@ import { Fragment, useState } from 'react';
 
 import { useSuspensePlayers } from '~/api';
 import { routes } from '~/constants/routes';
+import { createKoreanFuzzyMatcher } from '~/utils/ko-fuzzy';
 
 import { PlayerDeleteDialog } from './player-delete-dialog';
 
@@ -32,7 +33,11 @@ export const PlayerList = ({ edit }: Props) => {
 
       <div className="column h-full gap-3 overflow-y-auto pb-[92px]">
         {data
-          .filter((player) => player.name?.includes(query) || player.studentNumber?.includes(query))
+          .filter((player) => {
+            if (!query) return true;
+            const matcher = createKoreanFuzzyMatcher(query);
+            return matcher.test(player.name) || player.studentNumber.includes(query);
+          })
           .map((player) => (
             <div
               key={player.playerId}

--- a/apps/manager/src/app/(private)/players/_components/player-list.tsx
+++ b/apps/manager/src/app/(private)/players/_components/player-list.tsx
@@ -3,7 +3,7 @@
 import { ChevronForwardIcon, DeleteForeverIcon } from '@hcc/icons';
 import { Spinner, Typography } from '@hcc/ui';
 import Link from 'next/link';
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useSuspenseInfinitePlayers } from '~/api';
 import { routes } from '~/constants/routes';
@@ -17,7 +17,6 @@ type Props = {
 
 export const PlayerList = ({ edit }: Props) => {
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage } = useSuspenseInfinitePlayers();
-  const players = data.pages.flat();
   const [query, setQuery] = useState<string>('');
   const sentinelRef = useRef<HTMLDivElement>(null);
   const fetchNextPageRef = useRef(fetchNextPage);
@@ -37,12 +36,14 @@ export const PlayerList = ({ edit }: Props) => {
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage]);
 
-  const filteredPlayers = query
-    ? players.filter((player) => {
-        const matcher = createKoreanFuzzyMatcher(query);
-        return matcher.test(player.name) || player.studentNumber.includes(query);
-      })
-    : players;
+  const filteredPlayers = useMemo(() => {
+    const players = data.pages.flat();
+    if (!query) return players;
+    const matcher = createKoreanFuzzyMatcher(query);
+    return players.filter(
+      (player) => matcher.test(player.name) || player.studentNumber.includes(query),
+    );
+  }, [data.pages, query]);
 
   return (
     <Fragment>

--- a/apps/manager/src/app/(private)/players/_components/player-list.tsx
+++ b/apps/manager/src/app/(private)/players/_components/player-list.tsx
@@ -3,10 +3,11 @@
 import { ChevronForwardIcon, DeleteForeverIcon } from '@hcc/icons';
 import { Spinner, Typography } from '@hcc/ui';
 import Link from 'next/link';
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useMemo, useState } from 'react';
 
 import { useSuspenseInfinitePlayers } from '~/api';
 import { routes } from '~/constants/routes';
+import { useIntersectionObserver } from '~/hooks';
 import { createKoreanFuzzyMatcher } from '~/utils/ko-fuzzy';
 
 import { PlayerDeleteDialog } from './player-delete-dialog';
@@ -18,23 +19,14 @@ type Props = {
 export const PlayerList = ({ edit }: Props) => {
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage } = useSuspenseInfinitePlayers();
   const [query, setQuery] = useState<string>('');
-  const sentinelRef = useRef<HTMLDivElement>(null);
-  const fetchNextPageRef = useRef(fetchNextPage);
-  fetchNextPageRef.current = fetchNextPage;
 
-  useEffect(() => {
-    if (!sentinelRef.current) return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
-          fetchNextPageRef.current();
-        }
-      },
-      { threshold: 0.1 },
-    );
-    observer.observe(sentinelRef.current);
-    return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage]);
+  const handleIntersect = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const { ref: sentinelRef } = useIntersectionObserver<HTMLDivElement>(handleIntersect, {
+    threshold: 0.1,
+  });
 
   const filteredPlayers = useMemo(() => {
     const players = data.pages.flat();

--- a/apps/manager/src/app/(private)/players/_components/player-list.tsx
+++ b/apps/manager/src/app/(private)/players/_components/player-list.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { ChevronForwardIcon, DeleteForeverIcon } from '@hcc/icons';
-import { Typography } from '@hcc/ui';
+import { Spinner, Typography } from '@hcc/ui';
 import Link from 'next/link';
-import { Fragment, useState } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 
-import { useSuspensePlayers } from '~/api';
+import { useSuspenseInfinitePlayers } from '~/api';
 import { routes } from '~/constants/routes';
 import { createKoreanFuzzyMatcher } from '~/utils/ko-fuzzy';
 
@@ -16,8 +16,33 @@ type Props = {
 };
 
 export const PlayerList = ({ edit }: Props) => {
-  const { data } = useSuspensePlayers();
+  const { data, hasNextPage, fetchNextPage, isFetchingNextPage } = useSuspenseInfinitePlayers();
+  const players = data.pages.flat();
   const [query, setQuery] = useState<string>('');
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const fetchNextPageRef = useRef(fetchNextPage);
+  fetchNextPageRef.current = fetchNextPage;
+
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPageRef.current();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(sentinelRef.current);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage]);
+
+  const filteredPlayers = query
+    ? players.filter((player) => {
+        const matcher = createKoreanFuzzyMatcher(query);
+        return matcher.test(player.name) || player.studentNumber.includes(query);
+      })
+    : players;
 
   return (
     <Fragment>
@@ -32,46 +57,46 @@ export const PlayerList = ({ edit }: Props) => {
       </Typography>
 
       <div className="column h-full gap-3 overflow-y-auto pb-[92px]">
-        {data
-          .filter((player) => {
-            if (!query) return true;
-            const matcher = createKoreanFuzzyMatcher(query);
-            return matcher.test(player.name) || player.studentNumber.includes(query);
-          })
-          .map((player) => (
-            <div
-              key={player.playerId}
-              className="row-between rounded-lg border border-neutral-100 px-4 py-3"
-            >
-              <div className="column gap-1.5">
-                <Typography weight="medium" lineHeight="none">
-                  {player.name} ({player.studentNumber})
+        {filteredPlayers.map((player) => (
+          <div
+            key={player.playerId}
+            className="row-between rounded-lg border border-neutral-100 px-4 py-3"
+          >
+            <div className="column gap-1.5">
+              <Typography weight="medium" lineHeight="none">
+                {player.name} ({player.studentNumber})
+              </Typography>
+              {player.teams && player.teams.length > 0 && (
+                <Typography
+                  color="var(--color-neutral-500)"
+                  fontSize={12}
+                  weight="medium"
+                  lineHeight="none"
+                >
+                  {player.teams.map((team) => team.name).join(', ')}
                 </Typography>
-                {player.teams && player.teams.length > 0 && (
-                  <Typography
-                    color="var(--color-neutral-500)"
-                    fontSize={12}
-                    weight="medium"
-                    lineHeight="none"
-                  >
-                    {player.teams.map((team) => team.name).join(', ')}
-                  </Typography>
-                )}
-              </div>
-
-              {edit ? (
-                <PlayerDeleteDialog id={player.playerId}>
-                  <span className="cursor-pointer text-[var(--color-danger-600)]">
-                    <DeleteForeverIcon size={24} />
-                  </span>
-                </PlayerDeleteDialog>
-              ) : (
-                <Link className="center" href={`/${routes.players}/${player.playerId}`}>
-                  <ChevronForwardIcon size={24} />
-                </Link>
               )}
             </div>
-          ))}
+
+            {edit ? (
+              <PlayerDeleteDialog id={player.playerId}>
+                <span className="cursor-pointer text-[var(--color-danger-600)]">
+                  <DeleteForeverIcon size={24} />
+                </span>
+              </PlayerDeleteDialog>
+            ) : (
+              <Link className="center" href={`/${routes.players}/${player.playerId}`}>
+                <ChevronForwardIcon size={24} />
+              </Link>
+            )}
+          </div>
+        ))}
+
+        {(hasNextPage || isFetchingNextPage) && (
+          <div ref={sentinelRef} className="flex justify-center py-2">
+            {isFetchingNextPage && <Spinner size="sm" color="neutral" />}
+          </div>
+        )}
       </div>
     </Fragment>
   );

--- a/apps/manager/src/app/(private)/players/create/form-section.tsx
+++ b/apps/manager/src/app/(private)/players/create/form-section.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { toast } from '@hcc/ui';
-import { HTTPError } from 'ky';
 import { useRouter } from 'next/navigation';
 
 import { type PlayerFormType, useCreatePlayers } from '~/api';
+import { parseHTTPError } from '~/utils/form-util';
 
 import { PlayerForm } from '../_components/player-form';
 
@@ -15,17 +15,10 @@ export const FormSection = () => {
   const handleSubmit = async (data: PlayerFormType) => {
     try {
       await mutateAsync(data);
-      toast.success('선수가 생성되었어요.');
+      toast.success('선수가 생성되었어요');
       router.back();
     } catch (error) {
-      if (error instanceof HTTPError) {
-        const body = await error.response
-          .json<{ message?: string }>()
-          .catch((): { message?: string } => ({}));
-        toast.error(body.message ?? '선수 생성에 실패했어요.');
-      } else {
-        toast.error('선수 생성에 실패했어요.');
-      }
+      toast.error(await parseHTTPError(error, '선수 생성에 실패했어요'));
     }
   };
 

--- a/apps/manager/src/app/(private)/teams/[sport]/[id]/form-section.tsx
+++ b/apps/manager/src/app/(private)/teams/[sport]/[id]/form-section.tsx
@@ -7,6 +7,7 @@ import type { TeamFormType } from '~/api/mutations/useCreateTeams';
 
 import { useSuspenseTeam, useUpdateTeams } from '~/api';
 import { useImageUpload } from '~/hooks';
+import { parseHTTPError } from '~/utils/form-util';
 
 import { TeamForm } from '../../_components/team-form';
 
@@ -37,8 +38,7 @@ export const FormSection = ({ id }: Props) => {
       toast.success('팀이 수정되었어요');
       router.back();
     } catch (error) {
-      console.error(error);
-      toast.error('팀 수정에 실패했어요');
+      toast.error(await parseHTTPError(error, '팀 수정에 실패했어요'));
     }
   };
 

--- a/apps/manager/src/app/(private)/teams/[sport]/create/form-section.tsx
+++ b/apps/manager/src/app/(private)/teams/[sport]/create/form-section.tsx
@@ -8,6 +8,7 @@ import type { SportType } from '~/api/types';
 
 import { useCreateTeams } from '~/api';
 import { useImageUpload } from '~/hooks';
+import { parseHTTPError } from '~/utils/form-util';
 
 import { TeamForm } from '../../_components/team-form';
 
@@ -26,11 +27,10 @@ export function FormSection({ sportType }: { sportType: SportType }) {
       }
 
       await createTeam({ ...data, logoImageUrl: imageUrl });
-      toast.success('팀이 성공적으로 생성되었습니다!');
+      toast.success('팀이 생성되었어요');
       router.back();
     } catch (error) {
-      console.error('팀 생성 실패:', error);
-      toast.error('팀 생성에 실패했습니다. 다시 시도해주세요.');
+      toast.error(await parseHTTPError(error, '팀 생성에 실패했어요'));
     }
   };
 

--- a/apps/manager/src/hooks/index.ts
+++ b/apps/manager/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useImageUpload';
+export * from './useIntersectionObserver';

--- a/apps/manager/src/hooks/useIntersectionObserver.ts
+++ b/apps/manager/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+type IntersectHandler = (entry: IntersectionObserverEntry, observer: IntersectionObserver) => void;
+
+export function useIntersectionObserver<T extends HTMLElement>(
+  onIntersect: IntersectHandler,
+  options?: IntersectionObserverInit,
+) {
+  const ref = useRef<T | null>(null);
+  const callback = useCallback(
+    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) onIntersect(entry, observer);
+      });
+    },
+    [onIntersect],
+  );
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [ref, options, callback]);
+
+  return { ref };
+}

--- a/apps/manager/src/utils/form-util.ts
+++ b/apps/manager/src/utils/form-util.ts
@@ -19,7 +19,7 @@ export const parseHTTPError = async (error: unknown, fallback: string): Promise<
     const body = await error.response
       .json<{ message?: string }>()
       .catch((): { message?: string } => ({}));
-    return body.message ?? fallback;
+    return body.message || fallback;
   }
   return fallback;
 };

--- a/apps/manager/src/utils/form-util.ts
+++ b/apps/manager/src/utils/form-util.ts
@@ -1,6 +1,7 @@
 import type { FieldErrors } from 'react-hook-form';
 
 import { toast } from '@hcc/ui';
+import { HTTPError } from 'ky';
 
 export const handleFormError = (errors: FieldErrors) => {
   const messages = Object.values(errors)
@@ -11,4 +12,14 @@ export const handleFormError = (errors: FieldErrors) => {
   const suffix = rest.length > 0 ? ` (외 ${rest.length}개의 오류)` : '';
 
   toast.error(`${first}${suffix}`);
+};
+
+export const parseHTTPError = async (error: unknown, fallback: string): Promise<string> => {
+  if (error instanceof HTTPError) {
+    const body = await error.response
+      .json<{ message?: string }>()
+      .catch((): { message?: string } => ({}));
+    return body.message ?? fallback;
+  }
+  return fallback;
 };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 어시스턴트로 등록한 선수가 선수 관리에 표시되지 않는 문제 수정
useRegisterNL 성공 시 teams 쿼리만 invalidate하고 players 쿼리를 invalidate하지 않아, 등록 후 선수 관리 목록이 갱신되지 않던 문제를 수정했습니다.
- 선수/팀 수정 실패 시 서버 에러 메시지를 토스트로 추가하고 중복된 HTTP 에러 처리 로직을 parseHTTPError 유틸로 추출했습니다.
- 선수등록 화면에서 선수 검색 기능 추가했습니다.
- /players api에 무한 스크롤 가능하도록 page, size추가했습니다.


## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
