### PR TITLE
feat: 라인업 주장 해제 api 누락 문제 해결

### DIFF
--- a/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/game-lineup-edit-section.tsx
+++ b/apps/manager/src/app/(private)/leagues/[id]/_components/game-edit/game-lineup-edit-section.tsx
@@ -10,6 +10,7 @@ import {
   useDeleteGameTeamsLineup,
   useUpdateGamesCandidate,
   useUpdateGamesCaptainRegister,
+  useUpdateGamesCaptainRevoke,
   useUpdateGamesStarter,
   useSuspenseGame,
   useSuspenseGameLineup,
@@ -114,6 +115,7 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
   const { mutateAsync: patchStarter } = useUpdateGamesStarter();
   const { mutateAsync: patchCandidate } = useUpdateGamesCandidate();
   const { mutateAsync: patchCaptainRegister } = useUpdateGamesCaptainRegister();
+  const { mutateAsync: patchCaptainRevoke } = useUpdateGamesCaptainRevoke();
 
   const getPlayerState = (teamNumber: 1 | 2, teamPlayerId: number) => {
     const selection = teamNumber === 1 ? team1Selection : team2Selection;
@@ -196,6 +198,8 @@ const LineupEditContent = ({ gameId, leagueId, onNext, onPrevious }: Props) => {
         if (orig.lineupPlayerId !== undefined) {
           if (next.isCaptain) {
             await patchCaptainRegister({ gameId, lineupPlayerId: orig.lineupPlayerId });
+          } else {
+            await patchCaptainRevoke({ gameId, lineupPlayerId: orig.lineupPlayerId });
           }
         }
       } else if (orig.state !== next.state && orig.isCaptain !== next.isCaptain) {


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 라인업 주장 해제에 대한 api가 누락되어 주장 수정시에 변경이 안되는 문제를 해결했어요

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
