### PR TITLE
fix: 농구 상세 페이지 QA

### DIFF
--- a/apps/spectator/src/app/[sport]/games/_components/banner/index.tsx
+++ b/apps/spectator/src/app/[sport]/games/_components/banner/index.tsx
@@ -29,6 +29,9 @@ export const Banner = ({ gameId, sportType }: Props) => {
     month: '2-digit',
     day: '2-digit',
     weekday: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
   });
 
   return (

--- a/apps/spectator/src/app/[sport]/games/_components/banner/index.tsx
+++ b/apps/spectator/src/app/[sport]/games/_components/banner/index.tsx
@@ -31,7 +31,8 @@ export const Banner = ({ gameId, sportType }: Props) => {
     weekday: 'short',
     hour: '2-digit',
     minute: '2-digit',
-    hour12: false,
+    hourCycle: 'h23',
+    timeZone: 'Asia/Seoul',
   });
 
   return (

--- a/apps/spectator/src/app/[sport]/games/_components/banner/quarter-score.tsx
+++ b/apps/spectator/src/app/[sport]/games/_components/banner/quarter-score.tsx
@@ -28,7 +28,7 @@ export const QuarterScore = ({ gameId }: QuarterScoreProps) => {
   return (
     <div className="flex flex-col justify-center gap-0.5 text-xs font-medium">
       <ScoreRow
-        affix={'팀명'}
+        affix="팀명"
         scores={QUARTER_LABELS}
         renderScores={(props) => <Cell {...props} className="text-greyscale-200" />}
         suffix="총점"
@@ -55,10 +55,10 @@ export const QuarterScore = ({ gameId }: QuarterScoreProps) => {
 /* ----- row ----- */
 
 interface ScoreRowProps {
-  affix?: ReactNode;
-  suffix?: ReactNode;
+  affix: ReactNode;
+  suffix: ReactNode;
   marker?: ReactNode;
-  scores?: string[];
+  scores: string[];
   renderScores?: ComponentType<CellProps>;
 }
 
@@ -70,13 +70,11 @@ const ScoreRow = ({
   renderScores: ScoreCell = Cell,
 }: ScoreRowProps) => {
   return (
-    <div className="grid grid-cols-[25%_repeat(6,minmax(20px,40px))] grid-rows-[20px] items-center pr-2 pl-3">
-      {affix && (
-        <Cell className="flex items-center gap-2 justify-self-start">
-          {marker}
-          <span className="truncate">{affix}</span>
-        </Cell>
-      )}
+    <div className="grid grid-cols-[1fr_40px_40px_40px_40px_40px_40px] grid-rows-[20px] items-center pr-2 pl-3">
+      <Cell className="flex items-center gap-2 justify-self-start">
+        {marker}
+        <span className="truncate">{affix}</span>
+      </Cell>
 
       {scores?.map((score, index) => (
         // oxlint-disable-next-line react/no-array-index-key --- quarterScores는 항상 순서와 개수가 고정되어 있으므로 index 사용 허용
@@ -85,7 +83,7 @@ const ScoreRow = ({
         </ScoreCell>
       ))}
 
-      <Cell className="font-semibold text-(--color-primary-600)">{suffix ?? 0}</Cell>
+      <Cell className="font-semibold text-(--color-primary-600)">{suffix}</Cell>
     </div>
   );
 };

--- a/apps/spectator/src/app/[sport]/games/_components/banner/quarter-score.tsx
+++ b/apps/spectator/src/app/[sport]/games/_components/banner/quarter-score.tsx
@@ -70,7 +70,7 @@ const ScoreRow = ({
   renderScores: ScoreCell = Cell,
 }: ScoreRowProps) => {
   return (
-    <div className="grid grid-cols-[1fr_40px_40px_40px_40px_40px_40px] grid-rows-[20px] items-center pr-2 pl-3">
+    <div className="grid grid-cols-[25%_repeat(6,minmax(20px,40px))] grid-rows-[20px] items-center pr-2 pl-3">
       {affix && (
         <Cell className="flex items-center gap-2 justify-self-start">
           {marker}


### PR DESCRIPTION
## ✅ 작업 내용

- 쿼터 그리드에서 팀명의 너비를 항상 25%로 고정
- 경기 날짜에 시작 시간 포함

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
