### PR TITLE
refactor: api-base와 앱별 fetcher 관심사 분리

### DIFF
--- a/apps/manager/src/api/fetcher.ts
+++ b/apps/manager/src/api/fetcher.ts
@@ -1,0 +1,19 @@
+import { getFetcher, type HttpErrorHandlers } from '@hcc/api-base';
+
+let isRedirecting = false;
+
+const errorHandlers: HttpErrorHandlers = {
+  401: async (request) => {
+    if (request.url.includes('logout')) return;
+    if (isRedirecting || typeof window === 'undefined') return;
+
+    isRedirecting = true;
+    alert('로그인이 만료되었어요. 다시 로그인해주세요.');
+    await fetch('/api/logout', { method: 'POST' });
+    window.location.replace('/auth/login');
+  },
+};
+
+const apiBaseUrl = process.env.API_BASE_URL ?? '/api';
+
+export const fetcher = getFetcher(apiBaseUrl, { errorHandlers });

--- a/apps/manager/src/api/mutations/useCheckDuplicateNL.ts
+++ b/apps/manager/src/api/mutations/useCheckDuplicateNL.ts
@@ -2,7 +2,7 @@ import { useMutation } from '@hcc/api-base';
 
 import type { CheckDuplicateNLResponse, ParsedPlayer } from '~/api/types/nl';
 
