### PR TITLE
fix: 리그 선택 시 해당 조직/종목 팀만 조회하도록 수정

### DIFF
--- a/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
+++ b/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
@@ -134,9 +134,11 @@ export const SelectTeam = ({
     <div className="flex h-[60vh] flex-col pt-4">
       <div className="flex flex-grow flex-row overflow-hidden">
         {/* 왼쪽 열: 소속 */}
-        <div className="flex-1 border-r">
-          <div className="w-full bg-[#EBECEE] p-3 text-left text-base font-medium">소속</div>
-          <div className="overflow-y-auto">
+        <div className="flex flex-1 flex-col border-r">
+          <div className="w-full shrink-0 bg-[#EBECEE] p-3 text-left text-base font-medium">
+            소속
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto">
             {affiliations.map((affiliation) => (
               <SelectItem
                 key={affiliation.id}
@@ -152,8 +154,10 @@ export const SelectTeam = ({
 
         {/* 오른쪽 열: 팀 */}
         <div className="flex flex-1 flex-col">
-          <div className="w-full bg-[#EBECEE] p-3 text-left text-base font-medium">팀 이름</div>
-          <div className="overflow-y-auto">
+          <div className="w-full shrink-0 bg-[#EBECEE] p-3 text-left text-base font-medium">
+            팀 이름
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto">
             {selectedAffiliation?.teams.map((team) => (
               <SelectItem
                 key={team.id}

--- a/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
+++ b/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
@@ -51,7 +51,7 @@ export const SelectTeam = ({
   const { data: teamUnits = [], isLoading: isUnitsLoading } = useTeamUnits(sportType);
   const unitNames = useMemo(() => teamUnits.map((u) => u.unitName), [teamUnits]);
   const { data: teams = [], isLoading: isTeamsLoading } = useManagerTeams(unitNames, sportType);
-  const isLoading = isUnitsLoading || (unitNames.length > 0 && isTeamsLoading);
+  const isLoading = isUnitsLoading || isTeamsLoading;
   const deferredValue = useDeferredValue(value);
 
   const groupedByUnit = useMemo(() => {

--- a/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
+++ b/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
@@ -51,7 +51,7 @@ export const SelectTeam = ({
   const { data: teamUnits = [], isLoading: isUnitsLoading } = useTeamUnits(sportType);
   const unitNames = useMemo(() => teamUnits.map((u) => u.unitName), [teamUnits]);
   const { data: teams = [], isLoading: isTeamsLoading } = useManagerTeams(unitNames, sportType);
-  const isLoading = isUnitsLoading || isTeamsLoading;
+  const isLoading = isUnitsLoading || (unitNames.length > 0 && isTeamsLoading);
   const deferredValue = useDeferredValue(value);
 
   const groupedByUnit = useMemo(() => {

--- a/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
+++ b/apps/manager/src/app/(private)/leagues/_components/select-team.tsx
@@ -5,9 +5,7 @@ import { Button } from '@hcc/ui';
 import clsx from 'clsx';
 import { useDeferredValue, useMemo, useState } from 'react';
 
-import type { SportType } from '~/api';
-
-import { useTeams } from '~/api/queries/useTeams';
+import { useManagerTeams, useTeamUnits, type SportType } from '~/api';
 
 type RegisteredTeam = {
   affiliationName: string;
@@ -50,12 +48,14 @@ export const SelectTeam = ({
   maxSelectCount,
   sportType,
 }: TeamCreationFormProps) => {
-  const { data: teams = [], isLoading } = useTeams();
+  const { data: teamUnits = [], isLoading: isUnitsLoading } = useTeamUnits(sportType);
+  const unitNames = useMemo(() => teamUnits.map((u) => u.unitName), [teamUnits]);
+  const { data: teams = [], isLoading: isTeamsLoading } = useManagerTeams(unitNames, sportType);
+  const isLoading = isUnitsLoading || isTeamsLoading;
   const deferredValue = useDeferredValue(value);
 
   const groupedByUnit = useMemo(() => {
-    const filtered = teams.filter((team) => team.sportType === sportType);
-    const units = filtered.reduce<Record<string, Team[]>>((acc, team) => {
+    const units = teams.reduce<Record<string, Team[]>>((acc, team) => {
       if (!acc[team.unit]) {
         acc[team.unit] = [];
       }
@@ -68,7 +68,7 @@ export const SelectTeam = ({
       name: unit,
       teams: units[unit],
     }));
-  }, [teams, sportType]);
+  }, [teams]);
 
   const affiliations = useMemo(() => {
     const query = deferredValue.trim();


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- 리그 생성 시 해당 조직 소속 팀이 아닌 경우도 보여지는 문제를 발견 -> 해당 조직/종목만 필터링 하도록 api변경했어요
- 팀 선택 화면에서 스크롤되지 않는 문제를 해결했어요

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
