### PR TITLE
feat: cheerVS 언마운트 시 API 호출 보장

### DIFF
--- a/apps/spectator/package.json
+++ b/apps/spectator/package.json
@@ -30,6 +30,7 @@
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "clsx": "^2.1.1",
+    "es-toolkit": "^1.47.0",
     "ky": "^1.11.0",
     "next": "^16.1.0",
     "nuqs": "^2.6.0",

--- a/apps/spectator/src/app/[sport]/games/_components/cheer-vs.tsx
+++ b/apps/spectator/src/app/[sport]/games/_components/cheer-vs.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { colors, Typography, toast } from '@hcc/ui';
+import { debounce } from 'es-toolkit/function';
 import Image from 'next/image';
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   type GameCheerType,
@@ -11,7 +12,6 @@ import {
   useSuspenseGameCheer,
   useUpdateGameCheer,
 } from '~/api';
-import { useDebounce } from '~/hooks/useDebounce';
 import { cn } from '~/utils/cn';
 
 type Props = {
@@ -113,30 +113,68 @@ const CheerTeamBox = ({
   isFinished,
 }: CheerTeamBoxProps) => {
   const [pendingCount, setPendingCount] = useState(0);
+  const [inflightCount, setInflightCount] = useState(0);
   const pendingCountRef = useRef(0);
   const { mutate, isPending } = useUpdateGameCheer();
 
-  useDebounce(
-    () => {
-      const countToSubmit = pendingCountRef.current;
-      if (countToSubmit === 0) return;
+  const updateGameCheer = useCallback(() => {
+    const countToSubmit = pendingCountRef.current;
+    if (countToSubmit === 0) return;
 
-      pendingCountRef.current = 0;
-      setPendingCount(0);
+    pendingCountRef.current = 0;
+    setPendingCount(0);
+    setInflightCount((prev) => prev + countToSubmit);
 
-      mutate(
-        { cheerCount: countToSubmit, gameId, gameTeamId },
-        {
-          onError: () => {
-            pendingCountRef.current += countToSubmit;
-            setPendingCount((prev) => prev + countToSubmit);
-          },
+    mutate(
+      { cheerCount: countToSubmit, gameId, gameTeamId },
+      {
+        onSuccess: () => {
+          setInflightCount((prev) => prev - countToSubmit);
         },
-      );
-    },
-    1000,
-    [pendingCount, gameId, gameTeamId, mutate],
+        onError: () => {
+          setInflightCount((prev) => prev - countToSubmit);
+          pendingCountRef.current += countToSubmit;
+          setPendingCount((prev) => prev + countToSubmit);
+        },
+      },
+    );
+  }, [gameId, gameTeamId, mutate]);
+
+  const debouncedUpdateGameCheer = useMemo(
+    () => debounce(updateGameCheer, 1000),
+    [updateGameCheer],
   );
+
+  const flushBeacon = useCallback(() => {
+    const count = pendingCountRef.current;
+    if (count === 0) return;
+
+    pendingCountRef.current = 0;
+
+    const url = `${process.env.API_BASE_URL ?? '/api'}/games/${gameId}/cheer`;
+    const blob = new Blob([JSON.stringify({ cheerCount: count, gameTeamId })], {
+      type: 'application/json',
+    });
+
+    navigator.sendBeacon(url, blob);
+  }, [gameId, gameTeamId]);
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flushBeacon();
+    };
+
+    window.addEventListener('pagehide', flushBeacon);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      window.removeEventListener('pagehide', flushBeacon);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+
+      debouncedUpdateGameCheer.flush();
+      debouncedUpdateGameCheer.cancel();
+    };
+  }, [debouncedUpdateGameCheer, flushBeacon]);
 
   const handleCheer = () => {
     if (isFinished) {
@@ -146,6 +184,7 @@ const CheerTeamBox = ({
 
     pendingCountRef.current += 1;
     setPendingCount((prev) => prev + 1);
+    debouncedUpdateGameCheer();
   };
 
   return (
@@ -174,7 +213,7 @@ const CheerTeamBox = ({
       />
 
       <Typography color={colors.white} weight="medium">
-        {(cheerCount + pendingCount).toLocaleString()}
+        {(cheerCount + pendingCount + inflightCount).toLocaleString()}
       </Typography>
     </button>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      es-toolkit:
+        specifier: ^1.47.0
+        version: 1.47.0
       ky:
         specifier: ^1.11.0
         version: 1.11.0
@@ -2918,6 +2921,9 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
+
   esbuild@0.25.10:
     resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
     engines: {node: '>=18'}
@@ -4168,7 +4174,7 @@ packages:
   tar@7.5.1:
     resolution: {integrity: sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   terser-webpack-plugin@5.3.16:
     resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
@@ -6897,6 +6903,8 @@ snapshots:
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-toolkit@1.47.0: {}
 
   esbuild@0.25.10:
     optionalDependencies:


### PR DESCRIPTION
## ✅ 작업 내용

- 응원탭 배치 처리 시, 컴포넌트가 언마운트 되면 API 호출 누락 문제 발생
- `pagehide`, `visibilitychange` 이벤트로 탭 닫기, 새로고침, 페이지 이탈, 모바일 백그라운드, 탭 전환 시 API 호출
- useEffect의 클린업 콜백으로 debounce의 flush 메서드를 바인딩

## ♾️ 기타

- 추가로 필요한 작업 내용