-import { fetcher } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
 
 const postCheckDuplicateNL = (payload: { players: ParsedPlayer[] }) => {
   return fetcher.post<CheckDuplicateNLResponse>(`nl/check-duplicates`, { json: payload });

--- a/apps/manager/src/api/mutations/useCreateGameTeamsLineup.ts
+++ b/apps/manager/src/api/mutations/useCreateGameTeamsLineup.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 import type { GameTeamLineupCreateRequest } from '../types/games';
 

--- a/apps/manager/src/api/mutations/useCreateGames.ts
+++ b/apps/manager/src/api/mutations/useCreateGames.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { GameStateType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export type GameFormTeamType = {
   teamId: number;

--- a/apps/manager/src/api/mutations/useCreateLeagues.ts
+++ b/apps/manager/src/api/mutations/useCreateLeagues.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { LeagueDetailType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export type LeagueFormType = Pick<
   LeagueDetailType,

--- a/apps/manager/src/api/mutations/useCreatePlayers.ts
+++ b/apps/manager/src/api/mutations/useCreatePlayers.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { PlayerType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export type PlayerFormType = Pick<PlayerType, 'name' | 'studentNumber'>;
 

--- a/apps/manager/src/api/mutations/useCreateTeams.ts
+++ b/apps/manager/src/api/mutations/useCreateTeams.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { TeamType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export type TeamFormType = Pick<
   TeamType,

--- a/apps/manager/src/api/mutations/useCreateTimelineFoul.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineFoul.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { FoulType } from '~/api/types';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export const postTimelineFoul = ({ gameId, ...request }: FoulType) => {
   return fetcher.post<void>(`games/${gameId}/timelines/foul`, {

--- a/apps/manager/src/api/mutations/useCreateTimelinePK.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelinePK.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { PkType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export const postTimelinePK = ({ gameId, ...request }: PkType) => {
   return fetcher.post<void>(`games/${gameId}/timelines/pk`, {

--- a/apps/manager/src/api/mutations/useCreateTimelineReplacement.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineReplacement.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { ReplacementType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export const postTimelineReplace = ({ gameId, ...request }: ReplacementType) => {
   return fetcher.post<void>(`games/${gameId}/timelines/replacement`, {

--- a/apps/manager/src/api/mutations/useCreateTimelineScore.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineScore.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { ScoreType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export const postTimelineScore = ({ gameId, ...request }: ScoreType) => {
   return fetcher.post<void>(`games/${gameId}/timelines/score`, {

--- a/apps/manager/src/api/mutations/useCreateTimelineStatus.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineStatus.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { ProgressStateType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export const postTimelineProgress = ({ gameId, ...request }: ProgressStateType) => {
   return fetcher.post<void>(`games/${gameId}/timelines/progress`, {

--- a/apps/manager/src/api/mutations/useCreateTimelineWarning.ts
+++ b/apps/manager/src/api/mutations/useCreateTimelineWarning.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { WarningType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export const postTimelineWarning = ({ gameId, ...request }: WarningType) => {
   return fetcher.post<void>(`games/${gameId}/timelines/warning-card`, {

--- a/apps/manager/src/api/mutations/useDeleteGameTeamsLineup.ts
+++ b/apps/manager/src/api/mutations/useDeleteGameTeamsLineup.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   gameTeamId: number;

--- a/apps/manager/src/api/mutations/useDeleteGames.ts
+++ b/apps/manager/src/api/mutations/useDeleteGames.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export type Request = {
   leagueId: number;

--- a/apps/manager/src/api/mutations/useDeleteLeagueTeams.ts
+++ b/apps/manager/src/api/mutations/useDeleteLeagueTeams.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   leagueId: number;

--- a/apps/manager/src/api/mutations/useDeleteLeagues.ts
+++ b/apps/manager/src/api/mutations/useDeleteLeagues.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   leagueId: number;

--- a/apps/manager/src/api/mutations/useDeletePlayers.ts
+++ b/apps/manager/src/api/mutations/useDeletePlayers.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   id: number;

--- a/apps/manager/src/api/mutations/useDeleteTeams.ts
+++ b/apps/manager/src/api/mutations/useDeleteTeams.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   id: number;

--- a/apps/manager/src/api/mutations/useDeleteTimeline.ts
+++ b/apps/manager/src/api/mutations/useDeleteTimeline.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   gameId: number;

--- a/apps/manager/src/api/mutations/useGeneratePresignedUrl.ts
+++ b/apps/manager/src/api/mutations/useGeneratePresignedUrl.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@hcc/api-base';
 
-import { fetcher } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
 
 type Request = {
   extension: string;

--- a/apps/manager/src/api/mutations/useLogin.ts
+++ b/apps/manager/src/api/mutations/useLogin.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@hcc/api-base';
 
-import { fetcher } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
 
 type Request = {
   email: string;

--- a/apps/manager/src/api/mutations/useParseNL.ts
+++ b/apps/manager/src/api/mutations/useParseNL.ts
@@ -2,7 +2,7 @@ import { useMutation } from '@hcc/api-base';
 
 import type { ParseNLPayload, ParseNLResponse } from '~/api/types/nl';
 
-import { fetcher } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
 
 const postParseNL = (payload: ParseNLPayload) => {
   return fetcher.post<ParseNLResponse>(`nl/parse`, { json: payload });

--- a/apps/manager/src/api/mutations/useRegisterNL.ts
+++ b/apps/manager/src/api/mutations/useRegisterNL.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { RegisterNLResponse, RegisterNLPayload } from '~/api/types/nl';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 const postRegisterNL = (payload: RegisterNLPayload) => {
   return fetcher.post<RegisterNLResponse>(`nl/register-team`, { json: payload });

--- a/apps/manager/src/api/mutations/useUpdateCheerTalkBlock.ts
+++ b/apps/manager/src/api/mutations/useUpdateCheerTalkBlock.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   leagueId: number;

--- a/apps/manager/src/api/mutations/useUpdateCheerTalkUnblock.ts
+++ b/apps/manager/src/api/mutations/useUpdateCheerTalkUnblock.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   leagueId: number;

--- a/apps/manager/src/api/mutations/useUpdateGames.ts
+++ b/apps/manager/src/api/mutations/useUpdateGames.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { GameQuarterType, GameStateType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export type GameUpdateFormType = {
   leagueId: number;

--- a/apps/manager/src/api/mutations/useUpdateGamesCandidate.ts
+++ b/apps/manager/src/api/mutations/useUpdateGamesCandidate.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   gameId: number;

--- a/apps/manager/src/api/mutations/useUpdateGamesCaptainRegister.ts
+++ b/apps/manager/src/api/mutations/useUpdateGamesCaptainRegister.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   gameId: number;

--- a/apps/manager/src/api/mutations/useUpdateGamesCaptainRevoke.ts
+++ b/apps/manager/src/api/mutations/useUpdateGamesCaptainRevoke.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   gameId: number;

--- a/apps/manager/src/api/mutations/useUpdateGamesStarter.ts
+++ b/apps/manager/src/api/mutations/useUpdateGamesStarter.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   gameId: number;

--- a/apps/manager/src/api/mutations/useUpdateLeagueTeams.ts
+++ b/apps/manager/src/api/mutations/useUpdateLeagueTeams.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { LeagueDetailType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   leagueId: number;

--- a/apps/manager/src/api/mutations/useUpdateLeagues.ts
+++ b/apps/manager/src/api/mutations/useUpdateLeagues.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { LeagueDetailType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   leagueId: number;

--- a/apps/manager/src/api/mutations/useUpdatePlayers.ts
+++ b/apps/manager/src/api/mutations/useUpdatePlayers.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { PlayerFormType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   id: number;

--- a/apps/manager/src/api/mutations/useUpdateTeamPlayers.ts
+++ b/apps/manager/src/api/mutations/useUpdateTeamPlayers.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { TeamPlayer } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   teamId: number;

--- a/apps/manager/src/api/mutations/useUpdateTeams.ts
+++ b/apps/manager/src/api/mutations/useUpdateTeams.ts
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from '@hcc/api-base';
 
 import type { TeamFormType } from '~/api';
 
-import { fetcher, queryKeys } from '~/api/queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 type Request = {
   id: number;

--- a/apps/manager/src/api/queries/useCheerTalkBlock.ts
+++ b/apps/manager/src/api/queries/useCheerTalkBlock.ts
@@ -2,7 +2,8 @@ import { useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@hcc/api-b
 
 import type { CheerTalkListResponse, CheerTalkPayload } from '~/api';
 
-import { fetcher, queryKeys } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export const useCheerTalkBlock = (payload: CheerTalkPayload) =>
   useQuery(queryKeys.cheertalks.blocked(payload));

--- a/apps/manager/src/api/queries/useCheerTalkReport.ts
+++ b/apps/manager/src/api/queries/useCheerTalkReport.ts
@@ -2,7 +2,7 @@ import { useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@hcc/api-b
 
 import type { CheerTalkListResponse, CheerTalkPayload } from '~/api';
 
-import { fetcher } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
 
 export const useCheerTalkReport = (payload: CheerTalkPayload) =>
   useQuery({

--- a/apps/manager/src/api/queries/useCheerTalks.ts
+++ b/apps/manager/src/api/queries/useCheerTalks.ts
@@ -2,7 +2,7 @@ import { useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@hcc/api-b
 
 import type { CheerTalkListResponse, CheerTalkPayload } from '~/api';
 
-import { fetcher } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
 
 export const useCheerTalks = (payload: CheerTalkPayload) =>
   useQuery({

--- a/apps/manager/src/api/queries/useGameCheerTalks.ts
+++ b/apps/manager/src/api/queries/useGameCheerTalks.ts
@@ -2,7 +2,7 @@ import { useSuspenseInfiniteQuery } from '@hcc/api-base';
 
 import type { CheerTalkListResponse, GameCheerTalkPayload } from '~/api';
 
-import { fetcher } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
 
 export const useSuspenseInfiniteGamesCheerTalks = (payload: GameCheerTalkPayload) =>
   useSuspenseInfiniteQuery({

--- a/apps/manager/src/api/queries/useGamesCheerTalkBlock.ts
+++ b/apps/manager/src/api/queries/useGamesCheerTalkBlock.ts
@@ -2,7 +2,8 @@ import { useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@hcc/api-b
 
 import type { CheerTalkListResponse, GameCheerTalkPayload } from '~/api';
 
-import { fetcher, queryKeys } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export const useGamesCheerTalkBlock = (payload: GameCheerTalkPayload) =>
   useQuery(queryKeys.games.cheerTalksBlocked(payload));

--- a/apps/manager/src/api/queries/useGamesCheerTalkReport.ts
+++ b/apps/manager/src/api/queries/useGamesCheerTalkReport.ts
@@ -2,7 +2,7 @@ import { useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@hcc/api-b
 
 import type { CheerTalkListResponse, CheerTalkType, GameCheerTalkPayload } from '~/api';
 
-import { fetcher } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
 
 export const useGamesCheerTalkReport = (payload: GameCheerTalkPayload) =>
   useQuery({

--- a/apps/manager/src/api/queries/useLeagueCheerTalkBlock.ts
+++ b/apps/manager/src/api/queries/useLeagueCheerTalkBlock.ts
@@ -2,7 +2,8 @@ import { useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@hcc/api-b
 
 import type { CheerTalkListResponse, LeagueCheerTalkPayload } from '~/api';
 
-import { fetcher, queryKeys } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export const useLeagueCheerTalkBlock = (payload: LeagueCheerTalkPayload) =>
   useQuery(queryKeys.leagues.cheerTalksBlocked(payload));

--- a/apps/manager/src/api/queries/useLeagueCheerTalkReport.ts
+++ b/apps/manager/src/api/queries/useLeagueCheerTalkReport.ts
@@ -2,7 +2,7 @@ import { useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@hcc/api-b
 
 import type { CheerTalkListResponse, CheerTalkType, LeagueCheerTalkPayload } from '~/api';
 
-import { fetcher } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
 
 export const useLeagueCheerTalkReport = (payload: LeagueCheerTalkPayload) =>
   useQuery({

--- a/apps/manager/src/api/queries/useLeagueCheerTalks.ts
+++ b/apps/manager/src/api/queries/useLeagueCheerTalks.ts
@@ -2,7 +2,7 @@ import { useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@hcc/api-b
 
 import type { CheerTalkListResponse, CheerTalkType, LeagueCheerTalkPayload } from '~/api';
 
-import { fetcher } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
 
 export const useLeagueCheerTalks = (payload: LeagueCheerTalkPayload) =>
   useQuery({

--- a/apps/manager/src/api/queries/usePlayers.ts
+++ b/apps/manager/src/api/queries/usePlayers.ts
@@ -2,7 +2,8 @@ import { useSuspenseInfiniteQuery, useQuery, useSuspenseQuery } from '@hcc/api-b
 
 import type { PlayerListPayload, PlayerListResponse } from '~/api';
 
-import { fetcher, queryKeys } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
 
 export const usePlayers = () => useQuery(queryKeys.players.list);
 

--- a/apps/manager/src/api/queryKey.ts
+++ b/apps/manager/src/api/queryKey.ts
@@ -30,7 +30,6 @@ import type {
 } from './types';
 
 import { fetcher } from './fetcher';
-export { fetcher } from './fetcher';
 
 const leagueQueryKeys = createQueryKeys('leagues', {
   home: {

--- a/apps/manager/src/api/queryKey.ts
+++ b/apps/manager/src/api/queryKey.ts
@@ -1,4 +1,3 @@
-import { getFetcher } from '@hcc/api-base';
 import { createQueryKeys, mergeQueryKeys } from '@lukemorales/query-key-factory';
 
 import type {
@@ -30,8 +29,8 @@ import type {
   TimelineResponseType,
 } from './types';
 
-const apiBaseUrl = process.env.API_BASE_URL ?? '/api';
-export const fetcher = getFetcher(apiBaseUrl);
+import { fetcher } from './fetcher';
+export { fetcher } from './fetcher';
 
 const leagueQueryKeys = createQueryKeys('leagues', {
   home: {

--- a/apps/spectator/src/api/fetcher.ts
+++ b/apps/spectator/src/api/fetcher.ts
@@ -1,0 +1,5 @@
+import { getFetcher } from '@hcc/api-base';
+
+const apiBaseUrl = process.env.API_BASE_URL ?? '/api';
+
+export const fetcher = getFetcher(apiBaseUrl);

--- a/apps/spectator/src/api/mutations/useCreateCheerTalk.ts
+++ b/apps/spectator/src/api/mutations/useCreateCheerTalk.ts
@@ -2,8 +2,9 @@ import { useMutation } from '@hcc/api-base';
 
 import type { CheerTalkType } from '~/api';
 
+import { fetcher } from '~/api/fetcher';
+
 import { handleHTTPError } from '../http-error';
-import { fetcher } from '../queryKey';
 
 type Request = Pick<CheerTalkType, 'gameTeamId' | 'content'>;
 

--- a/apps/spectator/src/api/mutations/useCreateCheerTalkReport.ts
+++ b/apps/spectator/src/api/mutations/useCreateCheerTalkReport.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@hcc/api-base';
 
-import { fetcher } from '../queryKey';
+import { fetcher } from '~/api/fetcher';
 
 type Request = {
   cheerTalkId: number;

--- a/apps/spectator/src/api/mutations/useUpdateGameCheer.ts
+++ b/apps/spectator/src/api/mutations/useUpdateGameCheer.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQueryClient } from '@hcc/api-base';
 
+import { fetcher } from '~/api/fetcher';
+import { queryKeys } from '~/api/queryKey';
+
 import { handleHTTPError } from '../http-error';
-import { fetcher, queryKeys } from '../queryKey';
 
 export type Request = {
   gameId: number;

--- a/apps/spectator/src/api/queryKey.ts
+++ b/apps/spectator/src/api/queryKey.ts
@@ -1,4 +1,3 @@
-import { getFetcher } from '@hcc/api-base';
 import { createQueryKeys, mergeQueryKeys } from '@lukemorales/query-key-factory';
 
 import type {
@@ -47,8 +46,7 @@ import type {
   TeamUnitsPayload,
 } from './types';
 
-const apiBaseUrl = process.env.API_BASE_URL ?? '/api';
-export const fetcher = getFetcher(apiBaseUrl);
+import { fetcher } from './fetcher';
 
 const gameQueryKeys = createQueryKeys('games', {
   list: (payload: GameListPayload) => ({

--- a/packages/api-base/src/fetcher.ts
+++ b/packages/api-base/src/fetcher.ts
@@ -9,23 +9,15 @@ const defaultOption: Options = {
   throwHttpErrors: true,
 };
 
-type ErrorHandler = (request: Request, response: Response) => void | Promise<void>;
+export type HttpErrorHandler = (request: Request, response: Response) => void | Promise<void>;
 
-let isRedirecting = false;
+export type HttpErrorHandlers = Partial<Record<number, HttpErrorHandler>>;
 
-const errorHandlers: Partial<Record<number, ErrorHandler>> = {
-  401: async (request) => {
-    if (request.url.includes('logout')) return;
-    if (isRedirecting || typeof window === 'undefined') return;
-
-    isRedirecting = true;
-    alert('로그인이 만료되었어요. 다시 로그인해주세요.');
-    await fetch('/api/logout', { method: 'POST' });
-    window.location.replace('/auth/login');
-  },
+export type FetcherConfig = {
+  errorHandlers?: HttpErrorHandlers;
 };
 
-export const getInstance = (apiUrl?: string) =>
+export const getInstance = (apiUrl?: string, config: FetcherConfig = {}) =>
   ky.create({
     prefixUrl: apiUrl,
     headers: { 'Content-Type': 'application/json' },
@@ -33,7 +25,7 @@ export const getInstance = (apiUrl?: string) =>
       afterResponse: [
         async (request, _, response) => {
           if (!response.ok) {
-            await errorHandlers[response.status]?.(request, response);
+            await config.errorHandlers?.[response.status]?.(request, response);
           }
         },
       ],
@@ -54,8 +46,8 @@ export async function resultify<T>(response: ResponsePromise) {
   }
   return (await res.text()) as unknown as T;
 }
-export const getFetcher = (apiUrl: string) => {
-  const { get, post, put, patch, delete: del } = getInstance(apiUrl);
+export const getFetcher = (apiUrl: string, config?: FetcherConfig) => {
+  const { get, post, put, patch, delete: del } = getInstance(apiUrl, config);
 
   return {
     get: <T>(pathname: string, options?: Options) => resultify<T>(get(pathname, options)),


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- `api-base`의 공통 fetcher에서 manager 전용 401 처리 로직을 제거
- manager 전용 fetcher를 분리
  - 401 발생 시 로그아웃 처리 및 로그인 페이지 이동을 manager의 `api/fetcher.ts`로 처리
- spectator의 queryKey에 있던 fetcher 분리
  - spectator 전용 `api/fetcher.ts`를 생성
- manager와 spectator의 API 코드가 각 앱의 fetcher를 직접 참조하도록 변경

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
